### PR TITLE
Fix bug with Gremlin node tooltips being displayed incorrectly

### DIFF
--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -81,9 +81,13 @@ def get_id(element):
         return str(element)
 
 
-def strip_and_truncate_label(old_label: str, max_len: int):
-    label = str(old_label).strip("[]'")
-    return label if len(label) <= max_len else label[:max_len - 3] + '...'
+def strip_and_truncate_label_and_title(old_label: str, max_len: int):
+    title = str(old_label).strip("[]'")
+    if len(title) <= max_len:
+        label = title
+    else:
+        label = title[:max_len - 3] + '...'
+    return title, label
 
 
 class GremlinNetwork(EventfulNetwork):
@@ -323,10 +327,12 @@ class GremlinNetwork(EventfulNetwork):
             label = title if len(title) <= self.label_max_length else title[:self.label_max_length - 3] + '...'
 
             if self.display_property in [T_ID, 'id']:
+                title = str(node_id)
                 label = str(node_id)
             elif isinstance(self.display_property, dict):
                 try:
                     if self.display_property[title] in [T_ID, 'id']:
+                        title = str(node_id)
                         label = str(node_id)
                 except KeyError:
                     pass
@@ -341,7 +347,7 @@ class GremlinNetwork(EventfulNetwork):
             # Since it is needed for checking for the vertex label's desired grouping behavior in group_by_property
             if T.label in v.keys():
                 title = str(v[T.label])
-                label = strip_and_truncate_label(title, self.label_max_length)
+                title_plc, label = strip_and_truncate_label_and_title(title, self.label_max_length)
             for k in v:
                 if str(k) == T_ID:
                     node_id = str(v[k])
@@ -357,11 +363,11 @@ class GremlinNetwork(EventfulNetwork):
                 if isinstance(self.display_property, dict):
                     try:
                         if str(k) == self.display_property[title]:
-                            label = strip_and_truncate_label(str(v[k]), self.label_max_length)
+                            title, label = strip_and_truncate_label_and_title(str(v[k]), self.label_max_length)
                     except KeyError:
                         continue
                 elif str(k) == self.display_property:
-                    label = strip_and_truncate_label(str(v[k]), self.label_max_length)
+                    title, label = strip_and_truncate_label_and_title(str(v[k]), self.label_max_length)
 
             # handle when there is no id in a node. In this case, we will generate one which
             # is consistently regenerated so that duplicate dicts will be reduced to the same vertex.

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -52,6 +52,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['label'], 'vertex')
+        self.assertEqual(node['title'], 'vertex')
 
     def test_add_explicit_type_vertex_with_invalid_node_property_label(self):
         vertex = Vertex(id='1')
@@ -60,6 +61,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['label'], 'vertex')
+        self.assertEqual(node['title'], 'vertex')
 
     def test_add_explicit_type_vertex_with_node_property_label(self):
         vertex = Vertex(id='1')
@@ -68,6 +70,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['label'], 'vertex')
+        self.assertEqual(node['title'], 'vertex')
 
     def test_add_explicit_type_vertex_with_node_property_id(self):
         vertex = Vertex(id='1')
@@ -76,6 +79,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['label'], '1')
+        self.assertEqual(node['title'], '1')
 
     def test_add_explicit_type_vertex_with_node_property_json(self):
         vertex1 = Vertex(id='1')
@@ -84,6 +88,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex1)
         node1 = gn.graph.nodes.get('1')
         self.assertEqual(node1['label'], '1')
+        self.assertEqual(node1['title'], '1')
 
     def test_add_explicit_type_vertex_with_node_property_json_invalid_json(self):
         vertex1 = Vertex(id='1')
@@ -92,6 +97,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex1)
         node1 = gn.graph.nodes.get('1')
         self.assertEqual(node1['label'], 'vertex')
+        self.assertEqual(node1['title'], 'vertex')
 
     def test_add_explicit_type_vertex_with_node_property_json_invalid_key(self):
         vertex1 = Vertex(id='1')
@@ -100,6 +106,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex1)
         node1 = gn.graph.nodes.get('1')
         self.assertEqual(node1['label'], 'vertex')
+        self.assertEqual(node1['title'], 'vertex')
 
     def test_add_explicit_type_vertex_with_node_property_json_invalid_value(self):
         vertex1 = Vertex(id='1')
