### PR TITLE
Add support for grouping by different properties by label in Gremlin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Add support for notebook variables in Sparql/Gremlin magic queries ([Link to PR](https://github.com/aws/graph-notebook/pull/113))
+- Add support for grouping by different properties per label in Gremlin ([Link to PR](https://github.com/aws/graph-notebook/pull/115))
+- Fix missing Boto3 dependency in setup.py ([Link to PR](https://github.com/aws/graph-notebook/pull/118))
+
 
 ## Release 2.1.0 (April 15, 2021)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -340,7 +340,7 @@ class Graph(Magics):
         parser.add_argument('query_mode', nargs='?', default='query',
                             help='query mode (default=query) [query|explain|profile]')
         parser.add_argument('-p', '--path-pattern', default='', help='path pattern')
-        parser.add_argument('-g', '--group-by', default='T.label',
+        parser.add_argument('-g', '--group-by', type=str, default='T.label',
                             help='Property used to group nodes (e.g. code, T.region) default is T.label')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
         parser.add_argument('--ignore-groups', action='store_true', default=False, help="Ignore all grouping options")

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -290,7 +290,6 @@ class GremlinNetwork(EventfulNetwork):
                 else:
                     group = ''
             else:  # handle dict format group_by
-                print(self.group_by_property)
                 try:
                     if str(v.label) in self.group_by_property:
                         if self.group_by_property[str(v.label)]['groupby'] in [T_LABEL, 'label']:

--- a/src/graph_notebook/notebooks/02-Visualization/Visualization-Grouping-Coloring-Gremlin.ipynb
+++ b/src/graph_notebook/notebooks/02-Visualization/Visualization-Grouping-Coloring-Gremlin.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "neural-balance",
+   "id": "a7f4e963",
    "metadata": {},
    "source": [
     "Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n",
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mature-foster",
+   "id": "20cbc162",
    "metadata": {},
    "source": [
     "# Visualization - Grouping and Appearance Customization\n",
@@ -26,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "assigned-reform",
+   "id": "3232a5e5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "reverse-meeting",
+   "id": "df4617ec",
    "metadata": {},
    "source": [
     "With the air-routes data now loaded we are ready to begin looking at how to group and customize our result visualization.  \n",
@@ -59,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "quarterly-formula",
+   "id": "0d2eac8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "discrete-festival",
+   "id": "f70c0847",
    "metadata": {},
    "source": [
     "From the results we see three groups each represented by a different color.  Each of the vertices is added to a group based on it's label.  \n",
@@ -81,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fitted-paris",
+   "id": "0b7074b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "attempted-precipitation",
+   "id": "c461a12b",
    "metadata": {},
    "source": [
     "From the resultant visualization we see that we still have three groups of vertices, grouped by the label.  \n",
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "still-schema",
+   "id": "b697ec16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "figured-diabetes",
+   "id": "f992ea07",
    "metadata": {},
    "source": [
     "From the results we see that all our vertices are in a single group now and colored the same.  When our results do not contain the label for the vertex we must then specify the property we want to group by.  \n",
@@ -131,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hungry-pursuit",
+   "id": "c4e0331f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "unable-calculation",
+   "id": "d51905df",
    "metadata": {},
    "source": [
     "As we see our results are now split into three groups (MX/US/CA) based on the country property.  \n",
@@ -152,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "excess-personality",
+   "id": "d1b51d2a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "motivated-theater",
+   "id": "776edf46",
    "metadata": {},
    "source": [
     "The resultant graph looks very similar to the previous one except that their is now four groups instead of three.  Unlike in the previous example where we only returned `route` connections, this query returned all connected vertices so our resultset came back with a `continent` and `country` vertex in addition to the `airport` vertices.  Neither the `country` nor `continent` vertices have a `country` property.  When a vertex does not contain the property specified to group by then that vertex is put into a default group.  This same behavior occurs when you use the incorrect casing for the property name, as shown in the query below."
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "valid-supervision",
+   "id": "d337fae1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +181,72 @@
   },
   {
    "cell_type": "markdown",
-   "id": "supported-security",
+   "id": "a8f75778",
+   "metadata": {},
+   "source": [
+    "### Grouping on different properties for each label"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bf09b32",
+   "metadata": {},
+   "source": [
+    "While the `continent` and `country` vertices cannot be grouped on properties exclusive to `airport` vertices, we do have the ability to add additional properties with which to form new groups. To do this, we will make use of Jupyter's built-in line magic variable injection to pass in a variable containing a JSON-format string, where we can specify what property we want to use to group each of the individual vertex labels.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e500b5c8",
+   "metadata": {},
+   "source": [
+    "The group-by variable must be defined in following format:  \n",
+    "\n",
+    "`groups_var = '{\"label_1\":{\"groupby\":\"property_1\"},\"label_2\":{\"groupby\":\"property_2\"}}'`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "158189c0",
+   "metadata": {},
+   "source": [
+    "Let's try defining group-by with individual properties for `airport`, `continent`, and `country`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa2dab8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "groups_var = '{\"airport\":{\"groupby\":\"country\"},\"country\":{\"groupby\":\"desc\"},\"continent\":{\"groupby\":\"code\"}}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "327ccddd",
+   "metadata": {},
+   "source": [
+    "Then, we can rerun our previous query, this time with `$groups_var`, and see that the `continent` and `country` vertices now belong to their own groups based on the specified properties.  \n",
+    "\n",
+    "**Note** we also need to use `valueMap(true)` so that the label names and relevant properties can be accessed for group matching."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2f0fb09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%gremlin -p v,inv -g $groups_var\n",
+    "g.V().hasLabel('airport').has('code','CZM').both().path().by(valueMap(true))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bade0fd5",
    "metadata": {},
    "source": [
     "### Ignoring Grouping\n",
@@ -192,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stuck-mercy",
+   "id": "3c34d478",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "written-heating",
+   "id": "1a4eadb7",
    "metadata": {},
    "source": [
     "Now that we know how to group our vertices together let's take a look at how to customize the appearance of these groups.\n",
@@ -228,7 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "deadly-alexander",
+   "id": "aece55f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "satisfactory-robertson",
+   "id": "516ea768",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +320,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "purple-makeup",
+   "id": "a178a54f",
    "metadata": {},
    "source": [
     "### Specifying Shape\n",
@@ -272,7 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "interesting-calculation",
+   "id": "f02b919b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "first-looking",
+   "id": "f7f8eed2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "alone-equality",
+   "id": "d969158e",
    "metadata": {},
    "source": [
     "### Specifying Icons and Images\n",
@@ -316,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "genetic-helping",
+   "id": "450de168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "geological-utilization",
+   "id": "40cd2de9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fifth-homeless",
+   "id": "2f676ac7",
    "metadata": {},
    "source": [
     "### Specifying Size\n",
@@ -365,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "elder-snake",
+   "id": "d0981894",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "alive-indiana",
+   "id": "dcbb1d97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "electoral-momentum",
+   "id": "438bc451",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -66,6 +66,110 @@ class TestGremlinNetwork(unittest.TestCase):
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['group'], 'SEA')
 
+    def test_group_with_groupby_multiple_labels_with_same_property(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'name': 'Seattle-Tacoma International Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        vertex2 = {
+            T.id: '2345',
+            T.label: 'country',
+            'type': 'Country',
+            'name': 'Austria',
+            'continent': 'Europe',
+        }
+
+        gn = GremlinNetwork(group_by_property='name')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['group'], 'Seattle-Tacoma International Airport')
+        self.assertEqual(node2['group'], 'Austria')
+
+    def test_group_with_groupby_properties_json_single_label(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"code"}}')
+        gn.add_vertex(vertex1)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        self.assertEqual(node1['group'], 'SEA')
+
+    def test_group_with_groupby_properties_json_multiple_labels(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        vertex2 = {
+            T.id: '2345',
+            T.label: 'country',
+            'type': 'Country',
+            'name': 'Austria',
+            'continent': 'Europe'
+        }
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"code"},"country":{"groupby":"continent"}}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['group'], 'SEA')
+        self.assertEqual(node2['group'], 'Europe')
+
+    def test_group_with_groupby_invalid_json_single_label(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"code"}}')
+        gn.add_vertex(vertex1)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        self.assertEqual(node1['group'], '')
+
+    def test_group_with_groupby_invalid_json_multiple_labels(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        vertex2 = {
+            T.id: '2345',
+            T.label: 'country',
+            'type': 'Country',
+            'name': 'Austria',
+            'continent': 'Europe'
+        }
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"code"},"country":{"groupby":"continent"}}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['group'], '')
+        self.assertEqual(node2['group'], '')
+
     def test_group_nonexistent_groupby(self):
         vertex = {
             T.id: '1234',
@@ -80,6 +184,84 @@ class TestGremlinNetwork(unittest.TestCase):
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['group'], '')
 
+    def test_group_nonexistent_groupby_properties_json_single_label(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"foo"}}')
+        gn.add_vertex(vertex1)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        self.assertEqual(node1['group'], '')
+
+    def test_group_nonexistent_groupby_properties_json_multiple_labels(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        vertex2 = {
+            T.id: '2345',
+            T.label: 'country',
+            'type': 'Country',
+            'name': 'Austria',
+            'continent': 'Europe'
+        }
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"foo"},"country":{"groupby":"continent"}}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['group'], '')
+        self.assertEqual(node2['group'], 'Europe')
+
+    def test_group_nonexistent_label_properties_json_single_label(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(group_by_property='{"air_port":{"groupby":"code"}')
+        gn.add_vertex(vertex1)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        self.assertEqual(node1['group'], '')
+
+    def test_group_nonexistent_label_properties_json_multiple_labels(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        vertex2 = {
+            T.id: '2345',
+            T.label: 'country',
+            'type': 'Country',
+            'name': 'Austria',
+            'continent': 'Europe'
+        }
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"code"},"a_country":{"groupby":"continent"}}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['group'], 'SEA')
+        self.assertEqual(node2['group'], '')
+
     def test_group_without_groupby(self):
         vertex = {
             T.id: '1234',
@@ -93,6 +275,31 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['group'], 'airport')
+
+    def test_group_without_groupby_multiple_labels(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        vertex2 = {
+            T.id: '2345',
+            T.label: 'country',
+            'type': 'Country',
+            'name': 'Austria',
+            'continent': 'Europe'
+        }
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['group'], 'airport')
+        self.assertEqual(node2['group'], 'country')
 
     def test_group_valueMap_true(self):
         vertex = {
@@ -140,6 +347,18 @@ class TestGremlinNetwork(unittest.TestCase):
         }
 
         gn = GremlinNetwork(group_by_property='code')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['group'], "['SEA']")
+
+    def test_group_with_groupby_list_properties_json(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'code': ['SEA']
+        }
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"code"}}')
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['group'], "['SEA']")
@@ -196,6 +415,54 @@ class TestGremlinNetwork(unittest.TestCase):
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['group'], "['ATL']")
 
+    def test_add_path_with_groupby_multiple_labels(self):
+        path = Path([], [{'country': ['US'], 'code': ['SEA'], 'longest': [11901], 'city': ['Seattle'],
+                          T.label: 'airport', 'lon': [-122.30899810791], 'type': ['airport'], 'elev': [432],
+                          T.id: '22', 'icao': ['KSEA'], 'runways': [3], 'region': ['US-WA'],
+                          'lat': [47.4490013122559], 'desc': ['Seattle-Tacoma']},
+                         {'country': ['US'], 'code': ['ATL'], 'longest': [12390], 'city': ['Atlanta'],
+                          T.label: 'airport', 'lon': [-84.4281005859375], 'type': ['airport'], 'elev': [1026],
+                          T.id: '1', 'icao': ['KATL'], 'runways': [5], 'region': ['US-GA'],
+                          'lat': [33.6366996765137], 'desc': ['Hartsfield - Jackson Atlanta International Airport']},
+                         {'code': ['AN'], T.label: 'continent', T.id: '3741', 'desc': ['Antarctica']}])
+        gn = GremlinNetwork(group_by_property='code')
+        gn.add_results([path])
+        node1 = gn.graph.nodes.get('1')
+        node2 = gn.graph.nodes.get('3741')
+        self.assertEqual(node1['group'], "['ATL']")
+        self.assertEqual(node2['group'], "['AN']")
+
+    def test_add_path_with_groupby_properties_json(self):
+        path = Path([], [{'country': ['US'], 'code': ['SEA'], 'longest': [11901], 'city': ['Seattle'],
+                          T.label: 'airport', 'lon': [-122.30899810791], 'type': ['airport'], 'elev': [432],
+                          T.id: '22', 'icao': ['KSEA'], 'runways': [3], 'region': ['US-WA'],
+                          'lat': [47.4490013122559], 'desc': ['Seattle-Tacoma']},
+                         {'country': ['US'], 'code': ['ATL'], 'longest': [12390], 'city': ['Atlanta'],
+                          T.label: 'airport', 'lon': [-84.4281005859375], 'type': ['airport'], 'elev': [1026],
+                          T.id: '1', 'icao': ['KATL'], 'runways': [5], 'region': ['US-GA'],
+                          'lat': [33.6366996765137], 'desc': ['Hartsfield - Jackson Atlanta International Airport']}])
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"code"}}')
+        gn.add_results([path])
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], "['ATL']")
+
+    def test_add_path_with_groupby_properties_json_multiple_labels(self):
+        path = Path([], [{'country': ['US'], 'code': ['SEA'], 'longest': [11901], 'city': ['Seattle'],
+                          T.label: 'airport', 'lon': [-122.30899810791], 'type': ['airport'], 'elev': [432],
+                          T.id: '22', 'icao': ['KSEA'], 'runways': [3], 'region': ['US-WA'],
+                          'lat': [47.4490013122559], 'desc': ['Seattle-Tacoma']},
+                         {'country': ['US'], 'code': ['ATL'], 'longest': [12390], 'city': ['Atlanta'],
+                          T.label: 'airport', 'lon': [-84.4281005859375], 'type': ['airport'], 'elev': [1026],
+                          T.id: '1', 'icao': ['KATL'], 'runways': [5], 'region': ['US-GA'],
+                          'lat': [33.6366996765137], 'desc': ['Hartsfield - Jackson Atlanta International Airport']},
+                         {'code': ['AN'], T.label: 'continent', T.id: '3741', 'desc': ['Antarctica']}])
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"region"}, "continent":{"groupby":"code"}}')
+        gn.add_results([path])
+        node1 = gn.graph.nodes.get('1')
+        node2 = gn.graph.nodes.get('3741')
+        self.assertEqual(node1['group'], "['US-GA']")
+        self.assertEqual(node2['group'], "['AN']")
+
     def test_ignore_group(self):
         vertex = {
             T.id: '1234',
@@ -214,6 +481,40 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['group'], '')
+
+    def test_ignore_group_properties_json(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        vertex2 = {
+            T.id: '2345',
+            T.label: 'country',
+            'type': 'Country',
+            'name': 'Austria',
+            'continent': 'Europe'
+        }
+
+        gn = GremlinNetwork(ignore_groups=True)
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['group'], '')
+        self.assertEqual(node2['group'], '')
+
+        gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"code"},"country":{"groupby":"continent"}}',
+                            ignore_groups=True)
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['group'], '')
+        self.assertEqual(node2['group'], '')
 
     def test_group_returnvertex_groupby_notspecified(self):
         vertex = Vertex(id='1')

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -526,8 +526,6 @@ class TestGremlinNetwork(unittest.TestCase):
 
     def test_group_returnvertex_groupby_label(self):
         vertex = Vertex(id='1')
