### PR TITLE
Update Gremlin server connection README.md

### DIFF
--- a/additional-databases/gremlin-server/README.md
+++ b/additional-databases/gremlin-server/README.md
@@ -2,7 +2,7 @@
 
 ![Gremlin](https://github.com/aws/graph-notebook/blob/main/images/gremlin-notebook.png?raw=true, "Picture of Gremlin holding a notebook")
 
-These notes explain how to connect the graph-notebook to a Gremlin server running locally on the same machine. The same steps should also work if you have a remote Gremlin Server. In such cases `localhost` should be replaced with the DNS or IP address of the remote server. It is assumed the [graph-notebook installation](https://github.com/aws/graph-notebook/blob/main/README.md) has been completed and the Jupyter environment is running before following these steps. 
+These notes explain how to connect the graph-notebook to a Gremlin server running locally on the same machine. The same steps should also work if you have a remote Gremlin Server. In such cases `localhost` should be replaced with the DNS or IP address of the remote server. It is assumed the [graph-notebook installation](https://github.com/aws/graph-notebook/blob/main/README.md) has been completed and the Jupyter environment is running before following these steps.
 
 ### Gremlin Server Configuration
 Several of the steps below are optional but please read each step carefully and decide if you want to apply it.

--- a/additional-databases/gremlin-server/README.md
+++ b/additional-databases/gremlin-server/README.md
@@ -2,7 +2,7 @@
 
 ![Gremlin](https://github.com/aws/graph-notebook/blob/main/images/gremlin-notebook.png?raw=true, "Picture of Gremlin holding a notebook")
 
-These notes explain how to connect the graph-notebook to a Gremlin server running locally on the same machine. The same steps should also work if you have a remote Gremlin Server. In such cases `localhost` should be replaced with the DNS or IP address of the remote server. It is assumed the [graph-notebook installation](https://github.com/aws/graph-notebook/blob/main/README.md) has been completed and the Jupyter environment is running before following these steps.
+These notes explain how to connect the graph-notebook to a Gremlin server running locally on the same machine. The same steps should also work if you have a remote Gremlin Server. In such cases `localhost` should be replaced with the DNS or IP address of the remote server. It is assumed the [graph-notebook installation](https://github.com/aws/graph-notebook/blob/main/README.md) has been completed and the Jupyter environment is running before following these steps. 
 
 ### Gremlin Server Configuration
 Several of the steps below are optional but please read each step carefully and decide if you want to apply it.
@@ -23,7 +23,7 @@ Several of the steps below are optional but please read each step carefully and 
    ```
    to
    ```
-    channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer`.
+    channelizer: org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer
    ```
    This will allow you to access the Gremlin Server from Jupyter using commands like `curl` as well as using the `%%gremlin` cell magic. This step is optional if you do not need HTTP connectivity to the server.
 5. Start the Gremlin server `bin/gremlin-server.sh start`
@@ -33,18 +33,22 @@ Several of the steps below are optional but please read each step carefully and 
 1. In the Jupyter Notebook disable SSL using `%%graph_notebook_config` and change the host to `localhost`
   ```
   %%graph_notebook_config
-  {
-    "host": "localhost",
-    "port": 8182,
-    "ssl": false
-  }
+{
+  "host": "localhost",
+  "port": 8182,
+  "auth_mode": "DEFAULT",
+  "iam_credentials_provider_type": "ROLE",
+  "load_from_s3_arn": "",
+  "ssl": false,
+  "aws_region": "us-east-1"
+}
   ```
 If the Gremlin Server you wish to connect to is remote,  replacing `localhost` with the IP address or DNS of the remote server should work. This assumes you have access to that server from your local machine.
 
 ### Using `%seed` with Gremlin Server
 The graph-notebook has a `%seed` command that can be used to load sample data. For some data sets to load successfully, the stack size used by the Gremlin Server needs to be increased. If you do not plan to use the `%seed` command to load the `air-routes` data set this step can be ignored.
 
-1. In order to load the `air-routes` data set into TinkerGraph via Gremlin Server using the graph-notebook `%seed` command, the size of the JVM thread stack needs to be increased. Editing the `gremlin-server.sh` file and adding `-Xss2m` to the JAVA_OPTIONS variable is one way to do that. Locate this section of the file and add the `-Xss2m` flag.
+1. In order to load the `airports` data set into TinkerGraph via Gremlin Server using the graph-notebook `%seed` command, the size of the JVM thread stack needs to be increased. Editing the `gremlin-server.sh` file and adding `-Xss2m` to the JAVA_OPTIONS variable is one way to do that. Locate this section of the file and add the `-Xss2m` flag.
 
   ```
   # Set Java options

--- a/additional-databases/gremlin-server/README.md
+++ b/additional-databases/gremlin-server/README.md
@@ -30,7 +30,7 @@ Several of the steps below are optional but please read each step carefully and 
 
 
 ### Connecting to a local Gremlin Server from Jupyter
-1. In the Jupyter Notebook disable SSL using `%%graph_notebook_config` and change the host to `localhost`
+1. In the Jupyter Notebook disable SSL using `%%graph_notebook_config` and change the host to `localhost`. Keep the other defaults even though they are not used for configuring the Gremlin Server.
   ```
   %%graph_notebook_config
 {


### PR DESCRIPTION
Minor changes to instructions
1. Channelizer string correction
2. graph_notebook_config connection string fixed
3. dataset name as it appears in graph notebook from "air-routes" to "airports"

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.