### PR TITLE
Update sample notebooks with '--label-max-length' parameter usage

### DIFF
--- a/src/graph_notebook/notebooks/02-Visualization/Visualization-Grouping-Coloring-Gremlin.ipynb
+++ b/src/graph_notebook/notebooks/02-Visualization/Visualization-Grouping-Coloring-Gremlin.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f0753d52",
+   "id": "racial-mouth",
    "metadata": {},
    "source": [
     "Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n",
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "052f5060",
+   "id": "comfortable-constant",
    "metadata": {},
    "source": [
     "# Visualization - Grouping and Appearance Customization\n",
@@ -26,7 +26,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06d6e34b",
+   "id": "promising-alabama",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,14 +35,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c85d0f58",
+   "id": "informational-frederick",
    "metadata": {},
    "source": [
     "With the air-routes data now loaded we are ready to begin looking at how to group and customize our result visualization.  \n",
     "\n",
     "## Node Property Options\n",
     "\n",
-    "Visualizing the results of a query will result in a graph where each vertex contains an identifying property. The property used will either be generated automatically from the label property, or abide by the property or set of label properties specified by the user.\n",
+    "Visualizing the results of a query will result in a graph where each vertex contains an identifying property. By default, the property used is generated automatically from the label property. If desired, it can instead abide by the property (or set of label properties) specified using the `--display-property` or `-d` parameter, followed by the property name. \n",
+    "\n",
+    "Additionally, labels are truncated after exceeding a default maximum length. This maximum length value can be modified by using the `--label-max-length` or `-l` parameter, followed by the desired length in characters.\n",
+    "\n",
     "\n",
     "### Default Node Properties\n",
     "\n",
@@ -52,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d620e12c",
+   "id": "angry-circumstances",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "156ec7b8",
+   "id": "round-trial",
    "metadata": {},
    "source": [
     "The results show us only three distinct labels, corresponding to each of the label properties `airport`, `country`, and `continent`.\n",
@@ -75,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9decfb0",
+   "id": "lined-burden",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3fe86f28",
+   "id": "detected-publicity",
    "metadata": {},
    "source": [
     "### Specifying a Single Node Property for all Vertices\n",
@@ -102,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5cb76379",
+   "id": "moved-optimization",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08b61141",
+   "id": "moving-offset",
    "metadata": {},
    "source": [
     "Looking at the resulting visualized graph, each individual node can now be identified by its distinct code.\n",
@@ -131,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afeb28db",
+   "id": "photographic-river",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8fe77ea",
+   "id": "lasting-jimmy",
    "metadata": {},
    "source": [
     "Now, we can take the previous query and pass `display_var` into the displayed properties parameter via the notebooks line variable injection functionality."
@@ -149,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e7fd48e",
+   "id": "surrounded-appendix",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,15 +162,63 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a2e4938c",
+   "id": "confidential-payday",
    "metadata": {},
    "source": [
-    "In the resulting visualization, we can see that the `airport` vertices retain the `code` property values, while the `country` and `continent` nodes now display their more descriptive `desc` property values, as we desired."
+    "In the resulting visualization, we can see that the `airport` vertices retain the `code` property values, while the `country` and `continent` nodes now display their more descriptive `desc` property values, as we desired.\n",
+    "\n",
+    "### Specifying the Maximum Label Length\n",
+    "\n",
+    "All node labels in the graph abide by a maximum length value, after which they are visually truncated. By default, this value is 10.\n",
+    "\n",
+    "You may encounter scenarios where you want to modify the truncation length to either be shorter or longer than the default value. This can be done by adding the `--label-max-length` or `-l` parameter to your Gremlin query, followed by the desired length in characters.\n",
+    "\n",
+    "Let's try to visualize a graph of all airports connected to Cozumel, while indicating that we want to display the full airport names on the nodes. Note that the label truncation length is left as default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "known-virtue",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%gremlin -p v,inv -d desc\n",
+    "g.V().hasLabel('airport').has('code','CZM').both().path().by(valueMap(true))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d611b88a",
+   "id": "catholic-cocktail",
+   "metadata": {},
+   "source": [
+    "We can see that most of the labels are cut off too early to be adequately descriptive!\n",
+    "\n",
+    "Let's try the same query again, this time incorporating the `-l` parameter, followed by a maximum length value of `60`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "engaging-swaziland",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%gremlin -p v,inv -d desc -l 60\n",
+    "g.V().hasLabel('airport').has('code','CZM').both().path().by(valueMap(true))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dried-instrumentation",
+   "metadata": {},
+   "source": [
+    "Now, we can see the full name of every airport on the graph."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "incorporate-earth",
    "metadata": {},
    "source": [
     "## Grouping Options\n",
@@ -189,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b0fa21f",
+   "id": "brief-onion",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55cbec6b",
+   "id": "public-subject",
    "metadata": {},
    "source": [
     "From the results we see three groups each represented by a different color.  Each of the vertices is added to a group based on it's label.  \n",
@@ -211,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f56dabdf",
+   "id": "static-panama",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "386ac671",
+   "id": "stainless-austria",
    "metadata": {},
    "source": [
     "From the resultant visualization we see that we still have three groups of vertices, grouped by the label.  \n",
@@ -233,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f7d951b",
+   "id": "baking-standing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +295,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a64cb250",
+   "id": "celtic-knife",
    "metadata": {},
    "source": [
     "From the results we see that all our vertices are in a single group now and colored the same.  When our results do not contain the label for the vertex we must then specify the property we want to group by.  \n",
@@ -261,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "709aaadf",
+   "id": "adjusted-germany",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +322,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77f659cd",
+   "id": "gentle-frank",
    "metadata": {},
    "source": [
     "As we see our results are now split into three groups (MX/US/CA) based on the country property.  \n",
@@ -282,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fcfcab6b",
+   "id": "boolean-camel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0ea9a53",
+   "id": "needed-entertainment",
    "metadata": {},
    "source": [
     "The resultant graph looks very similar to the previous one except that their is now four groups instead of three.  Unlike in the previous example where we only returned `route` connections, this query returned all connected vertices so our resultset came back with a `continent` and `country` vertex in addition to the `airport` vertices.  Neither the `country` nor `continent` vertices have a `country` property.  When a vertex does not contain the property specified to group by then that vertex is put into a default group.  This same behavior occurs when you use the incorrect casing for the property name, as shown in the query below."
@@ -301,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08f95b14",
+   "id": "desirable-romantic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +362,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d99247dd",
+   "id": "certified-great",
    "metadata": {},
    "source": [
     "### Grouping on different properties for each label"
@@ -319,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3190c25f",
+   "id": "demographic-testament",
    "metadata": {},
    "source": [
     "While the `continent` and `country` vertices cannot be grouped on properties exclusive to `airport` vertices, we do have the ability to add additional properties with which to form new groups. To do this, we will make use of Jupyter's built-in line magic variable injection to pass in a variable containing a JSON-format string, where we can specify what property we want to use to group each of the individual vertex labels.  "
@@ -327,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e47ddfb2",
+   "id": "major-jordan",
    "metadata": {},
    "source": [
     "The group-by variable must be defined in following format:  \n",
@@ -337,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43251d26",
+   "id": "hungarian-bradley",
    "metadata": {},
    "source": [
     "Let's try defining group-by with individual properties for `airport`, `continent`, and `country`."
@@ -346,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b08ceec9",
+   "id": "fifty-waterproof",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +406,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1004068",
+   "id": "fiscal-dairy",
    "metadata": {},
    "source": [
     "Then, we can rerun our previous query, this time with `$groups_var`, and see that the `continent` and `country` vertices now belong to their own groups based on the specified properties.  \n",
@@ -366,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2cf541a2",
+   "id": "marine-edmonton",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +427,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c1adc3f",
+   "id": "existing-advantage",
    "metadata": {},
    "source": [
     "### Ignoring Grouping\n",
@@ -387,7 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb774d8a",
+   "id": "warming-accordance",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "719ec590",
+   "id": "obvious-cameroon",
    "metadata": {},
    "source": [
     "Now that we know how to group our vertices together let's take a look at how to customize the appearance of these groups.\n",
@@ -423,7 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "317dda76",
+   "id": "american-spirit",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe17aaf8",
+   "id": "biological-diesel",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,7 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0786de26",
+   "id": "written-member",
    "metadata": {},
    "source": [
     "### Specifying Shape\n",
@@ -467,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7a0e561",
+   "id": "solved-rhythm",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c8da332",
+   "id": "random-breakfast",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +545,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba43ac4f",
+   "id": "essential-building",
    "metadata": {},
    "source": [
     "### Specifying Icons and Images\n",
@@ -511,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e1ad4f3",
+   "id": "illegal-contrast",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14961759",
+   "id": "empty-while",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "387ff8e1",
+   "id": "acquired-finding",
    "metadata": {},
    "source": [
     "### Specifying Size\n",
@@ -560,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f1f72db",
+   "id": "passive-smith",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "835f3fd9",
+   "id": "proud-gossip",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,7 +648,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e137fdb",
+   "id": "acute-coordinator",
    "metadata": {},
    "source": [
     "## Conclusion\n",
@@ -622,7 +673,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.6.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Issue #, if available: #35

Description of changes:
- Add example usage of the `-label-max-length`Gremlin magic parameter to the `Visualization-Grouping-Coloring-Gremlin` sample notebook

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.