### PR TITLE
add default values when checking load status

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,9 +6,11 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 This section contains the list of changes which will be included in the next release
 
-## Release 2.0.11 (Mar 25, 2021)
+## Release 2.0.12 (Mar 25, 2021)
 
+- Add default parameters for `get_load_status`
 - Add ipython as a dependency in `setup.py` ([Link to PT](https://github.com/aws/graph-notebook/pull/95))
+- Add parameters in `load_status` for `details`, `errors`, `page`, and `errorsPerPage`
 
 ## Release 2.0.10 (Mar 18, 2021)
 

--- a/src/graph_notebook/__init__.py
+++ b/src/graph_notebook/__init__.py
@@ -3,5 +3,5 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-__version__ = '2.0.11'
+__version__ = '2.0.12'
 

--- a/src/graph_notebook/loader/load.py
+++ b/src/graph_notebook/loader/load.py
@@ -58,7 +58,7 @@ def get_loader_jobs(host, port, use_ssl, request_param_generator):
     return res.json()
 
 
-def get_load_status(host, port, use_ssl, request_param_generator, id, loader_details, loader_errors, loader_page, loader_epp):
+def get_load_status(host, port, use_ssl, request_param_generator, id, loader_details="FALSE", loader_errors="FALSE", loader_page=1, loader_epp=10):
     payload = {
         'loadId': id,
         'details': loader_details,

--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph_notebook_widgets",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "author": "amazon",
   "description": "A Custom Jupyter Library for rendering NetworkX MultiDiGraphs using vis-network",
   "dependencies": {


### PR DESCRIPTION
Description of changes:
- Add default values when checking for load_status. Defaults taken from [public docs](https://docs.aws.amazon.com/neptune/latest/userguide/load-api-reference-status-requests.html#load-api-reference-status-request-syntax)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.