### PR TITLE
 Add new --edge-display-property parameter to Gremlin magic for specifying edge labels

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -348,6 +348,8 @@ class Graph(Magics):
                             help='Property used to group nodes (e.g. code, T.region) default is T.label')
         parser.add_argument('-d', '--display-property', type=str, default='T.label',
                             help='Property to display the value of on each node, default is T.label')
+        parser.add_argument('-de', '--edge-display-property', type=str, default='T.label',
+                            help='Property to display the value of on each edge, default is T.label')
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
                             help='Specifies max length of vertex label, in characters. Default is 10')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
@@ -393,9 +395,11 @@ class Graph(Magics):
             try:
                 logger.debug(f'groupby: {args.group_by}')
                 logger.debug(f'display_property: {args.display_property}')
+                logger.debug(f'edge_display_property: {args.edge_display_property}')
                 logger.debug(f'label_max_length: {args.label_max_length}')
                 logger.debug(f'ignore_groups: {args.ignore_groups}')
                 gn = GremlinNetwork(group_by_property=args.group_by, display_property=args.display_property,
+                                    edge_display_property=args.edge_display_property,
                                     label_max_length=args.label_max_length, ignore_groups=args.ignore_groups)
 
                 if args.path_pattern == '':

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -98,7 +98,8 @@ class GremlinNetwork(EventfulNetwork):
     """
 
     def __init__(self, graph: MultiDiGraph = None, callbacks=None, label_max_length=DEFAULT_LABEL_MAX_LENGTH,
-                 group_by_property=T_LABEL, display_property=T_LABEL, ignore_groups=False):
+                 group_by_property=T_LABEL, display_property=T_LABEL, edge_display_property=T_LABEL,
+                 ignore_groups=False):
         if graph is None:
             graph = MultiDiGraph()
         if label_max_length < 3:
@@ -113,6 +114,10 @@ class GremlinNetwork(EventfulNetwork):
             self.display_property = json.loads(display_property)
         except ValueError:
             self.display_property = display_property
+        try:
+            self.edge_display_property = json.loads(edge_display_property)
+        except ValueError:
+            self.edge_display_property = edge_display_property
         self.ignore_groups = ignore_groups
         super().__init__(graph, callbacks)
 
@@ -390,18 +395,40 @@ class GremlinNetwork(EventfulNetwork):
             from_id = from_id if from_id != '' else edge.outV.id
             to_id = to_id if to_id != '' else edge.inV.id
             data['properties'] = {'id': edge.id, 'label': edge.label, 'outV': str(edge.outV), 'inV': str(edge.inV)}
-            self.add_edge(from_id, to_id, edge.id, edge.label, data)
+            if isinstance(self.edge_display_property, dict):
+                try:
+                    display_label = data['properties'][self.edge_display_property[edge.label]]
+                except KeyError:
+                    display_label = edge.label
+            else:
+                if self.edge_display_property == T_LABEL:
+                    display_label = edge.label
+                else:
+                    try:
+                        display_label = data['properties'][self.edge_display_property]
+                    except KeyError:
+                        display_label = edge.label
+            self.add_edge(from_id, to_id, edge.id, display_label, data)
         elif type(edge) is dict:
             properties = {}
             edge_id = ''
             edge_label = ''
+            if T.label in edge.keys():
+                edge_label = str(edge[T.label])
             for k in edge:
-                if str(k) == T_LABEL:
-                    edge_label = str(edge[k])
-                elif str(k) == T_ID:
+                if str(k) == T_ID:
                     edge_id = str(edge[k])
 
                 properties[k] = edge[k]
+                if self.edge_display_property is not T_LABEL:
+                    if isinstance(self.edge_display_property, dict):
+                        try:
+                            if str(k) == self.edge_display_property[edge_label]:
+                                edge_label = str(edge[k])
+                        except KeyError:
+                            continue
+                    elif str(k) == self.edge_display_property:
+                        edge_label = str(edge[k])
             data['properties'] = properties
             self.add_edge(from_id, to_id, edge_id, edge_label, data)
         else:

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import unittest
-from gremlin_python.structure.graph import Path
+from gremlin_python.structure.graph import Path, Edge, Vertex
 from gremlin_python.process.traversal import T
 from graph_notebook.network.EventfulNetwork import EVENT_ADD_NODE
 from graph_notebook.network.gremlin.GremlinNetwork import GremlinNetwork
@@ -354,6 +354,319 @@ class TestGremlinNetwork(unittest.TestCase):
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'Seattle-Taco...')
 
+    def test_add_explicit_type_single_edge_without_edge_property(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_explicit_type_single_edge_with_invalid_edge_property(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork(edge_display_property='length')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_explicit_type_single_edge_with_edge_property_string_label(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork(edge_display_property='label')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_explicit_type_single_edge_with_edge_property_string_id(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork(edge_display_property='id')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], '1')
+
+    def test_add_explicit_type_single_edge_with_edge_property_json_single_label(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork(edge_display_property='{"route":"inV"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'v[2]')
+
+    def test_add_explicit_type_single_edge_with_edge_property_malformed_json_single_label(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork(edge_display_property='{"route":inV}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_explicit_type_single_edge_with_edge_property_json_invalid_key_single_label(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork(edge_display_property='{"road":"inV"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_explicit_type_single_edge_with_edge_property_json_invalid_value_single_label(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork(edge_display_property='{"route":"distance"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_explicit_type_multiple_edges_with_edge_property_string(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        vertex3 = Vertex(id='3')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='airway')
+        edge2 = Edge(id='2', outV=vertex2, inV=vertex3, label='road')
+
+        gn = GremlinNetwork(edge_display_property='id')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        gn.add_path_edge(edge2)
+        edge_route = gn.graph.get_edge_data('1', '2')
+        edge_path = gn.graph.get_edge_data('2', '3')
+        self.assertEqual(edge_route['1']['label'], '1')
+        self.assertEqual(edge_path['2']['label'], '2')
+
+    def test_add_explicit_type_multiple_edges_with_edge_property_json_single_label(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        vertex3 = Vertex(id='3')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='route')
+        edge2 = Edge(id='2', outV=vertex2, inV=vertex3, label='route')
+
+        gn = GremlinNetwork(edge_display_property='{"route":"inV"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        gn.add_path_edge(edge2)
+        edge_route = gn.graph.get_edge_data('1', '2')
+        edge_path = gn.graph.get_edge_data('2', '3')
+        self.assertEqual(edge_route['1']['label'], 'v[2]')
+        self.assertEqual(edge_path['2']['label'], 'v[3]')
+
+    def test_add_explicit_type_multiple_edges_with_edge_property_json_multiple_labels(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        vertex3 = Vertex(id='3')
+
+        edge1 = Edge(id='1', outV=vertex1, inV=vertex2, label='airway')
+        edge2 = Edge(id='2', outV=vertex2, inV=vertex3, label='road')
+
+        gn = GremlinNetwork(edge_display_property='{"airway":"inV","road":"id"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        gn.add_path_edge(edge2)
+        edge_route = gn.graph.get_edge_data('1', '2')
+        edge_path = gn.graph.get_edge_data('2', '3')
+        self.assertEqual(edge_route['1']['label'], 'v[2]')
+        self.assertEqual(edge_path['2']['label'], '2')
+
+    def test_add_single_edge_without_edge_property(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_invalid_edge_property(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_display_property='distance')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_string_label(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_display_property='T.label')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_string_id(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_display_property='T.id')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], '1')
+
+    def test_add_single_edge_with_edge_property_json(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_display_property='{"route":"inV"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'v[2]')
+
+    def test_add_single_edge_with_edge_property_invalid_json(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_display_property='{"route":inV}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_json_invalid_key(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_display_property='{"distance":"inV"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_json_invalid_value(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_display_property='{"route":"foo"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_multiple_edges_with_edge_property_string(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+        edge2 = {T.id: '2', T.label: 'route', 'outV': 'v[2]', 'inV': 'v[3]'}
+
+        gn = GremlinNetwork(edge_display_property='inV')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        gn.add_path_edge(edge2, from_id='2', to_id='3')
+        edge1_data = gn.graph.get_edge_data('1', '2')
+        edge2_data = gn.graph.get_edge_data('2', '3')
+        self.assertEqual(edge1_data['1']['label'], 'v[2]')
+        self.assertEqual(edge2_data['2']['label'], 'v[3]')
+
+    def test_add_multiple_edges_with_edge_property_json_single_label(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+        edge2 = {T.id: '2', T.label: 'route', 'outV': 'v[2]', 'inV': 'v[3]'}
+
+        gn = GremlinNetwork(edge_display_property='{"route":"inV"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        gn.add_path_edge(edge2, from_id='2', to_id='3')
+        edge1_data = gn.graph.get_edge_data('1', '2')
+        edge2_data = gn.graph.get_edge_data('2', '3')
+        self.assertEqual(edge1_data['1']['label'], 'v[2]')
+        self.assertEqual(edge2_data['2']['label'], 'v[3]')
+
+    def test_add_multiple_edges_with_edge_property_json_multiple_labels(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'airway', 'outV': 'v[1]', 'inV': 'v[2]'}
+        edge2 = {T.id: '2', T.label: 'road', 'outV': 'v[2]', 'inV': 'v[3]'}
+
+        gn = GremlinNetwork(edge_display_property='{"airway":"outV","road":"T.id"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        gn.add_path_edge(edge2, from_id='2', to_id='3')
+        edge1_data = gn.graph.get_edge_data('1', '2')
+        edge2_data = gn.graph.get_edge_data('2', '3')
+        self.assertEqual(edge1_data['1']['label'], 'v[1]')
+        self.assertEqual(edge2_data['2']['label'], '2')
+
     def test_add_path_with_integer(self):
         path = Path([], ['ANC', 3030, 'DFW'])
         gn = GremlinNetwork()
@@ -694,6 +1007,24 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('graph_notebook-ed8fddedf251d3d5745dccfd53edf51d')
         self.assertEqual(node['group'], '')
+
+    def test_add_path_with_edge_property_string(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        path = Path([], [vertex1, Edge(id='1', outV=vertex1, inV=vertex2, label='route'), vertex2])
+        gn = GremlinNetwork(edge_display_property='id')
+        gn.add_results([path])
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], '1')
+
+    def test_add_path_with_edge_property_json(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        path = Path([], [vertex1, Edge(id='1', outV=vertex1, inV=vertex2, label='route'), vertex2])
+        gn = GremlinNetwork(edge_display_property='{"route":"id"}')
+        gn.add_results([path])
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], '1')
 
     def test_add_path_without_groupby(self):
         path = Path([], [{'country': ['US'], 'code': ['SEA'], 'longest': [11901], 'city': ['Seattle'],

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -8,7 +8,6 @@ from gremlin_python.structure.graph import Path, Edge, Vertex
 from gremlin_python.process.traversal import T
 from graph_notebook.network.EventfulNetwork import EVENT_ADD_NODE
 from graph_notebook.network.gremlin.GremlinNetwork import GremlinNetwork
-from gremlin_python.structure.graph import Vertex
 
 
 class TestGremlinNetwork(unittest.TestCase):


### PR DESCRIPTION
Issue #, if available: #34, #92

Description of changes:
- Added new `--edge-display-property` / `-de` parameter to the Gremlin cell magic. This allows for specifying what edge property value is displayed over each edge in the graph visualization. Usage is identical to the existing `--group-by` and `--display-property` parameters.

Example usage:

![Screen Shot 2021-06-29 at 11 14 28 PM](https://user-images.githubusercontent.com/10456376/123911080-2b1e5d80-d930-11eb-8a98-53c17ec7c198.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.