### PR TITLE
Display %load command execution time as HH:MM:SS for large values

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Add support for notebook variables in Sparql/Gremlin magic queries ([Link to PR](https://github.com/aws/graph-notebook/pull/113))
 - Add support for grouping by different properties per label in Gremlin ([Link to PR](https://github.com/aws/graph-notebook/pull/115))
 - Fix missing Boto3 dependency in setup.py ([Link to PR](https://github.com/aws/graph-notebook/pull/118))
-
+- Update %load execution time to HH:MM:SS format if over a minute ([Link to PR]())
 
 ## Release 2.1.1 (April 22, 2021)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Add support for notebook variables in Sparql/Gremlin magic queries ([Link to PR](https://github.com/aws/graph-notebook/pull/113))
 - Add support for grouping by different properties per label in Gremlin ([Link to PR](https://github.com/aws/graph-notebook/pull/115))
 - Fix missing Boto3 dependency in setup.py ([Link to PR](https://github.com/aws/graph-notebook/pull/118))
-- Update %load execution time to HH:MM:SS format if over a minute ([Link to PR]())
+- Update %load execution time to HH:MM:SS format if over a minute ([Link to PR](https://github.com/aws/graph-notebook/pull/121))
 
 ## Release 2.1.1 (April 22, 2021)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -9,6 +9,7 @@ import argparse
 import logging
 import json
 import time
+import datetime
 import os
 import uuid
 from enum import Enum
@@ -823,7 +824,12 @@ class Graph(Magics):
                             print(f'Overall Status: {interval_check_response["payload"]["overallStatus"]["status"]}')
                             if interval_check_response["payload"]["overallStatus"]["status"] in FINAL_LOAD_STATUSES:
                                 execution_time = interval_check_response["payload"]["overallStatus"]["totalTimeSpent"]
-                                execution_time_statement = '<1 second' if execution_time == 0 else f'{execution_time} seconds'
+                                if execution_time == 0:
+                                    execution_time_statement = '<1 second'
+                                elif execution_time > 59:
+                                    execution_time_statement = str(datetime.timedelta(seconds=execution_time))
+                                else:
+                                    execution_time_statement = f'{execution_time} seconds'
                                 print('Total execution time: ' + execution_time_statement)
                                 interval_output.close()
                                 print('Done.')


### PR DESCRIPTION
Issue #, if available: #120

Description of changes:
- Use HH:MM:SS format for any execution times 1 minute or over

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.