### PR TITLE
Support for specifying prefix-paths

### DIFF
--- a/src/graph_notebook/__init__.py
+++ b/src/graph_notebook/__init__.py
@@ -3,4 +3,4 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'

--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -22,11 +22,27 @@ class AuthModeEnum(Enum):
 DEFAULT_AUTH_MODE = AuthModeEnum.DEFAULT
 
 
+class SparqlSection(object):
+    """
+    Used for sparql-specific settings in a notebook's configuration
+    """
+    def __init__(self, endpoint_prefix: str):
+        """
+        :param endpoint_prefix: used to specify the base-path of the api being connected to do get to its
+                     corresponding sparql endpoint.
+        """
+        self.endpoint_prefix = endpoint_prefix
+
+    def to_dict(self):
+        return self.__dict__
+
+
 class Configuration(object):
     def __init__(self, host: str, port: int,
                  auth_mode: AuthModeEnum = AuthModeEnum.DEFAULT,
                  iam_credentials_provider_type: IAMAuthCredentialsProvider = DEFAULT_IAM_CREDENTIALS_PROVIDER,
-                 load_from_s3_arn='', ssl: bool = True, aws_region: str = 'us-east-1'):
+                 load_from_s3_arn='', ssl: bool = True, aws_region: str = 'us-east-1',
+                 sparql_section: SparqlSection = None):
         self.host = host
         self.port = port
         self.auth_mode = auth_mode
@@ -34,6 +50,7 @@ class Configuration(object):
         self.load_from_s3_arn = load_from_s3_arn
         self.ssl = ssl
         self.aws_region = aws_region
+        self.sparql = sparql_section if sparql_section is not None else SparqlSection(endpoint_prefix='')
 
     def to_dict(self) -> dict:
         return {
@@ -43,7 +60,8 @@ class Configuration(object):
             'iam_credentials_provider_type': self.iam_credentials_provider_type.value,
             'load_from_s3_arn': self.load_from_s3_arn,
             'ssl': self.ssl,
-            'aws_region': self.aws_region
+            'aws_region': self.aws_region,
+            'sparql': self.sparql.to_dict()
         }
 
     def write_to_file(self, file_path=DEFAULT_CONFIG_LOCATION):

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -6,15 +6,17 @@ SPDX-License-Identifier: Apache-2.0
 import json
 
 from graph_notebook.authentication.iam_credentials_provider.credentials_factory import IAMAuthCredentialsProvider
-from graph_notebook.configuration.generate_config import DEFAULT_CONFIG_LOCATION, Configuration, AuthModeEnum
+from graph_notebook.configuration.generate_config import DEFAULT_CONFIG_LOCATION, Configuration, AuthModeEnum, \
+    SparqlSection
 
 
 def get_config_from_dict(data: dict) -> Configuration:
