### PR TITLE
Print execution time when running %load command

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -741,6 +741,9 @@ class Graph(Magics):
                         with job_status_output:
                             print(f'Overall Status: {interval_check_response["payload"]["overallStatus"]["status"]}')
                             if interval_check_response["payload"]["overallStatus"]["status"] in FINAL_LOAD_STATUSES:
+                                execution_time = interval_check_response["payload"]["overallStatus"]["totalTimeSpent"]
+                                execution_time_statement = '<1 second' if execution_time == 0 else f'{execution_time} seconds'
+                                print('Total execution time: ' + execution_time_statement)
                                 interval_output.close()
                                 print('Done.')
                                 return


### PR DESCRIPTION
Issue #, if available: #46

Description of changes:
- Print the total execution time of the bulk loader query when running the %load magic command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.