### PR TITLE
Support use of multi-property values in vertex and edge labels

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 
+- Added support for multi-property values in vertex and edge labels ([Link to PR](https://github.com/aws/graph-notebook/pull/186))
+
 ## Release 3.0.4 (August 25, 2021)
 
 - Disabled SigV4 signing for non-IAM AWS requests ([Link to PR](https://github.com/aws/graph-notebook/pull/179))

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -175,6 +175,21 @@ class TestGremlinNetwork(unittest.TestCase):
         self.assertEqual(node['label'], 'SEA')
         self.assertEqual(node['title'], 'SEA')
 
+    def test_add_vertex_with_node_property_string_apostrophe(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': "S'E'A"
+        }
+
+        gn = GremlinNetwork(display_property='code')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], "S'E'A")
+        self.assertEqual(node['title'], "S'E'A")
+
     def test_add_vertex_with_node_property_string_invalid(self):
         vertex = {
             T.id: '1234',
@@ -204,6 +219,21 @@ class TestGremlinNetwork(unittest.TestCase):
         node = gn.graph.nodes.get(vertex[T.id])
         self.assertEqual(node['label'], 'SEA')
         self.assertEqual(node['title'], 'SEA')
+
+    def test_add_vertex_with_node_property_json_apostrophe(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': "S'E'A"
+        }
+
+        gn = GremlinNetwork(display_property='{"airport":"code"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], "S'E'A")
+        self.assertEqual(node['title'], "S'E'A")
 
     def test_add_vertex_with_node_property_json_invalid_json(self):
         vertex = {
@@ -303,6 +333,185 @@ class TestGremlinNetwork(unittest.TestCase):
         self.assertEqual(node1['title'], 'SEA')
         self.assertEqual(node2['label'], 'NA')
         self.assertEqual(node2['title'], 'NA')
+
+    def test_add_vertex_multiple_with_multiple_node_properties_and_multiproperty_values(self):
+        vertex1 = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA',
+            'regionality': ['domestic', 'international']
+        }
+
+        vertex2 = {
+            T.id: '2345',
+            T.label: 'country',
+            'type': 'Country',
+            'continent': 'NA',
+            'code': 'USA',
+            'alliances': ['NATO', 'UN']
+        }
+
+        gn = GremlinNetwork(display_property='{"airport":"regionality[0]","country":"alliances[1]"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        node1 = gn.graph.nodes.get(vertex1[T.id])
+        node2 = gn.graph.nodes.get(vertex2[T.id])
+        self.assertEqual(node1['label'], 'domestic')
+        self.assertEqual(node1['title'], 'domestic')
+        self.assertEqual(node2['label'], 'UN')
+        self.assertEqual(node2['title'], 'UN')
+
+    def test_add_vertex_with_node_property_string_and_multiproperty_access(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': ['SEA', 'SFO', 'SJC']
+        }
+
+        gn = GremlinNetwork(display_property='code[0]')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], 'SEA')
+        self.assertEqual(node['title'], 'SEA')
+
+    def test_add_vertex_with_node_property_string_and_multiproperty_access_no_property_match(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': ['SEA', 'SFO', 'SJC']
+        }
+
+        gn = GremlinNetwork(display_property='distance[0]')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
+
+    def test_add_vertex_with_node_property_string_and_multiproperty_access_with_non_multiproperty(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(display_property='code[0]')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
+
+    def test_add_vertex_with_node_property_string_and_multiproperty_access_with_bad_index(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': ['SEA', 'SFO', 'SJC']
+        }
+
+        gn = GremlinNetwork(display_property='code[3]')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
+
+    def test_add_vertex_with_node_property_string_and_non_multiproperty_access_on_multiproperty_value(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': ['SEA', 'SFO', 'SJC']
+        }
+
+        gn = GremlinNetwork(display_property='code', label_max_length=50)
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], "['SEA', 'SFO', 'SJC']")
+        self.assertEqual(node['title'], "['SEA', 'SFO', 'SJC']")
+
+    def test_add_vertex_with_node_property_json_and_multiproperty_access(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': ['SEA', 'SFO', 'SJC']
+        }
+
+        gn = GremlinNetwork(display_property='{"airport":"code[2]"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], 'SJC')
+        self.assertEqual(node['title'], 'SJC')
+
+    def test_add_vertex_with_node_property_json_and_multiproperty_display_param_has_no_index(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': ['SEA', 'SFO', 'SJC']
+        }
+
+        gn = GremlinNetwork(display_property='{"airport":"code"}', label_max_length=50)
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], "['SEA', 'SFO', 'SJC']")
+        self.assertEqual(node['title'], "['SEA', 'SFO', 'SJC']")
+
+    def test_add_vertex_with_node_property_json_and_multiproperty_access_with_non_multiproperty(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        gn = GremlinNetwork(display_property='{"airport":"code[2]"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
+
+    def test_add_vertex_with_node_property_json_and_multiproperty_access_no_match(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': ['SEA', 'SFO', 'SJC']
+        }
+
+        gn = GremlinNetwork(display_property='{"airport":"distance[2]"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
+
+    def test_add_vertex_with_node_property_json_and_multiproperty_access_with_bad_index(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': ['SEA', 'SFO', 'SJC']
+        }
+
+        gn = GremlinNetwork(display_property='{"airport":"code[3]"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['label'], 'airport')
+        self.assertEqual(node['title'], 'airport')
 
     def test_add_vertex_with_label_length(self):
         vertex = {
@@ -578,6 +787,19 @@ class TestGremlinNetwork(unittest.TestCase):
         edge = gn.graph.get_edge_data('1', '2')
         self.assertEqual(edge['1']['label'], 'route')
 
+    def test_add_single_edge_with_edge_property_string_label_apostrophe(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: "ro'ut'e", 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_display_property='T.label')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], "ro'ut'e")
+
     def test_add_single_edge_with_edge_property_string_id(self):
         vertex1 = Vertex(id='1')
         vertex2 = Vertex(id='2')
@@ -603,6 +825,19 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_path_edge(edge1, from_id='1', to_id='2')
         edge = gn.graph.get_edge_data('1', '2')
         self.assertEqual(edge['1']['label'], 'v[2]')
+
+    def test_add_single_edge_with_edge_property_json_apostrophe(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'route', 'outV': 'v[1]', 'inV': "v['2']"}
+
+        gn = GremlinNetwork(edge_display_property='{"route":"inV"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], "v['2']")
 
     def test_add_single_edge_with_edge_property_invalid_json(self):
         vertex1 = Vertex(id='1')
@@ -693,6 +928,177 @@ class TestGremlinNetwork(unittest.TestCase):
         edge2_data = gn.graph.get_edge_data('2', '3')
         self.assertEqual(edge1_data['1']['label'], 'v[1]')
         self.assertEqual(edge2_data['2']['label'], '2')
+
+    def test_add_single_edge_with_edge_property_string_and_multiproperty_access(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': ['foo', 'bar']
+        }
+
+        gn = GremlinNetwork(edge_display_property='test_multi[0]')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'foo')
+
+    def test_add_single_edge_with_edge_property_string_and_multiproperty_access_no_property_match(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': ['foo', 'bar']
+        }
+
+        gn = GremlinNetwork(edge_display_property='distance[0]')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_string_and_multiproperty_access_with_non_multiproperty(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': 'foo'
+        }
+
+        gn = GremlinNetwork(edge_display_property='test_multi[0]')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_string_and_multiproperty_access_with_bad_index(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': ['foo', 'bar']
+        }
+
+        gn = GremlinNetwork(edge_display_property='test_multi[2]')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_json_and_multiproperty_access(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': ['foo', 'bar']
+        }
+
+        gn = GremlinNetwork(edge_display_property='{"route":"test_multi[0]"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'foo')
+
+    def test_add_single_edge_with_edge_property_json_and_multiproperty_display_param_has_no_index(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': ['foo', 'bar']
+        }
+
+        gn = GremlinNetwork(edge_display_property='{"route":"test_multi"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], "['foo', 'bar']")
+
+    def test_add_single_edge_with_edge_property_json_and_multiproperty_access_with_non_multiproperty(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': 'foo'
+        }
+
+        gn = GremlinNetwork(edge_display_property='{"route":"test_multi[0]"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_json_and_multiproperty_access_no_match(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': ['foo', 'bar']
+        }
+
+        gn = GremlinNetwork(edge_display_property='{"route":"bad_test[0]"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
+
+    def test_add_single_edge_with_edge_property_json_and_multiproperty_access_with_bad_index(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {
+            T.id: '1',
+            T.label: 'route',
+            'outV': 'v[1]',
+            'inV': 'v[2]',
+            'test_multi': ['foo', 'bar']
+        }
+
+        gn = GremlinNetwork(edge_display_property='{"route":"test_multi[2]"}')
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'route')
 
     def test_add_path_with_integer(self):
         path = Path([], ['ANC', 3030, 'DFW'])

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -707,6 +707,30 @@ class TestOpenCypherNetwork(unittest.TestCase):
         self.assertEqual(node1['label'], 'SEA')
         self.assertEqual(node1['title'], 'SEA')
 
+    def test_set_vertex_label_property_string_apostrophe_value(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "S'E'A"
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='code')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], "S'E'A")
+        self.assertEqual(node1['title'], "S'E'A")
+
     def test_set_vertex_label_property_string_id(self):
         res = {
             "results": [
@@ -802,6 +826,30 @@ class TestOpenCypherNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['label'], 'SEA')
         self.assertEqual(node1['title'], 'SEA')
+
+    def test_set_vertex_label_property_json_apostrophe_value(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "S'E'A"
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='{"airport":"code"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], "S'E'A")
+        self.assertEqual(node1['title'], "S'E'A")
 
     def test_set_vertex_label_property_invalid_json(self):
         res = {
@@ -994,6 +1042,305 @@ class TestOpenCypherNetwork(unittest.TestCase):
         self.assertEqual(node2['label'], 'United ...')
         self.assertEqual(node2['title'], 'United States')
 
+    def test_set_vertex_label_property_string_and_multiproperty_access(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": ["SEA", "SJC"]
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='code[1]')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], 'SJC')
+        self.assertEqual(node1['title'], 'SJC')
+
+    def test_set_vertex_label_property_string_and_multiproperty_access_no_property_match(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": ["SEA", "SJC"]
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='distance[1]')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
+
+    def test_set_vertex_label_property_string_and_multiproperty_access_non_multiproperty(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='code[1]')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
+
+    def test_set_vertex_label_property_string_and_multiproperty_access_with_bad_index(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": ["SEA", "SJC"]
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='code[2]')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
+
+    def test_set_vertex_label_property_string_and_non_multiproperty_access_on_multiproperty_value(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": ["SEA", "SJC"]
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='code', label_max_length=50)
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], "['SEA', 'SJC']")
+        self.assertEqual(node1['title'], "['SEA', 'SJC']")
+
+    def test_set_vertex_label_property_json_and_multiproperty_access(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": ["SEA", "SJC"]
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='{"airport":"code[1]"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], 'SJC')
+        self.assertEqual(node1['title'], 'SJC')
+
+    def test_set_vertex_label_property_json_and_non_multiproperty_access_on_multiproperty_value(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": ["SEA", "SJC"]
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='{"airport":"code"}', label_max_length=50)
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], "['SEA', 'SJC']")
+        self.assertEqual(node1['title'], "['SEA', 'SJC']")
+
+    def test_set_vertex_label_property_json_and_multiproperty_access_on_non_multiproperty(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='{"airport":"code[1]"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
+
+    def test_set_vertex_label_property_json_and_multiproperty_access_no_match(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": ["SEA", "SJC"]
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='{"airport":"distance[1]"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
+
+    def test_set_vertex_label_property_json_and_multiproperty_access_with_bad_index(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": ["SEA", "SJC"]
+                        }
+                    }
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='{"airport":"code[2]"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['label'], 'airport')
+        self.assertEqual(node1['title'], 'airport')
+
+    def test_set_multiple_vertex_label_multiproperty(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "2",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Anchorage Ted Stevens",
+                                "lon": -149.996002197266,
+                                "runways": 3,
+                                "type": "airport",
+                                "country": "US",
+                                "region": "US-AK",
+                                "lat": 61.1744003295898,
+                                "elev": 151,
+                                "city": "Anchorage",
+                                "icao": "PANC",
+                                "code": "ANC",
+                                "longest": 12400,
+                                'regionality': ['domestic', 'international']
+                            }
+                        },
+                        {
+                            "~id": "53617",
+                            "~entityType": "relationship",
+                            "~start": "3670",
+                            "~end": "2",
+                            "~type": "contains"
+                        },
+                        {
+                            "~id": "3670",
+                            "~entityType": "node",
+                            "~labels": [
+                                "country"
+                            ],
+                            "~properties": {
+                                "desc": "United States",
+                                "code": "US",
+                                "alliances": ['NATO', 'UN']
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        gn = OCNetwork(display_property='{"airport":"regionality[0]","country":"alliances[0]"}')
+        gn.add_results(path)
+        node1 = gn.graph.nodes.get('2')
+        node2 = gn.graph.nodes.get('3670')
+        self.assertEqual(node1['label'], 'domestic')
+        self.assertEqual(node1['title'], 'domestic')
+        self.assertEqual(node2['label'], 'NATO')
+        self.assertEqual(node2['title'], 'NATO')
+
     def test_add_edge_without_property(self):
         path = {
             "results": [
@@ -1128,6 +1475,265 @@ class TestOpenCypherNetwork(unittest.TestCase):
         edge_route = gn.graph.get_edge_data('365', '136', '30601')
         self.assertEqual(edge_route['label'], '792')
 
+    def test_add_edge_with_property_string_apostrophe_value(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Cozumel International Airport",
+                                "lon": -86.9255981445312,
+                                "runways": 2,
+                                "type": "airport",
+                                "country": "MX",
+                                "region": "MX-ROO",
+                                "lat": 20.5223999023438,
+                                "elev": 15,
+                                "city": "Cozumel",
+                                "icao": "MMCZ",
+                                "code": "CZM",
+                                "longest": 10165
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": "7'9'2"
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Mexico City, Licenciado Benito Juarez International Airport",
+                                "lon": -99.0720977783203,
+                                "runways": 2,
+                                "type": "airport",
+                                "country": "MX",
+                                "region": "MX-DIF",
+                                "lat": 19.43630027771,
+                                "elev": 7316,
+                                "city": "Mexico City",
+                                "icao": "MMMX",
+                                "code": "MEX",
+                                "longest": 12966
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='dist')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], "7'9'2")
+
+    def test_add_edge_with_property_string_and_multiproperty_access(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='endpoints[0]')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], '365')
+
+    def test_add_edge_with_property_string_and_multiproperty_access_no_property_match(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='callsigns[0]')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], 'route')
+
+    def test_add_edge_with_property_string_and_multiproperty_access_with_non_multiproperty(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='dist[0]')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], 'route')
+
+    def test_add_edge_with_property_string_and_multiproperty_access_with_bad_index(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='endpoints[2]')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], 'route')
+
     def test_add_edge_with_property_string_invalid(self):
         path = {
             "results": [
@@ -1261,6 +1867,73 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(path)
         edge_route = gn.graph.get_edge_data('365', '136', '30601')
         self.assertEqual(edge_route['label'], '792')
+
+    def test_add_edge_with_property_json_apostrophe_value(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Cozumel International Airport",
+                                "lon": -86.9255981445312,
+                                "runways": 2,
+                                "type": "airport",
+                                "country": "MX",
+                                "region": "MX-ROO",
+                                "lat": 20.5223999023438,
+                                "elev": 15,
+                                "city": "Cozumel",
+                                "icao": "MMCZ",
+                                "code": "CZM",
+                                "longest": 10165
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": "7'9'2"
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Mexico City, Licenciado Benito Juarez International Airport",
+                                "lon": -99.0720977783203,
+                                "runways": 2,
+                                "type": "airport",
+                                "country": "MX",
+                                "region": "MX-DIF",
+                                "lat": 19.43630027771,
+                                "elev": 7316,
+                                "city": "Mexico City",
+                                "icao": "MMMX",
+                                "code": "MEX",
+                                "longest": 12966
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='{"route":"dist"}')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], "7'9'2")
 
     def test_add_edge_with_property_invalid_json(self):
         path = {
@@ -1459,6 +2132,246 @@ class TestOpenCypherNetwork(unittest.TestCase):
         }
 
         gn = OCNetwork(edge_display_property='{"route":"trips"}')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], 'route')
