### PR TITLE
Upgrade Jupyter notebook dependency to 5.7.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,18 +88,19 @@ It is recommended to check the [ChangeLog.md](ChangeLog.md) file periodically to
 You will need:
 
 * [Python](https://www.python.org/downloads/) 3.6.1-3.6.12
-* [Jupyter Notebook](https://jupyter.org/install) 5.7.10
+* [Jupyter Notebook](https://jupyter.org/install) 5.7.13
 * [Tornado](https://pypi.org/project/tornado/) 4.5.3
 * [RDFLib](https://pypi.org/project/rdflib/) 5.0.0
 * A graph database that provides one or more of:
   *  A SPARQL 1.1 endpoint 
   *  An Apache TinkerPop Gremlin Server compatible endpoint
   *  An endpoint compatible with openCypher
+  
 ## Installation
 
 ```
 # pin specific versions of Jupyter, Tornado, and RDFLib dependencies
-pip install notebook==5.7.10
+pip install notebook==5.7.13
 pip install tornado==4.5.3
 pip install rdflib==5.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ SPARQLWrapper==1.8.4
 networkx==2.4
 Jinja2==2.11.3
 jupyter
-notebook==5.7.10
+notebook==5.7.13
 ipywidgets==7.5.1
 jupyter-contrib-nbextensions
 widgetsnbextension


### PR DESCRIPTION
Issue #, if available: https://github.com/advisories/GHSA-hwvq-6gjx-j797

Description of changes:
- Upgraded to `notebook` dependency to v5.7.13 to address a critical vulnerability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.