### PR TITLE
Fix %status output for Blazegraph

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -471,9 +471,16 @@ class Graph(Magics):
         logger.info(f'calling for status on endpoint {self.graph_notebook_config.host}')
         status_res = self.client.status()
         status_res.raise_for_status()
-        res = status_res.json()
-        logger.info(f'got the response {res}')
-        return res
+        try:
+            res = status_res.json()
+            logger.info(f'got the json format response {res}')
+            return res
+        except ValueError:
+            logger.info(f'got the HTML format response {status_res.text}')
+            print("For more information on the status of your Blazegraph cluster, please visit: ")
+            print()
+            print(f'http://{self.graph_notebook_config.host}:{self.graph_notebook_config.port}/blazegraph/#status')
+            return status_res
 
     @line_magic
     @display_exceptions


### PR DESCRIPTION
Issue #, if available: [StackOverflow question](https://stackoverflow.com/questions/68198550/using-graph-notebook-to-connect-to-blazegraph-database)

Description of changes:
- Fix a bug with %status throwing an error when parsing the Blazegraph status response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.