### PR TITLE
Add visualization support for elementMap() Gremlin step 

### DIFF
--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -10,7 +10,7 @@ import logging
 from enum import Enum
 
 from graph_notebook.network.EventfulNetwork import EventfulNetwork
-from gremlin_python.process.traversal import T
+from gremlin_python.process.traversal import T, Direction
 from gremlin_python.structure.graph import Path, Vertex, Edge
 from networkx import MultiDiGraph
 
@@ -242,46 +242,51 @@ class GremlinNetwork(EventfulNetwork):
             raise ValueError("results must be a list of paths")
 
         for path in results:
-            if not isinstance(path, Path):
-                raise ValueError("all entries in results must be paths")
+            if isinstance(path, Path):
+                if type(path[0]) is Edge or type(path[-1]) is Edge:
+                    raise INVALID_PATH_ERROR
 
-            if type(path[0]) is Edge or type(path[-1]) is Edge:
-                raise INVALID_PATH_ERROR
-
-            for i in range(len(path)):
-                if i == 0:
-                    self.add_vertex(path[i])
-                    continue
-
-                if type(path[i]) is Edge:
-                    edge = path[i]
-                    path_left = get_id(path[i - 1])
-                    path_right = get_id(path[i + 1])
-
-                    # If the edge is an object type but its vertices aren't, then the ID contained
-                    # in the edge won't be the same as the ids used to store those two vertices.
-                    # For example, g.V().inE().outV().path().by(valueMap()).by().by(valueMap(true)
-                    # will yield a V, E, V pattern where the first vertex is a dict without T.id, the edge
-                    # will be an Edge object, and the second vertex will be a dict with T.id.
-                    if edge.outV.id == path_left or edge.inV.id == path_right:
-                        from_id = path_left
-                        to_id = path_right
-                        self.add_path_edge(path[i], from_id, to_id)
-                    elif edge.inV.id == path_left or edge.outV.id == path_right:
-                        from_id = path_right
-                        to_id = path_left
-                        self.add_path_edge(path[i], from_id, to_id)
+                for i in range(len(path)):
+                    if isinstance(path[i], dict):
+                        self.insert_elementmap(path[i])
                     else:
-                        from_id = path_left
-                        to_id = path_right
-                        self.add_blank_edge(from_id, to_id, edge.id, label=edge.label)
-                    continue
-                else:
-                    from_id = get_id(path[i - 1])
+                        if i == 0:
+                            self.add_vertex(path[i])
+                            continue
 
