### PR TITLE
Pin RDFLib version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fix improper handling of Blazegraph status response ([Link to PR](https://github.com/aws/graph-notebook/pull/137))
 - Fix Gremlin node tooltips being displayed incorrectly ([Link to PR](https://github.com/aws/graph-notebook/pull/139))
 - Fix bug in using Gremlin explain/profile with large result sets ([Link to PR](https://github.com/aws/graph-notebook/pull/141))
+- Pin RDFLib version ([Link to PR](https://github.com/aws/graph-notebook/pull/151))
 
 ## Release 2.1.4 (June 27, 2021)
 - Support for additional customization of graph node labels in Gremlin ([Link to PR](https://github.com/aws/graph-notebook/pull/127))

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ setup(
         'requests-aws4auth==1.0.1',
         'botocore>=1.19.37',
         'boto3>=1.17.58',
-        'ipython>=7.16.1'
+        'ipython>=7.16.1',
+        'rdflib==5.0.0'
     ],
     package_data={
         'graph_notebook': ['graph_notebook/widgets/nbextensions/static/*.js',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Pin RDFLib to v5.0.0 due to compatibility issues with v6.0.0, which is picked up in Python versions >=3.7.0. This is a sub-dependency of SparqlWrapper, which only requires RDFLib >= 4.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.