### PR TITLE
Add metadata output tab for magic queries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 
 - Add support for Mode, queueRequest, and Dependencies parameters when running %load command
+- Add metadata output tab for magic queries
 
 ## Release 2.0.12 (Mar 25, 2021)
 


### PR DESCRIPTION
Issue #, if available: #25

Description of changes:
- Display new output tab with query metadata when executing SPARQL and Gremlin magic queries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.