-                self.add_vertex(path[i])
-                if type(path[i - 1]) is not Edge:
-                    self.add_blank_edge(from_id, get_id(path[i]))
+                        if type(path[i]) is Edge:
+                            edge = path[i]
+                            path_left = get_id(path[i - 1])
+                            path_right = get_id(path[i + 1])
+
+                            # If the edge is an object type but its vertices aren't, then the ID contained
+                            # in the edge won't be the same as the ids used to store those two vertices.
+                            # For example, g.V().inE().outV().path().by(valueMap()).by().by(valueMap(true)
+                            # will yield a V, E, V pattern where the first vertex is a dict without T.id, the edge
+                            # will be an Edge object, and the second vertex will be a dict with T.id.
+                            if edge.outV.id == path_left or edge.inV.id == path_right:
+                                from_id = path_left
+                                to_id = path_right
+                                self.add_path_edge(path[i], from_id, to_id)
+                            elif edge.inV.id == path_left or edge.outV.id == path_right:
+                                from_id = path_right
+                                to_id = path_left
+                                self.add_path_edge(path[i], from_id, to_id)
+                            else:
+                                from_id = path_left
+                                to_id = path_right
+                                self.add_blank_edge(from_id, to_id, edge.id, label=edge.label)
+                            continue
+                        else:
+                            from_id = get_id(path[i - 1])
+
+                        self.add_vertex(path[i])
+                        if type(path[i - 1]) is not Edge:
+                            self.add_blank_edge(from_id, get_id(path[i]))
+            elif isinstance(path, dict):
+                self.insert_elementmap(path)
+            else:
+                raise ValueError("all entries in results must be paths or maps")
 
     def add_vertex(self, v):
         """
@@ -418,8 +423,10 @@ class GremlinNetwork(EventfulNetwork):
             for k in edge:
                 if str(k) == T_ID:
                     edge_id = str(edge[k])
-
-                properties[k] = edge[k]
+                if type(edge[k]) is dict:  # Handle Direction properties, where the value is a map
+                    properties[k] = get_id(edge[k])
+                else:
+                    properties[k] = edge[k]
                 if self.edge_display_property is not T_LABEL:
                     if isinstance(self.edge_display_property, dict):
                         try:
@@ -449,3 +456,41 @@ class GremlinNetwork(EventfulNetwork):
             edge_id = str(uuid.uuid4())
         edge_data = UNDIRECTED_EDGE if undirected else {}
         self.add_edge(from_id, to_id, edge_id, label, edge_data)
+
+    def insert_elementmap(self, e_map):
+        """
+        Add a vertex or edge that has been returned by an elementMap query step.
+
+        Any elementMap representations of edges must be directed, and contain either of following:
+        1. Direction.IN AND Direction.OUT
+        2. Direction.BOTH
+
+        If the elementMap contains neither of these, then we assume it is a vertex.
+
+        :param e_map: A dictionary containing the elementMap representation of a vertex or an edge
+        """
+        # Handle directed edge elementMap
+        if Direction.IN in e_map.keys() and Direction.OUT in e_map.keys():
+            from_id = get_id(e_map[Direction.OUT])
+            to_id = get_id(e_map[Direction.IN])
+            # Ensure that the default nodes includes with edge elementMaps do not overwrite nodes
+            # with the same ID that have been explicitly inserted.
+            if not self.graph.has_node(from_id):
+                self.add_vertex(e_map[Direction.OUT])
+            if not self.graph.has_node(to_id):
+                self.add_vertex(e_map[Direction.IN])
+            self.add_path_edge(e_map, from_id, to_id)
+        elif Direction.BOTH in e_map.keys():  # TODO: Handle bidirectional edges
+            pass
+            # id_1 = get_id(path[Direction.BOTH][0])
+            # id_2 = get_id(path[Direction.BOTH][1])
+            # if not self.graph.has_node(from_id):
+            #    self.add_vertex(path[Direction.BOTH][0])
+            # if not self.graph.has_node(to_id):
+            #    self.add_vertex(path[Direction.BOTH][1])
+            # self.add_path_edge(path, id_1, id_2)
+            # self.add_path_edge(path, id_2, id_1)
+        # Handle vertex elementMap
+        else:
+            # Overwrite the the default node created by edge elementMap, if it exists already.
+            self.add_vertex(e_map)

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -461,11 +461,8 @@ class GremlinNetwork(EventfulNetwork):
         """
         Add a vertex or edge that has been returned by an elementMap query step.
 
