### PR TITLE
Adding support for %load_status details, errors, and pagination.

### DIFF
--- a/src/graph_notebook/loader/load.py
+++ b/src/graph_notebook/loader/load.py
@@ -58,9 +58,13 @@ def get_loader_jobs(host, port, use_ssl, request_param_generator):
     return res.json()
 
 
-def get_load_status(host, port, use_ssl, request_param_generator, id):
+def get_load_status(host, port, use_ssl, request_param_generator, id, loader_details, loader_errors, loader_page, loader_epp):
     payload = {
-        'loadId': id
+        'loadId': id,
+        'details': loader_details,
+        'errors': loader_errors,
+        'page': loader_page,
+        'errorsPerPage': loader_epp
     }
     res = call_and_get_response('get', LOADER_ACTION, host, port, request_param_generator, use_ssl, payload)
     return res.json()

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -795,12 +795,17 @@ class Graph(Magics):
         parser = argparse.ArgumentParser()
         parser.add_argument('load_id', default='', help='loader id to check status for')
         parser.add_argument('--store-to', type=str, default='')
+        parser.add_argument('--details', action='store_true', default=False)
+        parser.add_argument('--errors', action='store_true', default=False)
+        parser.add_argument('--page', '-p', default='1', help='The error page number. Only valid when the --errors option is set.')
+        parser.add_argument('--errorsPerPage', '-e', default='10', help='The number of errors per each page. Only valid when the --errors option is set.')
         args = parser.parse_args(line.split())
 
         credentials_provider_mode = self.graph_notebook_config.iam_credentials_provider_type
         request_generator = create_request_generator(self.graph_notebook_config.auth_mode, credentials_provider_mode)
         res = get_load_status(self.graph_notebook_config.host, self.graph_notebook_config.port,
-                              self.graph_notebook_config.ssl, request_generator, args.load_id)
+                              self.graph_notebook_config.ssl, request_generator, args.load_id, args.details, args.errors
+                              args.page, args,errorsPerPage)
         print(json.dumps(res, indent=2))
 
         if args.store_to != '' and local_ns is not None:

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -804,7 +804,7 @@ class Graph(Magics):
         credentials_provider_mode = self.graph_notebook_config.iam_credentials_provider_type
         request_generator = create_request_generator(self.graph_notebook_config.auth_mode, credentials_provider_mode)
         res = get_load_status(self.graph_notebook_config.host, self.graph_notebook_config.port,
-                              self.graph_notebook_config.ssl, request_generator, args.load_id, args.details, args.errors
+                              self.graph_notebook_config.ssl, request_generator, args.load_id, args.details, args.errors,
                               args.page, args,errorsPerPage)
         print(json.dumps(res, indent=2))
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -805,7 +805,7 @@ class Graph(Magics):
         request_generator = create_request_generator(self.graph_notebook_config.auth_mode, credentials_provider_mode)
         res = get_load_status(self.graph_notebook_config.host, self.graph_notebook_config.port,
                               self.graph_notebook_config.ssl, request_generator, args.load_id, args.details, args.errors,
-                              args.page, args,errorsPerPage)
+                              args.page, args.errorsPerPage)
         print(json.dumps(res, indent=2))
 
         if args.store_to != '' and local_ns is not None:


### PR DESCRIPTION
Issue #, if available:  Issues 14 and 24

Description of changes:  Adding parameter flags to `%load_status` magic in order to include details and errors for bulk loader status queries.  Also including the necessary parameters for pagination (page and errorsPerPage) per the Neptune documentation here:  https://docs.aws.amazon.com/neptune/latest/userguide/load-api-reference-status-requests.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.