+    sparql_section = SparqlSection(**data['sparql']) if 'sparql' in data else SparqlSection('')
     config = Configuration(host=data['host'], port=data['port'], auth_mode=AuthModeEnum(data['auth_mode']),
                            iam_credentials_provider_type=IAMAuthCredentialsProvider(
                                data['iam_credentials_provider_type']),
                            ssl=data['ssl'],
-                           load_from_s3_arn=data['load_from_s3_arn'], aws_region=data['aws_region'])
+                           load_from_s3_arn=data['load_from_s3_arn'], aws_region=data['aws_region'], sparql_section=sparql_section)
     return config
 
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -152,7 +152,7 @@ class Graph(Magics):
         parser.add_argument('query_mode', nargs='?', default='query',
                             help='query mode (default=query) [query|explain]')
         parser.add_argument('--endpoint-prefix', '-e', default='',
-                            help='prefix path to sparql endpoint. For example, "foo/bar". The queried path would then be /foo/bar/sparql')
+                            help='prefix path to sparql endpoint. For example, if "foo/bar" were specified, the endpoint called would be /foo/bar/sparql')
         parser.add_argument('--expand-all', action='store_true')
 
         request_generator = create_request_generator(self.graph_notebook_config.auth_mode,

--- a/src/graph_notebook/request_param_generator/default_request_generator.py
+++ b/src/graph_notebook/request_param_generator/default_request_generator.py
@@ -3,6 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
+
 class DefaultRequestGenerator(object):
     @staticmethod
     def generate_request_params(method, action, query, host, port, protocol, headers=None):

--- a/src/graph_notebook/request_param_generator/sparql_request_generator.py
+++ b/src/graph_notebook/request_param_generator/sparql_request_generator.py
@@ -3,6 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
+
 class SPARQLRequestGenerator(object):
     @staticmethod
     def generate_request_params(method, action, query, host, port, protocol, headers=None):
@@ -12,9 +13,11 @@ class SPARQLRequestGenerator(object):
         if 'Content-Type' not in headers:
             headers['Content-Type'] = "application/x-www-form-urlencoded"
 
+        action_segment = 'sparql' if not action.endswith('sparql') else action
+        url = f'{protocol}://{host}:{port}/{action_segment}'
         return {
             'method': method,
-            'url': f'{protocol}://{host}:{port}/sparql',
+            'url': url,
             'headers': headers,
             'params': query,
         }

--- a/src/graph_notebook/sparql/query.py
+++ b/src/graph_notebook/sparql/query.py
@@ -34,7 +34,7 @@ def query_type_to_action(query_type):
         return 'sparqlupdate'
 
 
-def do_sparql_query(query, host, port, use_ssl, request_param_generator, extra_headers=None):
+def do_sparql_query(query, host, port, use_ssl, request_param_generator, extra_headers=None, path_prefix: str = ''):
     if extra_headers is None:
         extra_headers = {}
     logger.debug(f'query={query}, endpoint={host}, port={port}')
@@ -47,7 +47,8 @@ def do_sparql_query(query, host, port, use_ssl, request_param_generator, extra_h
     elif action == 'sparqlupdate':
         data['update'] = query
 
-    res = call_and_get_response('post', SPARQL_ACTION, host, port, request_param_generator, use_ssl, data, extra_headers)
+    sparql_path = SPARQL_ACTION if path_prefix == '' else f'{path_prefix}/{SPARQL_ACTION}'
+    res = call_and_get_response('post', sparql_path, host, port, request_param_generator, use_ssl, data, extra_headers)
     try:
         content = res.json()  # attempt to return json, otherwise we will return the content string.
     except Exception:
@@ -56,7 +57,7 @@ def do_sparql_query(query, host, port, use_ssl, request_param_generator, extra_h
 
 
 def do_sparql_explain(query: str, host: str, port: str, use_ssl: bool, request_param_generator,
-                      accept_type='text/html'):
+                      accept_type='text/html', path_prefix: str = ''):
     query_type = get_query_type(query)
     action = query_type_to_action(query_type)
 
@@ -73,6 +74,6 @@ def do_sparql_explain(query: str, host: str, port: str, use_ssl: bool, request_p
         'Accept': accept_type
     }
 
-    res = call_and_get_response('post', SPARQL_ACTION, host, port, request_param_generator, use_ssl, data,
+    res = call_and_get_response('post', f'{path_prefix}/{SPARQL_ACTION}', host, port, request_param_generator, use_ssl, data,
                                 extra_headers)
     return res.content.decode('utf-8')

--- a/src/graph_notebook/sparql/query.py
+++ b/src/graph_notebook/sparql/query.py
@@ -74,6 +74,7 @@ def do_sparql_explain(query: str, host: str, port: str, use_ssl: bool, request_p
         'Accept': accept_type
     }
 
-    res = call_and_get_response('post', f'{path_prefix}/{SPARQL_ACTION}', host, port, request_param_generator, use_ssl, data,
+    sparql_path = SPARQL_ACTION if path_prefix == '' else f'{path_prefix}/{SPARQL_ACTION}'
+    res = call_and_get_response('post', sparql_path, host, port, request_param_generator, use_ssl, data,
                                 extra_headers)
     return res.content.decode('utf-8')

--- a/src/graph_notebook/status/get_status.py
+++ b/src/graph_notebook/status/get_status.py
@@ -2,6 +2,7 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
+from json import JSONDecodeError
 
 from graph_notebook.request_param_generator.call_and_get_response import call_and_get_response
 from graph_notebook.request_param_generator.default_request_generator import DefaultRequestGenerator
@@ -9,4 +10,8 @@ from graph_notebook.request_param_generator.default_request_generator import Def
 
 def get_status(host, port, use_ssl, request_param_generator=DefaultRequestGenerator()):
     res = call_and_get_response('get', 'status', host, port, request_param_generator, use_ssl)
-    return res.json()
+    try:
+        js = res.json()
+    except JSONDecodeError:
+        js = res.content
+    return js

--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph_notebook_widgets",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "amazon",
   "description": "A Custom Jupyter Library for rendering NetworkX MultiDiGraphs using vis-network",
   "dependencies": {

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -50,7 +50,7 @@ class TestGenerateConfiguration(unittest.TestCase):
                             config.load_from_s3_arn, config.aws_region)
         c.write_to_file(self.test_file_path)
         config_from_file = get_config(self.test_file_path)
-        self.assert_configs_are_equal(config, config_from_file)
+        self.assertEqual(config.to_dict(), config_from_file.to_dict())
 
     def test_generate_configuration_override_defaults(self):
         auth_mode = AuthModeEnum.IAM
@@ -65,8 +65,4 @@ class TestGenerateConfiguration(unittest.TestCase):
                             config.load_from_s3_arn, config.aws_region)
         c.write_to_file(self.test_file_path)
         config_from_file = get_config(self.test_file_path)
-        self.assert_configs_are_equal(config, config_from_file)
-
-    def assert_configs_are_equal(self, config1: Configuration, config2: Configuration):
-        for k in config1.__dict__:
-            self.assertEqual(config1.__dict__[k], config2.__dict__[k])
+        self.assertEqual(config.to_dict(), config_from_file.to_dict())

--- a/test/unit/configuration/test_configuration_from_main.py
+++ b/test/unit/configuration/test_configuration_from_main.py
@@ -36,7 +36,7 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config --host "{expected_config.host}" --port "{expected_config.port}" --auth_mode "" --ssl "" --iam_credentials_provider "" --load_from_s3_arn "" --config_destination="{self.test_file_path}" ')
         self.assertEqual(0, result)
         config = get_config(self.test_file_path)
-        self.assert_configs_are_equal(expected_config, config)
+        self.assertEqual(expected_config.to_dict(), config.to_dict())
 
     def generate_config_from_main_and_test(self, source_config: Configuration):
         # This will run the main method that our install script runs on a Sagemaker notebook.
@@ -45,8 +45,4 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config --host "{source_config.host}" --port "{source_config.port}" --auth_mode "{source_config.auth_mode.value}" --ssl "{source_config.ssl}" --iam_credentials_provider "{source_config.iam_credentials_provider_type.value}" --load_from_s3_arn "{source_config.load_from_s3_arn}" --config_destination="{self.test_file_path}" ')
         self.assertEqual(result, 0)
         config = get_config(self.test_file_path)
-        self.assert_configs_are_equal(source_config, config)
-
-    def assert_configs_are_equal(self, config1: Configuration, config2: Configuration):
-        for k in config1.__dict__:
-            self.assertEqual(config1.__dict__[k], config2.__dict__[k])
+        self.assertEqual(source_config.to_dict(), config.to_dict())


### PR DESCRIPTION
Issue #, if available: #39

Description of changes:
- Support to allow namespace specification for Blazegraph endpoints by specify the prefix to the sparql endpoint being queried.
- Add new config section for sparql-specific items

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.