-        Any elementMap representations of edges must be directed, and contain either of following:
-        1. Direction.IN AND Direction.OUT
-        2. Direction.BOTH
-
-        If the elementMap contains neither of these, then we assume it is a vertex.
+        Any elementMap representations of edges must be directed, and contain both of the Direction.IN and Direction.OUT
+        properties. If the elementMap contains neither of these, then we assume it is a vertex.
 
         :param e_map: A dictionary containing the elementMap representation of a vertex or an edge
         """
@@ -480,16 +477,6 @@ class GremlinNetwork(EventfulNetwork):
             if not self.graph.has_node(to_id):
                 self.add_vertex(e_map[Direction.IN])
             self.add_path_edge(e_map, from_id, to_id)
-        elif Direction.BOTH in e_map.keys():  # TODO: Handle bidirectional edges
-            pass
-            # id_1 = get_id(path[Direction.BOTH][0])
-            # id_2 = get_id(path[Direction.BOTH][1])
-            # if not self.graph.has_node(from_id):
-            #    self.add_vertex(path[Direction.BOTH][0])
-            # if not self.graph.has_node(to_id):
-            #    self.add_vertex(path[Direction.BOTH][1])
-            # self.add_path_edge(path, id_1, id_2)
-            # self.add_path_edge(path, id_2, id_1)
         # Handle vertex elementMap
         else:
             # Overwrite the the default node created by edge elementMap, if it exists already.

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import unittest
 from gremlin_python.structure.graph import Path, Edge, Vertex
-from gremlin_python.process.traversal import T
+from gremlin_python.process.traversal import T, Direction
 from graph_notebook.network.EventfulNetwork import EVENT_ADD_NODE
 from graph_notebook.network.gremlin.GremlinNetwork import GremlinNetwork
 
@@ -1213,6 +1213,279 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['group'], '1')
+
+    def test_add_elementmap_edge(self):
+        edge_map = {
+            T.id: '5298',
+            T.label: 'route',
+            Direction.IN: {T.id: '1112', T.label: 'airport'},
+            Direction.OUT: {T.id: '2', T.label: 'airport'},
+            'dist': 763
+        }
+
+        edge_expected = {
+            '5298': {
+                'properties': {
+                    T.id: '5298',
+                    T.label: 'route',
+                    Direction.IN: '1112',
+                    Direction.OUT: '2',
+                    'dist': 763
+                },
+                'label': 'route'
+            }
+        }
+
+        gn = GremlinNetwork()
+        gn.insert_elementmap(edge_map)
+        edge_data = gn.graph.get_edge_data('2', '1112')
+        inv_data = gn.graph.nodes.get('1112')
+        outv_data = gn.graph.nodes.get('2')
+        self.assertEqual(edge_data, edge_expected)
+        self.assertEqual(inv_data['properties'], edge_map[Direction.IN])
+        self.assertEqual(outv_data['properties'], edge_map[Direction.OUT])
+
+    def test_add_elementmap_vertex(self):
+        vertex = {
+            T.id: '2',
+            T.label: 'airport',
+            'code': 'ANC',
+            'type': 'airport',
+            'desc': 'Anchorage Ted Stevens',
+            'country': 'US', 'longest': 12400,
+            'city': 'Anchorage',
+            'lon': -149.996002197266,
+            'elev': 151,
+            'icao': 'PANC',
+            'region': 'US-AK',
+            'runways': 3,
+            'lat': 61.1744003295898
+        }
+
+        gn = GremlinNetwork()
+        gn.insert_elementmap(vertex)
+        vertex_data = gn.graph.nodes.get('2')
+        self.assertEqual(vertex_data['properties'], vertex)
+
+    def test_add_elementmap_edge_with_existing_full_vertices(self):
+        # Test case where a full elementmap vertex has already been inserted into the graph
+        # Afterwards, inserting an elementmap edge connected to the same vertex should not overwrite the old vertex
+        edge_map = {
+            T.id: '5298',
+            T.label: 'route',
+            Direction.IN: {T.id: '1112', T.label: 'airport'},
+            Direction.OUT: {T.id: '2', T.label: 'airport'},
+            'dist': 763
+        }
+
+        out_vertex = {
+            T.id: '2',
+            T.label: 'airport',
+            'code': 'ANC',
+            'type': 'airport',
+            'desc': 'Anchorage Ted Stevens',
+            'country': 'US', 'longest': 12400,
+            'city': 'Anchorage',
+            'lon': -149.996002197266,
+            'elev': 151,
+            'icao': 'PANC',
+            'region': 'US-AK',
+            'runways': 3,
+            'lat': 61.1744003295898
+        }
+
+        in_vertex = {
+            T.id: '1112',
+            T.label: 'airport',
+            'code': 'SNP',
+            'type': 'airport',
+            'desc': 'St Paul Island Airport',
+            'country': 'US',
+            'longest': 6500,
+            'city': 'St Paul Island',
+            'lon': -170.220001220703,
+            'elev': 63,
+            'icao': 'PASN',
+            'region': 'US-AK',
+            'runways': 1,
+            'lat': 57.1673011779785
+        }
+
+        gn = GremlinNetwork()
+        gn.insert_elementmap(in_vertex)
+        gn.insert_elementmap(out_vertex)
+        gn.insert_elementmap(edge_map)
+        outv_data = gn.graph.nodes.get('2')
+        inv_data = gn.graph.nodes.get('1112')
+        self.assertEqual(outv_data['properties'], out_vertex)
+        self.assertEqual(inv_data['properties'], in_vertex)
+
+    def test_add_elementmap_vertex_with_existing_basic_vertices(self):
+        # Test case where an edge elementmap has already inserted a minimal inVertex and outVertex into the graph
+        # Inserting the full vertex afterwards should overwrite the old inVertex or outVertex
+        edge_map = {
+            T.id: '5298',
+            T.label: 'route',
+            Direction.IN: {T.id: '1112', T.label: 'airport'},
+            Direction.OUT: {T.id: '2', T.label: 'airport'},
+            'dist': 763
+        }
+
+        vertex = {
+            T.id: '2',
+            T.label: 'airport',
+            'code': 'ANC',
+            'type': 'airport',
+            'desc': 'Anchorage Ted Stevens',
+            'country': 'US', 'longest': 12400,
+            'city': 'Anchorage',
+            'lon': -149.996002197266,
+            'elev': 151,
+            'icao': 'PANC',
+            'region': 'US-AK',
+            'runways': 3,
+            'lat': 61.1744003295898
+        }
+
+        gn = GremlinNetwork()
+        gn.insert_elementmap(edge_map)
+        outv_data_orig = gn.graph.nodes.get('2')
+        self.assertEqual(outv_data_orig['properties'], edge_map[Direction.OUT])
+
+        gn.insert_elementmap(vertex)
+        outv_data_final = gn.graph.nodes.get('2')
+        self.assertEqual(outv_data_final['properties'], vertex)
+
+    def test_add_results_as_list_of_elementmaps(self):
+        edge_map = {
+            T.id: '5298',
+            T.label: 'route',
+            Direction.IN: {T.id: '1112', T.label: 'airport'},
+            Direction.OUT: {T.id: '2', T.label: 'airport'},
+            'dist': 763
+        }
+
+        out_vertex = {
+            T.id: '2',
+            T.label: 'airport',
+            'code': 'ANC',
+            'type': 'airport',
+            'desc': 'Anchorage Ted Stevens',
+            'country': 'US', 'longest': 12400,
+            'city': 'Anchorage',
+            'lon': -149.996002197266,
+            'elev': 151,
+            'icao': 'PANC',
+            'region': 'US-AK',
+            'runways': 3,
+            'lat': 61.1744003295898
+        }
+
+        in_vertex = {
+            T.id: '1112',
+            T.label: 'airport',
+            'code': 'SNP',
+            'type': 'airport',
+            'desc': 'St Paul Island Airport',
+            'country': 'US',
+            'longest': 6500,
+            'city': 'St Paul Island',
+            'lon': -170.220001220703,
+            'elev': 63,
+            'icao': 'PASN',
+            'region': 'US-AK',
+            'runways': 1,
+            'lat': 57.1673011779785
+        }
+
+        edge_expected = {
+            '5298': {
+                'properties': {
+                    T.id: '5298',
+                    T.label: 'route',
+                    Direction.IN: '1112',
+                    Direction.OUT: '2',
+                    'dist': 763
+                },
+                'label': 'route'
+            }
+        }
+
+        results = [edge_map, out_vertex, in_vertex]
+
+        gn = GremlinNetwork()
+        gn.add_results(results)
+        edge_data = gn.graph.get_edge_data('2', '1112')
+        outv_data = gn.graph.nodes.get('2')
+        inv_data = gn.graph.nodes.get('1112')
+        self.assertEqual(outv_data['properties'], out_vertex)
+        self.assertEqual(inv_data['properties'], in_vertex)
+        self.assertEqual(edge_data, edge_expected)
+
+    def test_add_results_as_path_containing_elementmaps(self):
+        edge_map = {
+            T.id: '5298',
+            T.label: 'route',
+            Direction.IN: {T.id: '1112', T.label: 'airport'},
+            Direction.OUT: {T.id: '2', T.label: 'airport'},
+            'dist': 763
+        }
+
+        out_vertex = {
+            T.id: '2',
+            T.label: 'airport',
+            'code': 'ANC',
+            'type': 'airport',
+            'desc': 'Anchorage Ted Stevens',
+            'country': 'US', 'longest': 12400,
+            'city': 'Anchorage',
+            'lon': -149.996002197266,
+            'elev': 151,
+            'icao': 'PANC',
+            'region': 'US-AK',
+            'runways': 3,
+            'lat': 61.1744003295898
+        }
+
+        in_vertex = {
+            T.id: '1112',
+            T.label: 'airport',
+            'code': 'SNP',
+            'type': 'airport',
+            'desc': 'St Paul Island Airport',
+            'country': 'US',
+            'longest': 6500,
+            'city': 'St Paul Island',
+            'lon': -170.220001220703,
+            'elev': 63,
+            'icao': 'PASN',
+            'region': 'US-AK',
+            'runways': 1,
+            'lat': 57.1673011779785
+        }
+
+        edge_expected = {
+            '5298': {
+                'properties': {
+                    T.id: '5298',
+                    T.label: 'route',
+                    Direction.IN: '1112',
+                    Direction.OUT: '2',
+                    'dist': 763
+                },
+                'label': 'route'
+            }
+        }
+
+        path = Path([], [edge_map, out_vertex, in_vertex])
+        gn = GremlinNetwork()
+        gn.add_results([path])
+        edge_data = gn.graph.get_edge_data('2', '1112')
+        outv_data = gn.graph.nodes.get('2')
+        inv_data = gn.graph.nodes.get('1112')
+        self.assertEqual(outv_data['properties'], out_vertex)
+        self.assertEqual(inv_data['properties'], in_vertex)
+        self.assertEqual(edge_data, edge_expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Issue #, if available: #32

Description of changes:
- Add support for fully visualizing Gremlin queries containing the `elementMap()`step. Edge and vertex property sets returned by `elementMap()` will now be correctly rendered in the graph. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.