### PR TITLE
Rework sparql custom path

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,28 @@ Change the configuration using `%%graph_notebook_config` and modify the fields f
   "aws_region": "us-east-1"
 }
 ```
+
+You can also make use of namespaces for Blazegraph by specifying the path `graph-notebook` should use when querying your SPARQL like below:
+
+```
+%%graph_notebook_config
+
+{
+  "host": "localhost",
+  "port": 9999,
+  "auth_mode": "DEFAULT",
+  "iam_credentials_provider_type": "ENV",
+  "load_from_s3_arn": "",
+  "ssl": false,
+  "aws_region": "us-west-2",
+  "sparql": {
+    "path": "blazegraph/namespace/foo/sparql"
+  }
+}
+```
+
+This will result in the url `localhost:9999/blazegraph/namespace/foo/sparql` being used when executing any `%%sparql` magic commands. 
+
 To setup a new local Blazegraph database for use with the graph notebook, check out the [Quick Start](https://github.com/blazegraph/database/wiki/Quick_Start) from Blazegraph.
 
 ### Amazon Neptune

--- a/src/graph_notebook/__init__.py
+++ b/src/graph_notebook/__init__.py
@@ -3,4 +3,4 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-__version__ = '2.0.7'
+__version__ = '2.0.8'

--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -9,6 +9,7 @@ import os
 from enum import Enum
 
 from graph_notebook.authentication.iam_credentials_provider.credentials_factory import IAMAuthCredentialsProvider
+from graph_notebook.sparql.query import SPARQL_ACTION
 
 DEFAULT_IAM_CREDENTIALS_PROVIDER = IAMAuthCredentialsProvider.ROLE
 DEFAULT_CONFIG_LOCATION = os.path.expanduser('~/graph_notebook_config.json')
@@ -26,12 +27,18 @@ class SparqlSection(object):
     """
     Used for sparql-specific settings in a notebook's configuration
     """
-    def __init__(self, endpoint_prefix: str):
+
+    def __init__(self, path: str = SPARQL_ACTION, endpoint_prefix: str = ''):
         """
-        :param endpoint_prefix: used to specify the base-path of the api being connected to do get to its
+        :param path: used to specify the base-path of the api being connected to do get to its
                      corresponding sparql endpoint.
         """
-        self.endpoint_prefix = endpoint_prefix
+
+        if endpoint_prefix != '':
+            print('endpoint_prefix has been deprecated and will be removed in version 2.0.20 or greater.')
+            if path == '':
+                path = f'{endpoint_prefix}/sparql'
+        self.path = path
 
     def to_dict(self):
         return self.__dict__
@@ -50,7 +57,7 @@ class Configuration(object):
         self.load_from_s3_arn = load_from_s3_arn
         self.ssl = ssl
         self.aws_region = aws_region
-        self.sparql = sparql_section if sparql_section is not None else SparqlSection(endpoint_prefix='')
+        self.sparql = sparql_section if sparql_section is not None else SparqlSection()
 
     def to_dict(self) -> dict:
         return {

--- a/src/graph_notebook/request_param_generator/sparql_request_generator.py
+++ b/src/graph_notebook/request_param_generator/sparql_request_generator.py
@@ -13,8 +13,7 @@ class SPARQLRequestGenerator(object):
         if 'Content-Type' not in headers:
             headers['Content-Type'] = "application/x-www-form-urlencoded"
 
-        action_segment = 'sparql' if not action.endswith('sparql') else action
-        url = f'{protocol}://{host}:{port}/{action_segment}'
+        url = f'{protocol}://{host}:{port}/{action}'
         return {
             'method': method,
             'url': url,

--- a/src/graph_notebook/sparql/query.py
+++ b/src/graph_notebook/sparql/query.py
@@ -34,7 +34,9 @@ def query_type_to_action(query_type):
         return 'sparqlupdate'
 
 
-def do_sparql_query(query, host, port, use_ssl, request_param_generator, extra_headers=None, path_prefix: str = ''):
+def do_sparql_query(query, host, port, use_ssl, request_param_generator, extra_headers=None, path: str = SPARQL_ACTION):
+    path = SPARQL_ACTION if path == '' else path
+
     if extra_headers is None:
         extra_headers = {}
     logger.debug(f'query={query}, endpoint={host}, port={port}')
@@ -47,8 +49,7 @@ def do_sparql_query(query, host, port, use_ssl, request_param_generator, extra_h
     elif action == 'sparqlupdate':
         data['update'] = query
 
-    sparql_path = SPARQL_ACTION if path_prefix == '' else f'{path_prefix}/{SPARQL_ACTION}'
-    res = call_and_get_response('post', sparql_path, host, port, request_param_generator, use_ssl, data, extra_headers)
+    res = call_and_get_response('post', path, host, port, request_param_generator, use_ssl, data, extra_headers)
     try:
         content = res.json()  # attempt to return json, otherwise we will return the content string.
     except Exception:
@@ -57,7 +58,9 @@ def do_sparql_query(query, host, port, use_ssl, request_param_generator, extra_h
 
 
 def do_sparql_explain(query: str, host: str, port: str, use_ssl: bool, request_param_generator,
-                      accept_type='text/html', path_prefix: str = ''):
+                      accept_type='text/html', path: str = ''):
+    path = SPARQL_ACTION if path == '' else path
+
     query_type = get_query_type(query)
     action = query_type_to_action(query_type)
 
@@ -74,7 +77,6 @@ def do_sparql_explain(query: str, host: str, port: str, use_ssl: bool, request_p
         'Accept': accept_type
     }
 
-    sparql_path = SPARQL_ACTION if path_prefix == '' else f'{path_prefix}/{SPARQL_ACTION}'
-    res = call_and_get_response('post', sparql_path, host, port, request_param_generator, use_ssl, data,
+    res = call_and_get_response('post', path, host, port, request_param_generator, use_ssl, data,
                                 extra_headers)
     return res.content.decode('utf-8')

--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph_notebook_widgets",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "author": "amazon",
   "description": "A Custom Jupyter Library for rendering NetworkX MultiDiGraphs using vis-network",
   "dependencies": {

--- a/test/integration/notebook/test_sparql_graph_notebook.py
+++ b/test/integration/notebook/test_sparql_graph_notebook.py
@@ -15,3 +15,19 @@ class TestGraphMagicGremlin(GraphNotebookIntegrationTest):
         sparql_res = self.ip.user_ns[store_to_var]
         self.assertTrue(sparql_res.startswith('<!DOCTYPE html>'))
         self.assertTrue('</table>' in sparql_res)
+
+    def test_load_sparql_config(self):
+        config = '''{
+              "host": "localhost",
+              "port": 3030,
+              "auth_mode": "DEFAULT",
+              "iam_credentials_provider_type": "ENV",
+              "load_from_s3_arn": "",
+              "ssl": false,
+              "aws_region": "us-west-2",
+              "sparql": {
+                "path": "/query"
+              }
+            }'''
+
+        self.ip.run_cell_magic('graph_notebook_config', '', config)

--- a/test/integration/sparql/sparql_query_without_iam.py
+++ b/test/integration/sparql/sparql_query_without_iam.py
@@ -14,7 +14,7 @@ class TestSparqlQuery(IntegrationTest):
         query = "SELECT * WHERE {?s ?p ?o} LIMIT 1"
         request_generator = SPARQLRequestGenerator()
 
-        res = do_sparql_query(query, self.host, self.port, self.ssl, request_generator, path='ds/query')
+        res = do_sparql_query(query, self.host, self.port, self.ssl, request_generator)
         self.assertEqual(type(res), dict)
         self.assertTrue('s' in res['head']['vars'])
         self.assertTrue('p' in res['head']['vars'])

--- a/test/integration/sparql/sparql_query_without_iam.py
+++ b/test/integration/sparql/sparql_query_without_iam.py
@@ -14,7 +14,7 @@ class TestSparqlQuery(IntegrationTest):
         query = "SELECT * WHERE {?s ?p ?o} LIMIT 1"
         request_generator = SPARQLRequestGenerator()
 
-        res = do_sparql_query(query, self.host, self.port, self.ssl, request_generator)
+        res = do_sparql_query(query, self.host, self.port, self.ssl, request_generator, path='ds/query')
         self.assertEqual(type(res), dict)
         self.assertTrue('s' in res['head']['vars'])
         self.assertTrue('p' in res['head']['vars'])

--- a/test/unit/notebooks/test_validate_notebooks.py
+++ b/test/unit/notebooks/test_validate_notebooks.py
@@ -27,6 +27,7 @@ class TestValidateAllNotebooks(unittest.TestCase):
             f'{NOTEBOOK_BASE_DIR}/02-Visualization/Blog Workbench Visualization.ipynb',
             f'{NOTEBOOK_BASE_DIR}/02-Visualization/EPL-Gremlin.ipynb',
             f'{NOTEBOOK_BASE_DIR}/02-Visualization/EPL-SPARQL.ipynb',
+            f'{NOTEBOOK_BASE_DIR}/03-Applications/Introduction-to-Fraud-Graphs.ipynb',
             f'{NOTEBOOK_BASE_DIR}/04-Machine-Learning/Neptune-ML-00-Getting-Started-with-Neptune-ML-Gremlin.ipynb',
             f'{NOTEBOOK_BASE_DIR}/04-Machine-Learning/Neptune-ML-01-Introduction-to-Node-Classification-Gremlin.ipynb',
             f'{NOTEBOOK_BASE_DIR}/04-Machine-Learning/Neptune-ML-02-Introduction-to-Node-Regression-Gremlin.ipynb',

--- a/test/unit/request_param_generator/test_sparql_request_generator.py
+++ b/test/unit/request_param_generator/test_sparql_request_generator.py
@@ -29,7 +29,7 @@ class TestSparqlRequestGenerator(unittest.TestCase):
             'Content-Type': 'application/x-www-form-urlencoded'
         }
 
-        expected_url = f'{protocol}://{host}:{port}/sparql'
+        expected_url = f'{protocol}://{host}:{port}/{action}'
         self.assertEqual(request_params['method'], method)
         self.assertEqual(request_params['url'], expected_url)
         self.assertEqual(request_params['headers'], expected_headers)
@@ -51,7 +51,7 @@ class TestSparqlRequestGenerator(unittest.TestCase):
             'Content-Type': 'application/x-www-form-urlencoded'
         }
 
-        expected_url = f'{protocol}://{host}:{port}/sparql'
+        expected_url = f'{protocol}://{host}:{port}/{action}'
         self.assertEqual(request_params['method'], method)
         self.assertEqual(request_params['url'], expected_url)
         self.assertEqual(request_params['headers'], expected_headers)


### PR DESCRIPTION
Issue #, if available: 61

Description of changes:

Change sparql custom path logic to no longer append `/sparql` to the end. This should help give support to all SPARQL endpoints.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.