### PR TITLE
Fix bug in using Gremlin Explain/Profile with large result sets

### DIFF
--- a/src/graph_notebook/magics/metadata.py
+++ b/src/graph_notebook/magics/metadata.py
@@ -76,9 +76,10 @@ def set_gremlin_profile_metrics(gremlin_metadata: Metadata, profile_str: str) ->
     if querytime_regex:
         gremlin_metadata.set_metric_value('query_time', float(querytime_regex.group(1)))
     if predicates_regex:
-        gremlin_metadata.set_metric_value('predicates', int(predicates_regex.group(1).replace(',', '')))
+        gremlin_metadata.set_metric_value('predicates', int(predicates_regex.group(1).replace(",", '')
+                                                            .replace(".", '')))
     if count_regex:
-        gremlin_metadata.set_metric_value('results', int(count_regex.group(1).replace(',', '')))
+        gremlin_metadata.set_metric_value('results', int(count_regex.group(1).replace(",", '').replace(".", '')))
     if serialization_regex:
         gremlin_metadata.set_metric_value('seri_time', float(serialization_regex.group(1)))
     if results_size_regex:
@@ -145,7 +146,7 @@ def build_gremlin_metadata_from_query(query_type: str, results: any, res: Respon
         gremlin_metadata = create_gremlin_metadata_obj('explain')
         gremlin_metadata.set_request_metrics(res)
         gremlin_metadata.set_metric_value('predicates', int((re.search(r'# of predicates: (.*?)\n', results).group(1))
-                                                            .replace(',', '')))
+                                                            .replace(".", '').replace(",", '')))
         return gremlin_metadata
     elif query_type == 'profile':
         gremlin_metadata = create_gremlin_metadata_obj('profile')

--- a/src/graph_notebook/magics/metadata.py
+++ b/src/graph_notebook/magics/metadata.py
@@ -76,9 +76,9 @@ def set_gremlin_profile_metrics(gremlin_metadata: Metadata, profile_str: str) ->
     if querytime_regex:
         gremlin_metadata.set_metric_value('query_time', float(querytime_regex.group(1)))
     if predicates_regex:
-        gremlin_metadata.set_metric_value('predicates', int(predicates_regex.group(1)))
+        gremlin_metadata.set_metric_value('predicates', int(predicates_regex.group(1).replace(',', '')))
     if count_regex:
-        gremlin_metadata.set_metric_value('results', int(count_regex.group(1)))
+        gremlin_metadata.set_metric_value('results', int(count_regex.group(1).replace(',', '')))
     if serialization_regex:
         gremlin_metadata.set_metric_value('seri_time', float(serialization_regex.group(1)))
     if results_size_regex:
@@ -144,7 +144,8 @@ def build_gremlin_metadata_from_query(query_type: str, results: any, res: Respon
     if query_type == 'explain':
         gremlin_metadata = create_gremlin_metadata_obj('explain')
         gremlin_metadata.set_request_metrics(res)
-        gremlin_metadata.set_metric_value('predicates', int(re.search(r'# of predicates: (.*?)\n', results).group(1)))
+        gremlin_metadata.set_metric_value('predicates', int((re.search(r'# of predicates: (.*?)\n', results).group(1))
+                                                            .replace(',', '')))
         return gremlin_metadata
     elif query_type == 'profile':
         gremlin_metadata = create_gremlin_metadata_obj('profile')

--- a/test/unit/graph_magic/gremlin_profile_large_results_predicates.txt
+++ b/test/unit/graph_magic/gremlin_profile_large_results_predicates.txt
@@ -6,7 +6,7 @@ WARNING: reverse traversal with no edge label(s) - .in() / .both() may impact qu
 
 Results
 =======
-Count: 999,999
+Count: 999.999
 Output: [v[3], v[3600], v[3614], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11], v[12], v[47], v[49], v[136], v[13], v[15], v[16], v[17], v[18], v[389], v[20], v[21], v[22], v[23], v[24], v[25], v[26], v[27], v[28], v[416], v[29], v[30], v[430], v[31], v[9...
 Response serializer: GRYO_V3D0
 Response size (bytes): 23566

--- a/test/unit/graph_magic/gremlin_profile_large_results_predicates.txt
+++ b/test/unit/graph_magic/gremlin_profile_large_results_predicates.txt
@@ -1,0 +1,12 @@
+Predicates
+==========
+# of predicates: 999,999
+
+WARNING: reverse traversal with no edge label(s) - .in() / .both() may impact query performance
+
+Results
+=======
+Count: 999,999
+Output: [v[3], v[3600], v[3614], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11], v[12], v[47], v[49], v[136], v[13], v[15], v[16], v[17], v[18], v[389], v[20], v[21], v[22], v[23], v[24], v[25], v[26], v[27], v[28], v[416], v[29], v[30], v[430], v[31], v[9...
+Response serializer: GRYO_V3D0
+Response size (bytes): 23566

--- a/test/unit/graph_magic/metadata_gremlin_profile.py
+++ b/test/unit/graph_magic/metadata_gremlin_profile.py
@@ -33,3 +33,21 @@ class TestMetadataClassFunctions(unittest.TestCase):
         self.assertEqual(results_num_expected, results_metric.value)
         self.assertEqual(serialization_expected, seri_time_metric.value)
         self.assertEqual(results_size_expected, results_size_metric.value)
+
+    def test_gremlin_profile_metadata_large_results_and_predicates(self):
+        predicates_expected = 999999
+        results_num_expected = 999999
+
+        gremlin_metadata = Metadata()
+        with open('gremlin_profile_large_results_predicates.txt', 'r') as profile_file:
+            profile = profile_file.read()
+        query_time = Metric('query_time', 'Query execution time (ms)')
+        predicates = Metric('predicates', '# of predicates')
+        results_metric = Metric('results', '# of results')
+        seri_time_metric = Metric('seri_time', 'Serialization execution time (ms)')
+        results_size_metric = Metric('results_size', 'Results size (bytes)')
+        gremlin_metadata.bulk_insert_metrics([query_time, predicates, results_metric, seri_time_metric, results_size_metric])
+        gremlin_metadata = set_gremlin_profile_metrics(gremlin_metadata=gremlin_metadata, profile_str=profile)
+
+        self.assertEqual(predicates_expected, predicates.value)
+        self.assertEqual(results_num_expected, results_metric.value)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed bug caused by parsing of Gremlin explain and profile text when generating the metadata results tab

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.