### PR TITLE
Issue-93 - Fixed problem with GroupBy on Vertex objects

### DIFF
--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -271,7 +271,15 @@ class GremlinNetwork(EventfulNetwork):
         if type(v) is Vertex:
             node_id = v.id
             title = v.label
-            group = v.label
+            if self.group_by_property in [T_LABEL, 'label']:
+                # This sets the group key to the label if either "label" is passed in or
+                # T.label is set in order to handle the default case of grouping by label
+                # when no explicit key is specified
+                group = v.label
+            elif self.group_by_property == 'id':
+                group = v.id
+            else:
+                group = ''
             label = title if len(title) <= self.label_max_length else title[:self.label_max_length - 3] + '...'
             data = {'label': label, 'title': title, 'group': group, 'properties': {'id': node_id, 'label': title}}
         elif type(v) is dict:

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -8,6 +8,7 @@ from gremlin_python.structure.graph import Path
 from gremlin_python.process.traversal import T
 from graph_notebook.network.EventfulNetwork import EVENT_ADD_NODE
 from graph_notebook.network.gremlin.GremlinNetwork import GremlinNetwork
+from gremlin_python.structure.graph import Vertex
 
 
 class TestGremlinNetwork(unittest.TestCase):
@@ -212,6 +213,40 @@ class TestGremlinNetwork(unittest.TestCase):
         gn = GremlinNetwork(group_by_property="code", ignore_groups=True)
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['group'], '')
+
+    def test_group_returnvertex_groupby_notspecified(self):
+        vertex = Vertex(id='1')
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], 'vertex')
+
+    def test_group_returnvertex_groupby_label(self):
+        vertex = Vertex(id='1')
+
+        gn = GremlinNetwork(group_by_property="label")
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], 'vertex')
+
+        gn = GremlinNetwork(group_by_property="T.label")
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], 'vertex')
+
+    def test_group_returnvertex_groupby_id(self):
+        vertex = Vertex(id='1')
+
+        gn = GremlinNetwork(group_by_property="id")
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], '1')
+
+        gn = GremlinNetwork(group_by_property="T.id")
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
         self.assertEqual(node['group'], '')
 
 


### PR DESCRIPTION
Fixed problem where queries that returned only vertex objects were nt getting the grouping fields correctly applied.  Now they will group by the label by default or by id if specified

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.