@@ -108,6 +115,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex1)
         node1 = gn.graph.nodes.get('1')
         self.assertEqual(node1['label'], 'vertex')
+        self.assertEqual(node1['title'], 'vertex')
 
     def test_add_explicit_type_multiple_vertex_with_node_property_string(self):
         vertex1 = Vertex(id='1')
@@ -119,7 +127,9 @@ class TestGremlinNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get('1')
         node2 = gn.graph.nodes.get('2')
         self.assertEqual(node1['label'], '1')
+        self.assertEqual(node1['title'], '1')
         self.assertEqual(node2['label'], '2')
+        self.assertEqual(node2['title'], '2')
 
     def test_add_explicit_type_multiple_vertex_with_node_property_json(self):
         vertex1 = Vertex(id='1')
@@ -131,7 +141,9 @@ class TestGremlinNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get('1')
         node2 = gn.graph.nodes.get('2')
         self.assertEqual(node1['label'], '1')
+        self.assertEqual(node1['title'], '1')
         self.assertEqual(node2['label'], '2')
+        self.assertEqual(node2['title'], '2')
 
     def test_add_vertex_without_node_property(self):
         vertex = {
@@ -146,6 +158,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
 
     def test_add_vertex_with_node_property_string(self):
         vertex = {
@@ -160,6 +173,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'SEA')
+        self.assertEqual(node['title'], 'SEA')
 
     def test_add_vertex_with_node_property_string_invalid(self):
         vertex = {
@@ -174,6 +188,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
 
     def test_add_vertex_with_node_property_json(self):
         vertex = {
@@ -188,6 +203,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'SEA')
+        self.assertEqual(node['title'], 'SEA')
 
     def test_add_vertex_with_node_property_json_invalid_json(self):
         vertex = {
@@ -202,6 +218,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
 
     def test_add_vertex_with_node_property_json_invalid_key(self):
         vertex = {
@@ -216,6 +233,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
 
     def test_add_vertex_with_node_property_json_invalid_value(self):
         vertex = {
@@ -230,6 +248,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
 
     def test_add_vertex_multiple_with_node_property_string(self):
         vertex1 = {
@@ -254,7 +273,9 @@ class TestGremlinNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get(vertex1[T.id])
         node2 = gn.graph.nodes.get(vertex2[T.id])
         self.assertEqual(node1['label'], 'SEA')
+        self.assertEqual(node1['title'], 'SEA')
         self.assertEqual(node2['label'], 'USA')
+        self.assertEqual(node2['title'], 'USA')
 
     def test_add_vertex_multiple_with_multiple_node_properties(self):
         vertex1 = {
@@ -279,7 +300,9 @@ class TestGremlinNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get(vertex1[T.id])
         node2 = gn.graph.nodes.get(vertex2[T.id])
         self.assertEqual(node1['label'], 'SEA')
+        self.assertEqual(node1['title'], 'SEA')
         self.assertEqual(node2['label'], 'NA')
+        self.assertEqual(node2['title'], 'NA')
 
     def test_add_vertex_with_label_length(self):
         vertex = {
@@ -294,6 +317,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'Seattle-Taco...')
+        self.assertEqual(node['title'], 'Seattle-Tacoma International Airport')
 
     def test_add_vertex_with_bracketed_label_and_label_length(self):
         vertex = {
@@ -308,6 +332,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'Seattle-Taco...')
+        self.assertEqual(node['title'], 'Seattle-Tacoma International Airport')
 
     def test_add_vertex_with_label_length_less_than_3(self):
         vertex = {
@@ -322,6 +347,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], '...')
+        self.assertEqual(node['title'], 'Seattle-Tacoma International Airport')
 
     def test_add_vertex_with_node_property_string_and_label_length(self):
         vertex = {
@@ -337,6 +363,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'Seattle-Taco...')
+        self.assertEqual(node['title'], 'Seattle-Tacoma International Airport')
 
     def test_add_vertex_with_node_property_json_and_label_length(self):
         vertex = {
@@ -352,6 +379,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'Seattle-Taco...')
+        self.assertEqual(node['title'], 'Seattle-Tacoma International Airport')
 
     def test_add_explicit_type_single_edge_without_edge_property(self):
         vertex1 = Vertex(id='1')


### PR DESCRIPTION
Issue #, if available: None

Description of changes:
- In Gremlin graph visualizations, node tool-tips will now always match the node label when the label is modified using the `-d` parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.