### PR TITLE
Disable SigV4 signing of non-IAM AWS requests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 
+- Disabled SigV4 signing for non-IAM AWS requests ([Link to PR](https://github.com/aws/graph-notebook/pull/179))
+
 ## Release 3.0.3 (August 11, 2021)
 
 - Gremlin visualization bugfixes ([PR #1](https://github.com/aws/graph-notebook/pull/166)) ([PR #2](https://github.com/aws/graph-notebook/pull/174)) ([PR #3](https://github.com/aws/graph-notebook/pull/175))


### PR DESCRIPTION
Issue #, if available: #167

Description of changes:
- Changed request preparation to disable signing of requests being made to the endpoints of AWS services with IAM disabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.