### PR TITLE
pass sparql prefix_path param explicitly to explain

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -168,7 +168,7 @@ class Graph(Magics):
         logger.debug(f'using mode={mode}')
         if mode == QueryMode.EXPLAIN:
             res = do_sparql_explain(cell, self.graph_notebook_config.host, self.graph_notebook_config.port,
-                                    self.graph_notebook_config.ssl, request_generator, endpoint_prefix)
+                                    self.graph_notebook_config.ssl, request_generator, path_prefix=endpoint_prefix)
             store_to_ns(args.store_to, res, local_ns)
             if 'error' in res:
                 html = error_template.render(error=json.dumps(res['error'], indent=2))

--- a/test/integration/notebook/test_sparql_graph_notebook.py
+++ b/test/integration/notebook/test_sparql_graph_notebook.py
@@ -1,0 +1,17 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from test.integration.notebook.GraphNotebookIntegrationTest import GraphNotebookIntegrationTest
+
+
+class TestGraphMagicGremlin(GraphNotebookIntegrationTest):
+    def test_sparql_query(self):
+        query = 'SELECT * WHERE {?s ?o ?p } LIMIT 1'
+        store_to_var = 'sparql_res'
+        self.ip.run_cell_magic('sparql', f'explain --store-to {store_to_var}', query)
+        self.assertFalse('graph_notebook_error' in self.ip.user_ns)
+        sparql_res = self.ip.user_ns[store_to_var]
+        self.assertTrue(sparql_res.startswith('<!DOCTYPE html>'))
+        self.assertTrue('</table>' in sparql_res)


### PR DESCRIPTION
Description of changes:
- specify explain prefix_path param explicitly in `%%sparql explain` magic variant

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.