### PR TITLE
Support Gremlin Profile API parameters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Gremlin visualization bugfixes ([Link to PR](https://github.com/aws/graph-notebook/pull/166))
+- Fixed issue with selecting blank options in `%seed` ([Link to PR](https://github.com/aws/graph-notebook/pull/169))
+- Added support for Gremlin Profile API parameters ([Link to PR](https://github.com/aws/graph-notebook/pull/171))
 
 ## Release 3.0.2 (July 29, 2021)
 

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -187,15 +187,18 @@ class Client(object):
             raise ValueError('query_id must be a non-empty string')
         return self._query_status('gremlin', query_id=query_id, cancelQuery=True)
 
-    def gremlin_explain(self, query: str) -> requests.Response:
-        return self._gremlin_query_plan(query, 'explain')
+    def gremlin_explain(self, query: str, args={}) -> requests.Response:
+        return self._gremlin_query_plan(query=query, plan_type='explain', args=args)
 
-    def gremlin_profile(self, query: str) -> requests.Response:
-        return self._gremlin_query_plan(query, 'profile')
+    def gremlin_profile(self, query: str, args={}) -> requests.Response:
+        return self._gremlin_query_plan(query=query, plan_type='profile', args=args)
 
-    def _gremlin_query_plan(self, query: str, plan_type: str, ) -> requests.Response:
+    def _gremlin_query_plan(self, query: str, plan_type: str, args: dict, ) -> requests.Response:
         url = f'{self._http_protocol}://{self.host}:{self.port}/gremlin/{plan_type}'
         data = {'gremlin': query}
+        if args:
+            for param, value in args.items():
+                data[param] = value
         req = self._prepare_request('POST', url, data=json.dumps(data))
         res = self._http_session.send(req)
         return res


### PR DESCRIPTION
Issue #, if available: #146

Description of changes:
- Add support for use of Neptune's Gremlin Profile API parameters in Gremlin cell magics. 

The new parameters are as follows:

`--no-results`: Removes query results from the profile output. No input value.

`--chop`: Truncates profile output at the specified character length. Accepts an integer value.

`--serializer`: Specifies how to serialize the results. Accepts any string value of valid MIME type or TinkerPop driver "Serializers" enum values. 

`--indexOps`: Adds a more detailed report of index operations to the profile output. No input value.

Please see the official Neptune documentation for more information on these options: 
https://docs.aws.amazon.com/neptune/latest/userguide/gremlin-profile-api.html#gremlin-profile-api-parameters

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.