### PR TITLE
Sagemaker Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## graph-notebook
 
 Python package integrating jupyter notebooks with various graph-stores including
-[Apache Tinkerpop](https://tinkerpop.apache.org/) and [RDF SPARQL](https://www.w3.org/TR/rdf-sparql-query/).
+[Apache TinkerPop](https://tinkerpop.apache.org/) and [RDF SPARQL](https://www.w3.org/TR/rdf-sparql-query/).
 
 ## Requirements
 - Python3.6
@@ -23,6 +23,9 @@ python -m graph_notebook.nbextensions.install
 
 # copy premade starter notebooks
 python -m graph_notebook.notebooks.install --destination /notebook/destination/dir  
+
+# start jupyter
+jupyter notebook /notebook/destination/dir
 ```
 
 ## Configuration

--- a/setup.py
+++ b/setup.py
@@ -73,9 +73,9 @@ setup(
         'ipywidgets',
         'networkx==2.4',
         'Jinja2==2.10.1',
-        'notebook<=5.7.8',
-        'jupyter-contrib-nbextensions==0.5.1',
-        'widgetsnbextension==3.5.1',
+        'notebook',
+        'jupyter-contrib-nbextensions',
+        'widgetsnbextension',
         'jupyter>=1.0.0'
     ],
     package_data={

--- a/src/graph_notebook/__init__.py
+++ b/src/graph_notebook/__init__.py
@@ -3,4 +3,4 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-__version__ = '1.31.6'
+__version__ = '1.32.0'

--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph_notebook_widgets",
-  "version": "1.31.6",
+  "version": "1.32.0",
   "author": "amazon",
   "description": "A Custom Jupyter Library for rendering NetworkX MultiDiGraphs using vis-network",
   "dependencies": {


### PR DESCRIPTION
Issue #, if available: None

Description of changes:
- Change package version requirements so AWS Sagemaker can install graph-notebook without any issues.
- Small updates to README

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.