### PR TITLE
Fixed elementMap identification

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
-- Gremlin visualization bugfixes ([Link to PR](https://github.com/aws/graph-notebook/pull/166))
+- Gremlin visualization bugfixes ([PR #1](https://github.com/aws/graph-notebook/pull/166)) ([PR #2](https://github.com/aws/graph-notebook/pull/174))
 - Updated the airport data loadable via %seed to the latest version ([Link to PR](https://github.com/aws/graph-notebook/pull/172))
 - Added support for Gremlin Profile API parameters ([Link to PR](https://github.com/aws/graph-notebook/pull/171))
 - Improved %seed so the progress bar is seen to complete ([Link to PR](https://github.com/aws/graph-notebook/pull/173))

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -252,7 +252,7 @@ class GremlinNetwork(EventfulNetwork):
                         if T.id in path[i] and T.label in path[i]:
                             for prop, value in path[i].items():
                                 # T.id and/or T.label could be renamed by a project() step
-                                if prop not in [T.id, T.label] and isinstance(value, str):
+                                if isinstance(value, str) and prop not in [T.id, T.label]:
                                     is_elementmap = True
                                     break
                                 elif isinstance(value, dict):
@@ -260,6 +260,9 @@ class GremlinNetwork(EventfulNetwork):
                                         is_elementmap = True
                                         break
                                 elif isinstance(value, list):
+                                    break
+                                elif not isinstance(value, (str, list, dict)):
+                                    is_elementmap = True
                                     break
                         if is_elementmap:
                             self.insert_elementmap(path[i])


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed an issue with redundant nodes and edges being included in visualizations of some Gremlin queries using the `elementMap` step

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.