### PR TITLE
Pin RDFLib version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You will need:
 * [Python](https://www.python.org/downloads/) 3.6.1-3.6.12
 * [Jupyter Notebook](https://jupyter.org/install) 5.7.10
 * [Tornado](https://pypi.org/project/tornado/) 4.5.3
+* [RDFLib](https://pypi.org/project/rdflib/) 5.0.0
 * A graph database that provides a SPARQL 1.1 Endpoint or a Gremlin Server
 
 ## Installation
@@ -98,6 +99,7 @@ You will need:
 # pin specific versions of Jupyter and Tornado dependency
 pip install notebook==5.7.10
 pip install tornado==4.5.3
+pip install rdflib==5.0.0
 
 # install the package
 pip install graph-notebook

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You will need:
 ## Installation
 
 ```
-# pin specific versions of Jupyter and Tornado dependency
+# pin specific versions of Jupyter, Tornado, and RDFLib dependencies
 pip install notebook==5.7.10
 pip install tornado==4.5.3
 pip install rdflib==5.0.0


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Instruct users to pin the RDFLib version manually during the notebook install process.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.