### PR TITLE
Add new visualization physics options, and toggle button to enable/disable physics

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 
 - Added support for multi-property values in vertex and edge labels ([Link to PR](https://github.com/aws/graph-notebook/pull/186))
+- Added new visualization physics options, toggle button ([Link to PR](https://github.com/aws/graph-notebook/pull/190))
 
 ## Release 3.0.5 (August 27, 2021)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -225,6 +225,10 @@ class Graph(Magics):
         parser.add_argument('--explain-format', default='text/html', help='response format for explain query mode',
                             choices=['text/csv', 'text/html'])
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
+        parser.add_argument('-sp', '--stop-physics', action='store_true', default=False,
+                            help="Disable visualization physics after the initial simulation stabilizes.")
+        parser.add_argument('-sd', '--simulation-duration', type=int, default=1500,
+                            help='Specifies maximum duration of visualization physics simulation. Default is 1500ms')
         args = parser.parse_args(line.split())
         mode = str_to_query_mode(args.query_mode)
         tab = widgets.Tab()
@@ -280,6 +284,9 @@ class Graph(Magics):
 
                 logger.debug(f'number of nodes is {len(sn.graph.nodes)}')
                 if len(sn.graph.nodes) > 0:
+                    self.graph_notebook_vis_options['physics']['disablePhysicsAfterInitialSimulation'] \
+                        = args.stop_physics
+                    self.graph_notebook_vis_options['physics']['simulationDuration'] = args.simulation_duration
                     f = Force(network=sn, options=self.graph_notebook_vis_options)
                     titles.append('Graph')
                     children.append(f)
@@ -394,6 +401,11 @@ class Graph(Magics):
                                  'TinkerPop driver "Serializers" enum values. Default is application/json')
         parser.add_argument('--indexOps', action='store_true', default=False,
                             help='Show a detailed report of all index operations.')
+        parser.add_argument('-sp', '--stop-physics', action='store_true', default=False,
+                            help="Disable visualization physics after the initial simulation stabilizes.")
+        parser.add_argument('-sd', '--simulation-duration', type=int, default=1500,
+                            help='Specifies maximum duration of visualization physics simulation. Default is 1500ms')
+
         args = parser.parse_args(line.split())
         mode = str_to_query_mode(args.query_mode)
         logger.debug(f'Arguments {args}')
@@ -461,6 +473,9 @@ class Graph(Magics):
                     gn.add_results_with_pattern(query_res, pattern)
                 logger.debug(f'number of nodes is {len(gn.graph.nodes)}')
                 if len(gn.graph.nodes) > 0:
+                    self.graph_notebook_vis_options['physics']['disablePhysicsAfterInitialSimulation'] \
+                        = args.stop_physics
+                    self.graph_notebook_vis_options['physics']['simulationDuration'] = args.simulation_duration
                     f = Force(network=gn, options=self.graph_notebook_vis_options)
                     titles.append('Graph')
                     children.append(f)
@@ -1362,6 +1377,10 @@ class Graph(Magics):
                             help='Specifies max length of vertex label, in characters. Default is 10')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
         parser.add_argument('--ignore-groups', action='store_true', default=False, help="Ignore all grouping options")
+        parser.add_argument('-sp', '--stop-physics', action='store_true', default=False,
+                            help="Disable visualization physics after the initial simulation stabilizes.")
+        parser.add_argument('-sd', '--simulation-duration', type=int, default=1500,
+                            help='Specifies maximum duration of visualization physics simulation. Default is 1500ms')
         args = parser.parse_args(line.split())
         tab = widgets.Tab()
         logger.debug(args)
@@ -1384,6 +1403,9 @@ class Graph(Magics):
                 gn.add_results(res)
                 logger.debug(f'number of nodes is {len(gn.graph.nodes)}')
                 if len(gn.graph.nodes) > 0:
+                    self.graph_notebook_vis_options['physics']['disablePhysicsAfterInitialSimulation'] \
+                        = args.stop_physics
+                    self.graph_notebook_vis_options['physics']['simulationDuration'] = args.simulation_duration
                     force_graph_output = Force(network=gn, options=self.graph_notebook_vis_options)
             except ValueError as value_error:
                 logger.debug(f'unable to create network from result. Skipping from result set: {value_error}')

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1317,7 +1317,6 @@ class Graph(Magics):
     def graph_notebook_version(self, line):
         print(graph_notebook.__version__)
 
-    # TODO: find out where we call this, then add local_ns param and variable decorator
     @line_cell_magic
     @display_exceptions
     def graph_notebook_vis_options(self, line='', cell=''):

--- a/src/graph_notebook/options/options.py
+++ b/src/graph_notebook/options/options.py
@@ -3,6 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
+# Documentation for these options: https://visjs.github.io/vis-network/docs/network
 OPTIONS_DEFAULT_DIRECTED = {
     "nodes": {
         "borderWidthSelected": 0,
@@ -53,6 +54,8 @@ OPTIONS_DEFAULT_DIRECTED = {
         "selectConnectedEdges": False
     },
     "physics": {
+        "simulationDuration": 1500,
+        "disablePhysicsAfterInitialSimulation": False,
         "minVelocity": 0.75,
         "barnesHut": {
             "centralGravity": 0.1,

--- a/test/unit/options/test_options.py
+++ b/test/unit/options/test_options.py
@@ -108,6 +108,8 @@ class TestOptions(unittest.TestCase):
                 'original': OPTIONS_DEFAULT_DIRECTED,
                 'target': {
                     "physics": {
+                        "simulationDuration": 1500,
+                        "disablePhysicsAfterInitialSimulation": False,
                         "hierarchicalRepulsion": {
                             "centralGravity": 0
                         },
@@ -173,6 +175,8 @@ class TestOptions(unittest.TestCase):
                         "selectConnectedEdges": False
                     },
                     "physics": {
+                        "simulationDuration": 1500,
+                        "disablePhysicsAfterInitialSimulation": False,
                         "minVelocity": 0.75,
                         "barnesHut": {
                             "centralGravity": 0.1,
@@ -267,6 +271,8 @@ class TestOptions(unittest.TestCase):
                         "selectConnectedEdges": False
                     },
                     "physics": {
+                        "simulationDuration": 1500,
+                        "disablePhysicsAfterInitialSimulation": False,
                         "minVelocity": 0.75,
                         "barnesHut": {
                             "centralGravity": 0.1,


### PR DESCRIPTION
Issue #, if available: #74

Description of changes:
- Added `simulationDuration` option: allows setting maximum duration of the simulation, this was previously hardcoded to 1500ms;  can also be set using the `-sd`/`--simulation-duration` option with query magics
- Added `disablePhysicsAfterInitialSimulation` option: disables physics after the first simulation has stabilized; can also be set by specifying`-sp`/`--stop-physics`
- Added new lock/unlock button to graph tab to toggle physics state

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.