### PR TITLE
Add short sleep so progress bar can finish #50

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Gremlin visualization bugfixes ([Link to PR](https://github.com/aws/graph-notebook/pull/166))
 - Updated the airport data loadable via %seed to the latest version ([Link to PR](https://github.com/aws/graph-notebook/pull/172))
 - Added support for Gremlin Profile API parameters ([Link to PR](https://github.com/aws/graph-notebook/pull/171))
+- Improved %seed so the progress bar is seen to complete ([Link to PR](https://github.com/aws/graph-notebook/pull/173))
 
 ## Release 3.0.2 (July 29, 2021)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1227,7 +1227,8 @@ class Graph(Magics):
                         return
 
                 progress.value += 1
-
+            # Sleep for two seconds so the user sees the progress bar complete
+            time.sleep(2)
             progress.close()
             with output:
                 print('Done.')


### PR DESCRIPTION
Issue #50 

Description of changes:
Added a 2 second sleep before the progress bar is removed so that the user sees it complete

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.