### PR TITLE
Fix OC node tooltips display

### DIFF
--- a/src/graph_notebook/network/EventfulNetwork.py
+++ b/src/graph_notebook/network/EventfulNetwork.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 import collections
 from networkx import MultiDiGraph
 from .Network import Network
+from typing import Tuple
 
 EVENT_ADD_NODE = 'add_node'
 EVENT_ADD_NODE_DATA = 'add_node_data'
@@ -39,11 +40,15 @@ class EventfulNetwork(Network):
             graph = MultiDiGraph()
         super().__init__(graph)
 
-    def strip_and_truncate_label(self, old_label: str, max_len: int):
-        label = str(old_label).strip("[]'")
-        return label if len(label) <= max_len else label[:max_len - 3] + '...'
+    def strip_and_truncate_label_and_title(self, old_label: str, max_len: int) -> Tuple[str, str]:
+        title = str(old_label).strip("[]'")
+        if len(title) <= max_len:
+            label = title
+        else:
+            label = title[:max_len - 3] + '...'
+        return title, label
 
-    def flatten(self, d:dict, parent_key='', sep='_') -> dict:
+    def flatten(self, d: dict, parent_key='', sep='_') -> dict:
         """Flattens dictionaries including nested dictionaties
 
         Args:

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -81,15 +81,6 @@ def get_id(element):
         return str(element)
 
 
-def strip_and_truncate_label_and_title(old_label: str, max_len: int):
-    title = str(old_label).strip("[]'")
-    if len(title) <= max_len:
-        label = title
-    else:
-        label = title[:max_len - 3] + '...'
-    return title, label
-
-
 class GremlinNetwork(EventfulNetwork):
     """
     GremlinNetwork extends the Network class and uses the add_results method to parse two specific types of responses
@@ -350,7 +341,7 @@ class GremlinNetwork(EventfulNetwork):
             # Since it is needed for checking for the vertex label's desired grouping behavior in group_by_property
             if T.label in v.keys():
                 title = str(v[T.label])
-                title_plc, label = strip_and_truncate_label_and_title(title, self.label_max_length)
+                title_plc, label = self.strip_and_truncate_label_and_title(title, self.label_max_length)
             for k in v:
                 if str(k) == T_ID:
                     node_id = str(v[k])
@@ -366,11 +357,11 @@ class GremlinNetwork(EventfulNetwork):
                 if isinstance(self.display_property, dict):
                     try:
                         if str(k) == self.display_property[title]:
-                            title, label = strip_and_truncate_label_and_title(str(v[k]), self.label_max_length)
+                            title, label = self.strip_and_truncate_label_and_title(str(v[k]), self.label_max_length)
                     except KeyError:
                         continue
                 elif str(k) == self.display_property:
-                    title, label = strip_and_truncate_label_and_title(str(v[k]), self.label_max_length)
+                    title, label = self.strip_and_truncate_label_and_title(str(v[k]), self.label_max_length)
 
             # handle when there is no id in a node. In this case, we will generate one which
             # is consistently regenerated so that duplicate dicts will be reduced to the same vertex.

--- a/src/graph_notebook/network/opencypher/OCNetwork.py
+++ b/src/graph_notebook/network/opencypher/OCNetwork.py
@@ -67,8 +67,7 @@ class OCNetwork(EventfulNetwork):
             title = ""
             for key in node:
                 title += str(node[key])
-            
-        label = title if len(title) <= self.label_max_length else title[:self.label_max_length - 3] + '...'
+
         if not isinstance(self.group_by_property, dict):  # Handle string format group_by
             if self.group_by_property in [LABEL_KEY, 'labels'] and len(node[LABEL_KEY]) > 0:
                 group = node[LABEL_KEY][0]
@@ -103,6 +102,7 @@ class OCNetwork(EventfulNetwork):
                 else:
                     label = str(props)
             except KeyError:
+                label = title
                 pass
         elif self.display_property in [ID_KEY, 'id']:
             label = str(node[ID_KEY])
@@ -112,9 +112,10 @@ class OCNetwork(EventfulNetwork):
             label = str(node[VERTEX_TYPE_KEY])
         elif self.display_property in props:
             label = props[self.display_property]
+        else:
+            label = title
 
-        title = label
-        label = self.strip_and_truncate_label(label, self.label_max_length)
+        title, label = self.strip_and_truncate_label_and_title(label, self.label_max_length)
         data = {'properties': props, 'label': label, 'title': title, 'group': group}
         self.add_node(node[ID_KEY], data)
     

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -39,7 +39,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
                     "~labels": ['airport'],
                     'code': 'SEA',
                     'runways': 3},
-                'title': "['airport']"},
+                'title': "airport"},
             'node_id': '22'}
 
         def add_node_callback(network, event_name, data):
@@ -626,6 +626,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
 
     def test_set_vertex_label_property_string(self):
         res = {
@@ -649,6 +650,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'SEA')
+        self.assertEqual(node1['title'], 'SEA')
 
     def test_set_vertex_label_property_string_id(self):
         res = {
@@ -672,6 +674,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], '22')
+        self.assertEqual(node1['title'], '22')
 
     def test_set_vertex_label_property_string_label(self):
         res = {
@@ -695,6 +698,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
 
     def test_set_vertex_label_property_string_type(self):
         res = {
@@ -718,6 +722,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'node')
+        self.assertEqual(node1['title'], 'node')
 
     def test_set_vertex_label_property_json(self):
         res = {
@@ -741,6 +746,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'SEA')
+        self.assertEqual(node1['title'], 'SEA')
 
     def test_set_vertex_label_property_invalid_json(self):
         res = {
@@ -764,6 +770,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
 
     def test_set_vertex_label_property_invalid_key(self):
         res = {
@@ -787,6 +794,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
 
     def test_set_vertex_label_length(self):
         res = {
@@ -810,6 +818,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'ai...')
+        self.assertEqual(node1['title'], 'airport')
 
     def test_set_vertex_label_property_invalid_value(self):
         res = {
@@ -833,6 +842,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
 
     def test_set_label_property_multiple_vertices_property_string(self):
         res = {
@@ -868,7 +878,9 @@ class TestOpenCypherNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get('11')
         node2 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'JFK')
+        self.assertEqual(node1['title'], 'JFK')
         self.assertEqual(node2['label'], 'SEA')
+        self.assertEqual(node2['title'], 'SEA')
 
     def test_set_label_property_multiple_types(self):
         path = {
@@ -923,7 +935,9 @@ class TestOpenCypherNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get('2')
         node2 = gn.graph.nodes.get('3670')
         self.assertEqual(node1['label'], 'ANC')
+        self.assertEqual(node1['title'], 'ANC')
         self.assertEqual(node2['label'], 'United ...')
+        self.assertEqual(node2['title'], 'United States')
 
     def test_add_edge_without_property(self):
         path = {


### PR DESCRIPTION
Issue #, if available: None

Description of changes:
- Fix an issue with some openCypher visualization node tooltips being displayed incorrectly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.