### PR TITLE
Added functionality to allow for coloring by property in Gremlin

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -296,7 +296,7 @@ class Graph(Magics):
                 groupby=None
                 if args.groupby:
                     groupby=args.groupby
-                gn = GremlinNetwork()
+                gn = GremlinNetwork(group_by_property=groupby)
                 if args.path_pattern == '':
                     gn.add_results(res)
                 else:

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -251,8 +251,11 @@ class Graph(Magics):
         parser.add_argument('query_mode', nargs='?', default='query',
                             help='query mode (default=query) [query|explain|profile]')
         parser.add_argument('-p', '--path-pattern', default='', help='path pattern')
+        parser.add_argument('-g', '--groupby', default='', help='group by property')
+
         args = parser.parse_args(line.split())
         mode = str_to_query_mode(args.query_mode)
+        logger.debug(f'Arguments {args}')
 
         tab = widgets.Tab()
         if mode == QueryMode.EXPLAIN:
@@ -290,6 +293,9 @@ class Graph(Magics):
             children.append(table_output)
 
             try:
+                groupby=None
+                if args.groupby:
+                    groupby=args.groupby
                 gn = GremlinNetwork()
                 if args.path_pattern == '':
                     gn.add_results(res)

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -308,6 +308,8 @@ class GremlinNetwork(EventfulNetwork):
             if self.group_by_property:
                 if self.group_by_property in properties:
                     group = str(properties[self.group_by_property])
+                else:
+                    group = label
             else:
                 group = label
             data = {'properties': properties, 'label': label, 'title': title, 'group': group}
@@ -316,6 +318,8 @@ class GremlinNetwork(EventfulNetwork):
             title = str(v)
             label = title if len(title) <= self.label_max_length else title[:self.label_max_length - 3] + '...'
             data = {'title': title, 'label': label, 'group': ''}
+
+        logger.debug(data)
         self.add_node(node_id, data)
 
     def add_path_edge(self, edge, from_id='', to_id='', data=None):

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -104,6 +104,18 @@ class TestGremlinNetwork(unittest.TestCase):
         node = gn.graph.nodes.get(vertex['T.id'])
         self.assertEqual(node['group'], 'airport')
 
+    def test_group_without_groupby_choose_label(self):
+        vertex = {
+            'T.id': '1234',
+            'T.label': 'airport',
+            'code': ['SEA']
+        }
+
+        gn = GremlinNetwork(group_by_property='T.label')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex['T.id'])
+        self.assertEqual(node['group'], 'airport')
+
     def test_group_with_groupby_list(self):
         vertex = {
             'T.id': '1234',

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -50,6 +50,125 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_results([path])
         self.assertEqual(len(path), len(gn.graph.nodes))
 
+    def test_group_with_groupby(self):
+        vertex = {
+            'T.id': '1234',
+            'T.label': 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(group_by_property='code')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex['T.id'])
+        self.assertEqual(node['group'], 'SEA')
+
+    def test_group_nonexistent_groupby(self):
+        vertex = {
+            'T.id': '1234',
+            'T.label': 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(group_by_property='foo')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex['T.id'])
+        self.assertEqual(node['group'], '')
+
+    def test_group_without_groupby(self):
+        vertex = {
+            'T.id': '1234',
+            'T.label': 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex['T.id'])
+        self.assertEqual(node['group'], 'airport')
+
+    def test_group_without_groupby_list(self):
+        vertex = {
+            'T.id': '1234',
+            'T.label': 'airport',
+            'code': ['SEA']
+        }
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex['T.id'])
+        self.assertEqual(node['group'], 'airport')
+
+    def test_group_with_groupby_list(self):
+        vertex = {
+            'T.id': '1234',
+            'T.label': 'airport',
+            'code': ['SEA']
+        }
+
+        gn = GremlinNetwork(group_by_property='code')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex['T.id'])
+        self.assertEqual(node['group'], "['SEA']")
+
+    def test_group_notokens_groupby(self):
+        vertex = {
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(group_by_property='code')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('graph_notebook-ed8fddedf251d3d5745dccfd53edf51d')
+        self.assertEqual(node['group'], 'SEA')
+
+    def test_group_notokens_without_groupby(self):
+        vertex = {
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('graph_notebook-ed8fddedf251d3d5745dccfd53edf51d')
+        self.assertEqual(node['group'], '')
+
+    def test_add_path_without_groupby(self):
+        path = Path([], [{'country': ['US'], 'code': ['SEA'], 'longest': [11901], 'city': ['Seattle'],
+                          "T.label": 'airport', 'lon': [-122.30899810791], 'type': ['airport'], 'elev': [432],
+                          "T.id:": '22', 'icao': ['KSEA'], 'runways': [3], 'region': ['US-WA'],
+                          'lat': [47.4490013122559], 'desc': ['Seattle-Tacoma']},
+                         {'country': ['US'], 'code': ['ATL'], 'longest': [12390], 'city': ['Atlanta'],
+                          "T.label": 'airport', 'lon': [-84.4281005859375], 'type': ['airport'], 'elev': [1026],
+                         "T.id": '1', 'icao': ['KATL'], 'runways': [5], 'region': ['US-GA'],
+                          'lat': [33.6366996765137], 'desc': ['Hartsfield - Jackson Atlanta International Airport']}])
+        gn = GremlinNetwork()
+        gn.add_results([path])
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], "airport")
+
+    def test_add_path_with_groupby(self):
+        path = Path([], [{'country': ['US'], 'code': ['SEA'], 'longest': [11901], 'city': ['Seattle'],
+                          "T.label": 'airport', 'lon': [-122.30899810791], 'type': ['airport'], 'elev': [432],
+                          "T.id:": '22', 'icao': ['KSEA'], 'runways': [3], 'region': ['US-WA'],
+                          'lat': [47.4490013122559], 'desc': ['Seattle-Tacoma']},
+                         {'country': ['US'], 'code': ['ATL'], 'longest': [12390], 'city': ['Atlanta'],
+                          "T.label": 'airport', 'lon': [-84.4281005859375], 'type': ['airport'], 'elev': [1026],
+                         "T.id": '1', 'icao': ['KATL'], 'runways': [5], 'region': ['US-GA'],
+                          'lat': [33.6366996765137], 'desc': ['Hartsfield - Jackson Atlanta International Airport']}])
+        gn = GremlinNetwork(group_by_property="code")
+        gn.add_results([path])
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], "['ATL']")
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Added functionality to allow for grouping/coloring by property for Gremlin results.  

- Added a switch --groupby or -g  followed by the property name to group by e.g. `--groupby region` .  If a vertex does not have that property it will  be added to the default group
- If no switch is provided it will use the T.label if available.  If its not, then everything is in the default group

The colors/icons associated with these groups can then be set using the standard visjs options: https://visjs.github.io/vis-network/docs/network/groups.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.