### PR TITLE
Fix missing Boto3 dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         'jupyter>=1.0.0',
         'requests-aws4auth==1.0.1',
         'botocore>=1.19.37',
+        'boto3>=1.17.58',
         'ipython>=7.16.1'
     ],
     package_data={


### PR DESCRIPTION
Issue #, if available: #117

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.