+
+    def test_add_edge_with_property_json_and_multiproperty_access(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='{"route":"endpoints[0]"}')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], '365')
+
+    def test_add_edge_with_property_json_and_multiproperty_access_display_param_has_no_index(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='{"route":"endpoints"}')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], "['365', '136']")
+
+    def test_add_edge_with_property_json_and_multiproperty_access_with_non_multiproperty(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='{"route":"dist[0]"}')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], 'route')
+
+    def test_add_edge_with_property_json_and_multiproperty_access_no_matching_property(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='{"route":"callsigns[0]"}')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], 'route')
+
+    def test_add_edge_with_property_json_and_multiproperty_access_with_bad_index(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='{"route":"endpoints[2]"}')
         gn.add_results(path)
         edge_route = gn.graph.get_edge_data('365', '136', '30601')
         self.assertEqual(edge_route['label'], 'route')
@@ -1712,6 +2625,133 @@ class TestOpenCypherNetwork(unittest.TestCase):
         edge_path = gn.graph.get_edge_data('365', '367', '30604')
         self.assertEqual(edge_route['label'], '792')
         self.assertEqual(edge_path['label'], '30604')
+
+    def test_add_multiple_edge_with_property_json_and_multiproperties(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Cozumel International Airport",
+                                "lon": -86.9255981445312,
+                                "runways": 2,
+                                "type": "airport",
+                                "country": "MX",
+                                "region": "MX-ROO",
+                                "lat": 20.5223999023438,
+                                "elev": 15,
+                                "city": "Cozumel",
+                                "icao": "MMCZ",
+                                "code": "CZM",
+                                "longest": 10165
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "foobar": ['foo', 'bar']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Mexico City, Licenciado Benito Juarez International Airport",
+                                "lon": -99.0720977783203,
+                                "runways": 2,
+                                "type": "airport",
+                                "country": "MX",
+                                "region": "MX-DIF",
+                                "lat": 19.43630027771,
+                                "elev": 7316,
+                                "city": "Mexico City",
+                                "icao": "MMMX",
+                                "code": "MEX",
+                                "longest": 12966
+                            }
+                        }
+                    ]
+                },
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Cozumel International Airport",
+                                "lon": -86.9255981445312,
+                                "runways": 2,
+                                "type": "airport",
+                                "country": "MX",
+                                "region": "MX-ROO",
+                                "lat": 20.5223999023438,
+                                "elev": 15,
+                                "city": "Cozumel",
+                                "icao": "MMCZ",
+                                "code": "CZM",
+                                "longest": 10165
+                            }
+                        },
+                        {
+                            "~id": "30604",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "367",
+                            "~type": "path",
+                            "~properties": {
+                                "dist": 911,
+                                "barfoo": ["bar", "foo"]
+                            },
+                        },
+                        {
+                            "~id": "367",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "General Mariano Escobedo International Airport",
+                                "lon": -100.107002258,
+                                "runways": 1,
+                                "type": "airport",
+                                "country": "MX",
+                                "region": "MX-NLE",
+                                "lat": 25.7784996033,
+                                "elev": 1278,
+                                "city": "Monterrey",
+                                "icao": "MMMY",
+                                "code": "MTY",
+                                "longest": 5909
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(edge_display_property='{"route":"foobar[0]","path":"barfoo[0]"}')
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        edge_path = gn.graph.get_edge_data('365', '367', '30604')
+        self.assertEqual(edge_route['label'], 'foo')
+        self.assertEqual(edge_path['label'], 'bar')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added support for specifying what sub-values to use from a multi-property as node/vertex labels in Gremlin and openCypher visualizations. Users can specify the multi-property name along with the index of the desired value.

Examples of usage:
```
my_node_labels = '{"airport":"city[0]"}'

%%gremlin -d $my_node_labels
...
```

```
%%gremlin -d city[0]
...
```





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.