-        print(vertex.label)
-        print(vertex.id)
 
         gn = GremlinNetwork(group_by_property="label")
         gn.add_vertex(vertex)
@@ -541,8 +539,6 @@ class TestGremlinNetwork(unittest.TestCase):
 
     def test_group_returnvertex_groupby_label_properties_json(self):
         vertex = Vertex(id='1')
-        print(vertex.label)
-        print(vertex.id)
 
         gn = GremlinNetwork(group_by_property='{"vertex":{"groupby":"label"}}')
         gn.add_vertex(vertex)

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -526,6 +526,8 @@ class TestGremlinNetwork(unittest.TestCase):
 
     def test_group_returnvertex_groupby_label(self):
         vertex = Vertex(id='1')
+        print(vertex.label)
+        print(vertex.id)
 
         gn = GremlinNetwork(group_by_property="label")
         gn.add_vertex(vertex)
@@ -533,6 +535,21 @@ class TestGremlinNetwork(unittest.TestCase):
         self.assertEqual(node['group'], 'vertex')
 
         gn = GremlinNetwork(group_by_property="T.label")
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], 'vertex')
+
+    def test_group_returnvertex_groupby_label_properties_json(self):
+        vertex = Vertex(id='1')
+        print(vertex.label)
+        print(vertex.id)
+
+        gn = GremlinNetwork(group_by_property='{"vertex":{"groupby":"label"}}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], 'vertex')
+
+        gn = GremlinNetwork(group_by_property='{"vertex":{"groupby":"T.label"}}')
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['group'], 'vertex')
@@ -546,6 +563,19 @@ class TestGremlinNetwork(unittest.TestCase):
         self.assertEqual(node['group'], '1')
 
         gn = GremlinNetwork(group_by_property="T.id")
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], '')
+
+    def test_group_returnvertex_groupby_id_properties_json(self):
+        vertex = Vertex(id='1')
+
+        gn = GremlinNetwork(group_by_property='{"vertex":{"groupby":"id"}}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], '1')
+
+        gn = GremlinNetwork(group_by_property='{"vertex":{"groupby":"T.id"}}')
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['group'], '')


### PR DESCRIPTION
Issue #, if available: #97

Description of changes:
- Enhance the Gremlin cell magic group-by parameter by allowing users to specify individual grouping behaviors for vertices that have different labels but are returned in the same set of query results.


**Usage**:

The variable containing the desired grouping behavior must be formatted as:

`
groups_var = '{"label_1":{"groupby":"property_1"},"label_2":{"groupby":"property_2"}}'
`

A valueMap step returning the label property and the grouping property(i.e. valueMap(true) or valueMap('~label','property_1'...)) must also be included in the query.


**Example:**

<img width="892" alt="Screen Shot 2021-04-23 at 2 29 48 AM" src="https://user-images.githubusercontent.com/10456376/115851703-18415700-a3dc-11eb-8711-b606ac183f9a.png">




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.