### PR TITLE
Add usage of --edge-display-property to sample notebooks

### DIFF
--- a/src/graph_notebook/notebooks/02-Visualization/Visualization-Grouping-Coloring-Gremlin.ipynb
+++ b/src/graph_notebook/notebooks/02-Visualization/Visualization-Grouping-Coloring-Gremlin.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "racial-mouth",
+   "id": "similar-calibration",
    "metadata": {},
    "source": [
     "Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n",
@@ -11,12 +11,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "comfortable-constant",
+   "id": "passive-netherlands",
    "metadata": {},
    "source": [
     "# Visualization - Grouping and Appearance Customization\n",
     "\n",
-    "In this notebook we'll examine how to use the `--group-by` feature of the `%%gremlin` magic to group vertices and how to customize the appearance of these groups.  \n",
+    "In this notebook we'll examine how to use the `--group-by` feature of the `%%gremlin` magic to group vertices and how to customize the appearance of these groups. \n",
+    "\n",
+    "In addition, we will look at how to use the `--display-property`, `--edge-display-property`, and `--label-max-length` options to modify the appearances of node and edge labels.\n",
     "\n",
     "**Note** This notebook builds on the visualization patterns explained in [Air-Routes-Gremlin](Air-Routes-Gremlin.ipynb) notebook, so if you are not familiar with how the visualzation feaure works we recommend reviewing that prior to beginning this notebook.\n",
     "\n",
@@ -26,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "promising-alabama",
+   "id": "documented-chair",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "informational-frederick",
+   "id": "direct-senior",
    "metadata": {},
    "source": [
     "With the air-routes data now loaded we are ready to begin looking at how to group and customize our result visualization.  \n",
@@ -55,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "angry-circumstances",
+   "id": "cleared-medicare",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "round-trial",
+   "id": "electric-transsexual",
    "metadata": {},
    "source": [
     "The results show us only three distinct labels, corresponding to each of the label properties `airport`, `country`, and `continent`.\n",
@@ -78,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lined-burden",
+   "id": "economic-favorite",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "detected-publicity",
+   "id": "advance-source",
    "metadata": {},
    "source": [
     "### Specifying a Single Node Property for all Vertices\n",
@@ -105,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "moved-optimization",
+   "id": "equal-tennis",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "moving-offset",
+   "id": "addressed-small",
    "metadata": {},
    "source": [
     "Looking at the resulting visualized graph, each individual node can now be identified by its distinct code.\n",
@@ -134,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "photographic-river",
+   "id": "manufactured-platform",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lasting-jimmy",
+   "id": "latter-shoot",
    "metadata": {},
    "source": [
     "Now, we can take the previous query and pass `display_var` into the displayed properties parameter via the notebooks line variable injection functionality."
@@ -152,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "surrounded-appendix",
+   "id": "worthy-trinidad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "confidential-payday",
+   "id": "increasing-manhattan",
    "metadata": {},
    "source": [
     "In the resulting visualization, we can see that the `airport` vertices retain the `code` property values, while the `country` and `continent` nodes now display their more descriptive `desc` property values, as we desired.\n",
@@ -179,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "known-virtue",
+   "id": "mediterranean-musical",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "catholic-cocktail",
+   "id": "ideal-danger",
    "metadata": {},
    "source": [
     "We can see that most of the labels are cut off too early to be adequately descriptive!\n",
@@ -200,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "engaging-swaziland",
+   "id": "fourth-walker",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,15 +212,91 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dried-instrumentation",
+   "id": "apparent-twins",
    "metadata": {},
    "source": [
-    "Now, we can see the full name of every airport on the graph."
+    "Now, we can see the full name of every airport on the graph.\n",
+    "\n",
+    "## Edge Property Options\n",
+    "\n",
+    "Some graph visualizations of Gremlin magic queries will contain edges that are also accompanied by a visual label. The property displayed on each edge defaults to the edge's label property. \n",
+    "\n",
+    "We can specify what property values to display on the visualized edges in a similar fashion to how we customized node labels in the previous section. This is done by using the `--edge-display-property` or `-de` parameter, followed by the property name, or a json formatted string containing label-value:property-name pairs. \n",
+    "\n",
+    "### Specifying a single property for all edge labels\n",
+    "\n",
+    "Using a single property name as the parameter value for `--edge-display-property` will result every edge label being changed to property. Again, note that you can find the properties available by using the details view and clicking on any edge in the graph visualization.\n",
+    "\n",
+    "Let's observe the results of appending `-de outV` to a query that retrieves all routes from Austin, USA to Wellington, NZ. Note that we forgo usage of any `by` modulators in the query to ensure that we are retrieving all of the edge properties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adjusted-commander",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%gremlin -p v,oute,inv,oute,inv,oute,inv -de outV\n",
+    "g.V().has('airport','code','AUS').\n",
+    "  repeat(outE().inV().simplePath()).\n",
+    "  until(has('code','WLG')).\n",
+    "  limit(5).\n",
+    "  path()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "incorporate-earth",
+   "id": "civil-cache",
+   "metadata": {},
+   "source": [
+    "We can see that every edge is now indicated by its outgoing vertex via the `outV` property.\n",
+    "\n",
+    "### Specifying edge label properties in JSON format\n",
+    "\n",
+    "Making use of the cell variable injection feature, we can also define a JSON-format string variable containing our desired label-value:property-name pairs, and pass it into `-de`. This follows the format used when injecting JSON variables into `-d` and `-g`:\n",
+    "\n",
+    "`edge_display_var = '{\"label_1\":\"property_1\",\"label_2\":\"property_2\"}'`\n",
+    "\n",
+    "Let's re-define the same label-value:property-name pair used in the last query, this time in the JSON string variable format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "divided-happening",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display_edge_var = '{\"route\":\"inV\"}'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "secondary-soccer",
+   "metadata": {},
+   "source": [
+    "Then, we can pass `$display_edge_var` into `-de`, and observe that we get the same result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "historical-guess",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%gremlin -p v,oute,inv,oute,inv,oute,inv -de $display_edge_var\n",
+    "g.V().has('airport','code','AUS').\n",
+    "  repeat(outE().inV().simplePath()).\n",
+    "  until(has('code','WLG')).\n",
+    "  limit(5).\n",
+    "  path()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sixth-typing",
    "metadata": {},
    "source": [
     "## Grouping Options\n",
@@ -240,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "brief-onion",
+   "id": "emerging-memphis",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "public-subject",
+   "id": "classified-doctrine",
    "metadata": {},
    "source": [
     "From the results we see three groups each represented by a different color.  Each of the vertices is added to a group based on it's label.  \n",
@@ -262,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "static-panama",
+   "id": "proof-timber",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "stainless-austria",
+   "id": "european-edwards",
    "metadata": {},
    "source": [
     "From the resultant visualization we see that we still have three groups of vertices, grouped by the label.  \n",
@@ -284,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "baking-standing",
+   "id": "saving-europe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "celtic-knife",
+   "id": "treated-contents",
    "metadata": {},
    "source": [
     "From the results we see that all our vertices are in a single group now and colored the same.  When our results do not contain the label for the vertex we must then specify the property we want to group by.  \n",
@@ -312,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adjusted-germany",
+   "id": "technological-calgary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +400,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "gentle-frank",
+   "id": "protecting-protein",
    "metadata": {},
    "source": [
     "As we see our results are now split into three groups (MX/US/CA) based on the country property.  \n",
@@ -333,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "boolean-camel",
+   "id": "economic-expert",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "needed-entertainment",
+   "id": "informative-ivory",
    "metadata": {},
    "source": [
     "The resultant graph looks very similar to the previous one except that their is now four groups instead of three.  Unlike in the previous example where we only returned `route` connections, this query returned all connected vertices so our resultset came back with a `continent` and `country` vertex in addition to the `airport` vertices.  Neither the `country` nor `continent` vertices have a `country` property.  When a vertex does not contain the property specified to group by then that vertex is put into a default group.  This same behavior occurs when you use the incorrect casing for the property name, as shown in the query below."
@@ -352,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "desirable-romantic",
+   "id": "vital-capacity",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "certified-great",
+   "id": "certain-feeding",
    "metadata": {},
    "source": [
     "### Grouping on different properties for each label"
@@ -370,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "demographic-testament",
+   "id": "mineral-fusion",
    "metadata": {},
    "source": [
     "While the `continent` and `country` vertices cannot be grouped on properties exclusive to `airport` vertices, we do have the ability to add additional properties with which to form new groups. To do this, we will make use of Jupyter's built-in line magic variable injection to pass in a variable containing a JSON-format string, where we can specify what property we want to use to group each of the individual vertex labels.  "
@@ -378,7 +456,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "major-jordan",
+   "id": "assisted-luxury",
    "metadata": {},
    "source": [
     "The group-by variable must be defined in following format:  \n",
@@ -388,7 +466,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hungarian-bradley",
+   "id": "dress-spring",
    "metadata": {},
    "source": [
     "Let's try defining group-by with individual properties for `airport`, `continent`, and `country`."
@@ -397,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fifty-waterproof",
+   "id": "timely-tyler",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +484,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fiscal-dairy",
+   "id": "developmental-motivation",
    "metadata": {},
    "source": [
     "Then, we can rerun our previous query, this time with `$groups_var`, and see that the `continent` and `country` vertices now belong to their own groups based on the specified properties.  \n",
@@ -417,7 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "marine-edmonton",
+   "id": "valuable-draft",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "existing-advantage",
+   "id": "sexual-protest",
    "metadata": {},
    "source": [
     "### Ignoring Grouping\n",
@@ -438,7 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "warming-accordance",
+   "id": "warming-victorian",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "obvious-cameroon",
+   "id": "happy-japan",
    "metadata": {},
    "source": [
     "Now that we know how to group our vertices together let's take a look at how to customize the appearance of these groups.\n",
@@ -474,7 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "american-spirit",
+   "id": "incident-problem",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "biological-diesel",
+   "id": "saving-construction",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +579,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "written-member",
+   "id": "celtic-creativity",
    "metadata": {},
    "source": [
     "### Specifying Shape\n",
@@ -518,7 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "solved-rhythm",
+   "id": "established-defeat",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +613,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "random-breakfast",
+   "id": "confident-legislature",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,7 +623,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "essential-building",
+   "id": "pending-niagara",
    "metadata": {},
    "source": [
     "### Specifying Icons and Images\n",
@@ -562,7 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "illegal-contrast",
+   "id": "respected-neutral",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "empty-while",
+   "id": "accepted-weekly",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +676,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acquired-finding",
+   "id": "static-scheduling",
    "metadata": {},
    "source": [
     "### Specifying Size\n",
@@ -611,7 +689,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "passive-smith",
+   "id": "italic-address",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +716,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "proud-gossip",
+   "id": "bridal-acrylic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -648,7 +726,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acute-coordinator",
+   "id": "powerful-reconstruction",
    "metadata": {},
    "source": [
     "## Conclusion\n",

--- a/src/graph_notebook/notebooks/02-Visualization/Visualization-Grouping-Coloring-Gremlin.ipynb
+++ b/src/graph_notebook/notebooks/02-Visualization/Visualization-Grouping-Coloring-Gremlin.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "similar-calibration",
+   "id": "particular-telephone",
    "metadata": {},
    "source": [
     "Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\n",
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "passive-netherlands",
+   "id": "driven-reader",
    "metadata": {},
    "source": [
     "# Visualization - Grouping and Appearance Customization\n",
@@ -28,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "documented-chair",
+   "id": "freelance-surveillance",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "direct-senior",
+   "id": "conditional-massage",
    "metadata": {},
    "source": [
     "With the air-routes data now loaded we are ready to begin looking at how to group and customize our result visualization.  \n",
@@ -57,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cleared-medicare",
+   "id": "prompt-statistics",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "electric-transsexual",
+   "id": "detected-balloon",
    "metadata": {},
    "source": [
     "The results show us only three distinct labels, corresponding to each of the label properties `airport`, `country`, and `continent`.\n",
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "economic-favorite",
+   "id": "extensive-thirty",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "advance-source",
+   "id": "civil-evolution",
    "metadata": {},
    "source": [
     "### Specifying a Single Node Property for all Vertices\n",
@@ -107,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "equal-tennis",
+   "id": "small-speaker",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "addressed-small",
+   "id": "surgical-thought",
    "metadata": {},
    "source": [
     "Looking at the resulting visualized graph, each individual node can now be identified by its distinct code.\n",
@@ -136,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "manufactured-platform",
+   "id": "premium-williams",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "latter-shoot",
+   "id": "numerical-calendar",
    "metadata": {},
    "source": [
     "Now, we can take the previous query and pass `display_var` into the displayed properties parameter via the notebooks line variable injection functionality."
@@ -154,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "worthy-trinidad",
+   "id": "strong-shadow",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "increasing-manhattan",
+   "id": "divine-governor",
    "metadata": {},
    "source": [
     "In the resulting visualization, we can see that the `airport` vertices retain the `code` property values, while the `country` and `continent` nodes now display their more descriptive `desc` property values, as we desired.\n",
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "mediterranean-musical",
+   "id": "agricultural-patrol",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ideal-danger",
+   "id": "comparable-lodging",
    "metadata": {},
    "source": [
     "We can see that most of the labels are cut off too early to be adequately descriptive!\n",
@@ -202,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fourth-walker",
+   "id": "closing-slovenia",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "apparent-twins",
+   "id": "consolidated-quebec",
    "metadata": {},
    "source": [
     "Now, we can see the full name of every airport on the graph.\n",
@@ -227,27 +227,29 @@
     "\n",
     "Using a single property name as the parameter value for `--edge-display-property` will result every edge label being changed to property. Again, note that you can find the properties available by using the details view and clicking on any edge in the graph visualization.\n",
     "\n",
-    "Let's observe the results of appending `-de outV` to a query that retrieves all routes from Austin, USA to Wellington, NZ. Note that we forgo usage of any `by` modulators in the query to ensure that we are retrieving all of the edge properties."
+    "Let's observe the results of appending `-de dist` to a query that retrieves all routes from Austin, USA to Wellington, NZ. Note that we use `by(valueMap(true))` in the query to ensure that we are retrieving all of the edge properties."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adjusted-commander",
+   "id": "selected-redhead",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%gremlin -p v,oute,inv,oute,inv,oute,inv -de outV\n",
+    "%%gremlin -p v,oute,inv,oute,inv,oute,inv -de dist\n",
     "g.V().has('airport','code','AUS').\n",
     "  repeat(outE().inV().simplePath()).\n",
     "  until(has('code','WLG')).\n",
     "  limit(5).\n",
-    "  path()"
+    "  path().\n",
+    "    by(valueMap(true)).\n",
+    "    by(valueMap(true))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "civil-cache",
+   "id": "previous-flexibility",
    "metadata": {},
    "source": [
     "We can see that every edge is now indicated by its outgoing vertex via the `outV` property.\n",
@@ -256,7 +258,7 @@
     "\n",
     "Making use of the cell variable injection feature, we can also define a JSON-format string variable containing our desired label-value:property-name pairs, and pass it into `-de`. This follows the format used when injecting JSON variables into `-d` and `-g`:\n",
     "\n",
-    "`edge_display_var = '{\"label_1\":\"property_1\",\"label_2\":\"property_2\"}'`\n",
+    "`display_edge_var = '{\"label_1\":\"property_1\",\"label_2\":\"property_2\"}'`\n",
     "\n",
     "Let's re-define the same label-value:property-name pair used in the last query, this time in the JSON string variable format."
    ]
@@ -264,16 +266,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "divided-happening",
+   "id": "intelligent-shareware",
    "metadata": {},
    "outputs": [],
    "source": [
-    "display_edge_var = '{\"route\":\"inV\"}'"
+    "display_edge_var = '{\"route\":\"dist\"}'"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "secondary-soccer",
+   "id": "varying-myrtle",
    "metadata": {},
    "source": [
     "Then, we can pass `$display_edge_var` into `-de`, and observe that we get the same result."
@@ -282,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "historical-guess",
+   "id": "champion-brighton",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,12 +293,14 @@
     "  repeat(outE().inV().simplePath()).\n",
     "  until(has('code','WLG')).\n",
     "  limit(5).\n",
-    "  path()"
+    "  path().\n",
+    "    by(valueMap(true)).\n",
+    "    by(valueMap(true))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "sixth-typing",
+   "id": "nominated-slide",
    "metadata": {},
    "source": [
     "## Grouping Options\n",
@@ -318,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "emerging-memphis",
+   "id": "quick-germany",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +333,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "classified-doctrine",
+   "id": "separated-resistance",
    "metadata": {},
    "source": [
     "From the results we see three groups each represented by a different color.  Each of the vertices is added to a group based on it's label.  \n",
@@ -340,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "proof-timber",
+   "id": "typical-norman",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +355,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "european-edwards",
+   "id": "undefined-smoke",
    "metadata": {},
    "source": [
     "From the resultant visualization we see that we still have three groups of vertices, grouped by the label.  \n",
@@ -362,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "saving-europe",
+   "id": "gentle-freeware",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +377,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "treated-contents",
+   "id": "eligible-feedback",
    "metadata": {},
    "source": [
     "From the results we see that all our vertices are in a single group now and colored the same.  When our results do not contain the label for the vertex we must then specify the property we want to group by.  \n",
@@ -390,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "technological-calgary",
+   "id": "reserved-creativity",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +404,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "protecting-protein",
+   "id": "municipal-venice",
    "metadata": {},
    "source": [
     "As we see our results are now split into three groups (MX/US/CA) based on the country property.  \n",
@@ -411,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "economic-expert",
+   "id": "functioning-essay",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +425,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "informative-ivory",
+   "id": "numerous-association",
    "metadata": {},
    "source": [
     "The resultant graph looks very similar to the previous one except that their is now four groups instead of three.  Unlike in the previous example where we only returned `route` connections, this query returned all connected vertices so our resultset came back with a `continent` and `country` vertex in addition to the `airport` vertices.  Neither the `country` nor `continent` vertices have a `country` property.  When a vertex does not contain the property specified to group by then that vertex is put into a default group.  This same behavior occurs when you use the incorrect casing for the property name, as shown in the query below."
@@ -430,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vital-capacity",
+   "id": "corresponding-receipt",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +444,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "certain-feeding",
+   "id": "ideal-justice",
    "metadata": {},
    "source": [
     "### Grouping on different properties for each label"
@@ -448,7 +452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mineral-fusion",
+   "id": "labeled-strategy",
    "metadata": {},
    "source": [
     "While the `continent` and `country` vertices cannot be grouped on properties exclusive to `airport` vertices, we do have the ability to add additional properties with which to form new groups. To do this, we will make use of Jupyter's built-in line magic variable injection to pass in a variable containing a JSON-format string, where we can specify what property we want to use to group each of the individual vertex labels.  "
@@ -456,7 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "assisted-luxury",
+   "id": "impressive-pickup",
    "metadata": {},
    "source": [
     "The group-by variable must be defined in following format:  \n",
@@ -466,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dress-spring",
+   "id": "least-cooking",
    "metadata": {},
    "source": [
     "Let's try defining group-by with individual properties for `airport`, `continent`, and `country`."
@@ -475,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "timely-tyler",
+   "id": "green-proof",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,7 +488,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "developmental-motivation",
+   "id": "national-wireless",
    "metadata": {},
    "source": [
     "Then, we can rerun our previous query, this time with `$groups_var`, and see that the `continent` and `country` vertices now belong to their own groups based on the specified properties.  \n",
@@ -495,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "valuable-draft",
+   "id": "entire-glucose",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +509,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sexual-protest",
+   "id": "opening-bullet",
    "metadata": {},
    "source": [
     "### Ignoring Grouping\n",
@@ -516,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "warming-victorian",
+   "id": "chief-virgin",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "happy-japan",
+   "id": "neural-mechanics",
    "metadata": {},
    "source": [
     "Now that we know how to group our vertices together let's take a look at how to customize the appearance of these groups.\n",
@@ -552,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incident-problem",
+   "id": "aggregate-audit",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "saving-construction",
+   "id": "related-relay",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +583,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "celtic-creativity",
+   "id": "intense-geometry",
    "metadata": {},
    "source": [
     "### Specifying Shape\n",
@@ -596,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "established-defeat",
+   "id": "incorporated-evanescence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -613,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "confident-legislature",
+   "id": "timely-investigation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pending-niagara",
+   "id": "medical-warrior",
    "metadata": {},
    "source": [
     "### Specifying Icons and Images\n",
@@ -640,7 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "respected-neutral",
+   "id": "western-layout",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accepted-weekly",
+   "id": "expensive-ivory",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -676,7 +680,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "static-scheduling",
+   "id": "aquatic-newcastle",
    "metadata": {},
    "source": [
     "### Specifying Size\n",
@@ -689,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "italic-address",
+   "id": "suspected-research",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -716,7 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bridal-acrylic",
+   "id": "sticky-neutral",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -726,7 +730,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "powerful-reconstruction",
+   "id": "underlying-anthropology",
    "metadata": {},
    "source": [
     "## Conclusion\n",


### PR DESCRIPTION
Issue #, if available: #34, #92

Description of changes:
- Add example usage of the `-edge-display-property` / `-de` Gremlin magic parameter to the Visualization-Grouping-Coloring-Gremlin sample notebook

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.