### PR TITLE
Add node size and edge width scaling based on property values

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -39,7 +39,8 @@ from graph_notebook.visualization.template_retriever import retrieve_template
 from graph_notebook.configuration.get_config import get_config, get_config_from_dict
 from graph_notebook.seed.load_query import get_data_sets, get_queries, normalize_model_name
 from graph_notebook.widgets import Force
-from graph_notebook.options import OPTIONS_DEFAULT_DIRECTED, vis_options_merge
+from graph_notebook.options import OPTIONS_DEFAULT_DIRECTED, OPTIONS_DEFAULT_SCALING_NODES, \
+    OPTIONS_DEFAULT_SCALING_EDGES_ONLY, vis_options_merge
 from graph_notebook.magics.metadata import build_sparql_metadata_from_query, build_gremlin_metadata_from_query, \
     build_opencypher_metadata_from_query
 
@@ -224,6 +225,10 @@ class Graph(Magics):
                             choices=['dynamic', 'static', 'details'])
         parser.add_argument('--explain-format', default='text/html', help='response format for explain query mode',
                             choices=['text/csv', 'text/html'])
+        parser.add_argument('-sn', '--node-scaling-property', type=str, default=None,
+                            help='Optional property to specify what node property to use for node size scaling.')
+        parser.add_argument('-se', '--edge-scaling-property', type=str, default=None,
+                            help='Optional property to specify what edge property to use for edge width scaling.')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
         args = parser.parse_args(line.split())
         mode = str_to_query_mode(args.query_mode)
@@ -271,7 +276,9 @@ class Graph(Magics):
                 sparql_metadata = build_sparql_metadata_from_query(query_type='query', res=query_res, results=results,
                                                                    scd_query=True)
 
-                sn = SPARQLNetwork(expand_all=args.expand_all)
+                sn = SPARQLNetwork(expand_all=args.expand_all,
+                                   node_scaling_property=args.node_scaling_property,
+                                   edge_scaling_property=args.edge_scaling_property)
                 sn.extract_prefix_declarations_from_query(cell)
                 try:
                     sn.add_results(results)
@@ -280,6 +287,12 @@ class Graph(Magics):
 
                 logger.debug(f'number of nodes is {len(sn.graph.nodes)}')
                 if len(sn.graph.nodes) > 0:
+                    if args.node_scaling_property:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_SCALING_NODES
+                    elif args.edge_scaling_property:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_SCALING_EDGES_ONLY
+                    else:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_DIRECTED
                     f = Force(network=sn, options=self.graph_notebook_vis_options)
                     titles.append('Graph')
                     children.append(f)
@@ -380,6 +393,10 @@ class Graph(Magics):
                             help='Property to display the value of on each node, default is T.label')
         parser.add_argument('-de', '--edge-display-property', type=str, default='T.label',
                             help='Property to display the value of on each edge, default is T.label')
+        parser.add_argument('-sn', '--node-scaling-property', type=str, default=None,
+                            help='Optional property to specify what node property to use for node size scaling.')
+        parser.add_argument('-se', '--edge-scaling-property', type=str, default=None,
+                            help='Optional property to specify what edge property to use for edge width scaling.')
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
                             help='Specifies max length of vertex label, in characters. Default is 10')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
@@ -452,6 +469,8 @@ class Graph(Magics):
                 logger.debug(f'ignore_groups: {args.ignore_groups}')
                 gn = GremlinNetwork(group_by_property=args.group_by, display_property=args.display_property,
                                     edge_display_property=args.edge_display_property,
+                                    node_scaling_property=args.node_scaling_property,
+                                    edge_scaling_property=args.edge_scaling_property,
                                     label_max_length=args.label_max_length, ignore_groups=args.ignore_groups)
 
                 if args.path_pattern == '':
@@ -461,6 +480,12 @@ class Graph(Magics):
                     gn.add_results_with_pattern(query_res, pattern)
                 logger.debug(f'number of nodes is {len(gn.graph.nodes)}')
                 if len(gn.graph.nodes) > 0:
+                    if args.node_scaling_property:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_SCALING_NODES
+                    elif args.edge_scaling_property:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_SCALING_EDGES_ONLY
+                    else:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_DIRECTED
                     f = Force(network=gn, options=self.graph_notebook_vis_options)
                     titles.append('Graph')
                     children.append(f)
@@ -1359,6 +1384,10 @@ class Graph(Magics):
                             help='Property to display the value of on each node, default is ~labels')
         parser.add_argument('-de', '--edge-display-property', type=str, default='~labels',
                             help='Property to display the value of on each edge, default is ~type')
+        parser.add_argument('-sn', '--node-scaling-property', type=str, default=None,
+                            help='Optional property to specify what node property to use for node size scaling.')
+        parser.add_argument('-se', '--edge-scaling-property', type=str, default=None,
+                            help='Optional property to specify what edge property to use for edge width scaling.')
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
                             help='Specifies max length of vertex label, in characters. Default is 10')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
@@ -1368,7 +1397,7 @@ class Graph(Magics):
         logger.debug(args)
         titles = []
         children = []
-        force_graph_output=None
+        force_graph_output = None
         res = None
         if args.mode == 'query':
             query_start = time.time() * 1000  # time.time() returns time in seconds w/high precision; x1000 to get in ms
@@ -1380,11 +1409,19 @@ class Graph(Magics):
                                                                query_time=query_time)            
             try:
                 gn = OCNetwork(group_by_property=args.group_by, display_property=args.display_property,
-                               edge_display_property=args.edge_display_property,
-                               label_max_length=args.label_max_length, ignore_groups=args.ignore_groups)
+                               edge_display_property=args.edge_display_property, label_max_length=args.label_max_length,
+                               node_scaling_property=args.node_scaling_property,
+                               edge_scaling_property=args.edge_scaling_property,
+                               ignore_groups=args.ignore_groups)
                 gn.add_results(res)
                 logger.debug(f'number of nodes is {len(gn.graph.nodes)}')
                 if len(gn.graph.nodes) > 0:
+                    if args.node_scaling_property:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_SCALING_NODES
+                    elif args.edge_scaling_property:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_SCALING_EDGES_ONLY
+                    else:
+                        self.graph_notebook_vis_options = OPTIONS_DEFAULT_DIRECTED
                     force_graph_output = Force(network=gn, options=self.graph_notebook_vis_options)
             except ValueError as value_error:
                 logger.debug(f'unable to create network from result. Skipping from result set: {value_error}')

--- a/src/graph_notebook/network/EventfulNetwork.py
+++ b/src/graph_notebook/network/EventfulNetwork.py
@@ -130,17 +130,18 @@ class EventfulNetwork(Network):
         }
         self.dispatch_callbacks(EVENT_ADD_NODE_PROPERTY, data)
 
-    def add_node(self, node_id: str, data: dict = None):
+    def add_node(self, node_id: str, value: float = None, data: dict = None):
         if data is None:
             data = {}
         super().add_node(node_id, data)
         payload = {
             'node_id': node_id,
+            'value': value,
             'data': data
         }
         self.dispatch_callbacks(EVENT_ADD_NODE, payload)
 
-    def add_edge(self, from_id: str, to_id: str, edge_id: str, label: str, data: dict = None):
+    def add_edge(self, from_id: str, to_id: str, edge_id: str, label: str, value: float = None, data: dict = None):
         if data is None:
             data = {}
         super().add_edge(from_id, to_id, edge_id, label, data)
@@ -149,6 +150,7 @@ class EventfulNetwork(Network):
             'to_id': to_id,
             'edge_id': edge_id,
             'label': label,
+            'value': value,
             'data': data
         }
         self.dispatch_callbacks(EVENT_ADD_EDGE, payload)

--- a/src/graph_notebook/options/__init__.py
+++ b/src/graph_notebook/options/__init__.py
@@ -3,4 +3,5 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from .options import OPTIONS_DEFAULT_DIRECTED, vis_options_merge  # noqa F401
+from .options import OPTIONS_DEFAULT_DIRECTED, OPTIONS_DEFAULT_SCALING_NODES, OPTIONS_DEFAULT_SCALING_EDGES_ONLY, \
+    vis_options_merge  # noqa F401

--- a/src/graph_notebook/options/options.py
+++ b/src/graph_notebook/options/options.py
@@ -72,6 +72,165 @@ OPTIONS_DEFAULT_DIRECTED = {
     }
 }
 
+OPTIONS_DEFAULT_SCALING_EDGES_ONLY = {
+  "nodes": {
+        "borderWidthSelected": 0,
+        "borderWidth": 0,
+        "color": {
+            "background": "rgba(210, 229, 255, 1)",
+            "border": "transparent",
+            "highlight": {
+                "background": "rgba(9, 104, 178, 1)",
+                "border": "rgba(8, 62, 100, 1)"
+            }
+        },
+        "shadow": {
+            "enabled": False
+        },
+        "shape": "circle",
+        "widthConstraint": {
+            "minimum": 70,
+            "maximum": 70
+        },
+        "font": {
+            "face": "courier new",
+            "color": "black",
+            "size": 12
+        },
+    },
+  "edges": {
+    "arrowStrikethrough": False,
+    "color": {
+      "inherit": False
+    },
+    "smooth": {
+      "enabled": True,
+      "type": "straightCross"
+    },
+    "arrows": {
+      "to": {
+        "enabled": True,
+        "type": "arrow"
+      }
+    },
+    "font": {
+      "face": "courier new"
+    },
+    "scaling": {
+      "min": 3,
+      "max": 9,
+      "label": {
+        "min": 12,
+        "max": 12
+      }
+    }
+  },
+  "interaction": {
+    "hover": True,
+    "hoverConnectedEdges": True,
+    "selectConnectedEdges": False
+  },
+  "physics": {
+    "minVelocity": 0.75,
+    "barnesHut": {
+      "centralGravity": 0.1,
+      "gravitationalConstant": -50450,
+      "springLength": 95,
+      "springConstant": 0.04,
+      "damping": 0.09,
+      "avoidOverlap": 0.1
+    },
+    "solver": "barnesHut",
+    "enabled": True,
+    "adaptiveTimestep": True,
+    "stabilization": {
+      "enabled": True,
+      "iterations": 1
+    }
+  }
+}
+
+OPTIONS_DEFAULT_SCALING_NODES = {
+  "nodes": {
+    "borderWidthSelected": 0,
+    "borderWidth": 0,
+    "color": {
+      "background": "rgba(210, 229, 255, 1)",
+      "border": "transparent",
+      "highlight": {
+        "background": "rgba(9, 104, 178, 1)",
+        "border": "rgba(8, 62, 100, 1)"
+      }
+    },
+    "shadow": {
+      "enabled": False
+    },
+    "shape": "circle",
+    "font": {
+      "face": "courier new",
+      "color": "black"
+    },
+    "scaling": {
+      "min": 20,
+      "max": 10000,
+      "label": {
+        "min": 8,
+        "max": 24
+      }
+    }
+  },
+  "edges": {
+    "arrowStrikethrough": False,
+    "color": {
+      "inherit": False
+    },
+    "smooth": {
+      "enabled": True,
+      "type": "straightCross"
+    },
+    "arrows": {
+      "to": {
+        "enabled": True,
+        "type": "arrow"
+      }
+    },
+    "font": {
+      "face": "courier new"
+    },
+    "scaling": {
+      "min": 3,
+      "max": 9,
+      "label": {
+        "min": 12,
+        "max": 12
+      }
+    }
+  },
+  "interaction": {
+    "hover": True,
+    "hoverConnectedEdges": True,
+    "selectConnectedEdges": False
+  },
+  "physics": {
+    "minVelocity": 0.75,
+    "barnesHut": {
+      "centralGravity": 0.1,
+      "gravitationalConstant": -50450,
+      "springLength": 95,
+      "springConstant": 0.04,
+      "damping": 0.09,
+      "avoidOverlap": 0.1
+    },
+    "solver": "barnesHut",
+    "enabled": True,
+    "adaptiveTimestep": True,
+    "stabilization": {
+      "enabled": True,
+      "iterations": 1
+    }
+  }
+}
+
 
 def vis_options_merge(original, target):
     """Merge the target dict with the original dict, without modifying the input dicts.

--- a/src/graph_notebook/widgets/src/force_widget.ts
+++ b/src/graph_notebook/widgets/src/force_widget.ts
@@ -129,9 +129,11 @@ export class ForceView extends DOMWidgetView {
     returned, not json.
      */
 
+    console.log("FORCE: Generating new network.");
     const network = this.model.get("network");
     this.visOptions = this.model.get("options");
     this.populateDatasets(network);
+    console.log("FORCE: Populated datasets from network.");
     const dataset = {
       nodes: this.nodeDataset,
       edges: this.edgeDataset,
@@ -173,7 +175,11 @@ export class ForceView extends DOMWidgetView {
    */
   populateDatasets(network: ForceNetwork): void {
     const edges = this.linksToEdges(network.graph.links);
+    console.log("Nodes:");
+    console.log(network.graph.nodes);
     this.nodeDataset.update(network.graph.nodes);
+    console.log("Edges:");
+    console.log(edges);
     this.edgeDataset.update(edges);
   }
 
@@ -210,6 +216,7 @@ export class ForceView extends DOMWidgetView {
    */
   interceptCustom(msg: Message): void {
     const msgData = msg["data"];
+    console.log(msgData);
     switch (msg["method"]) {
       case "add_node":
         this.addNode(msgData);
@@ -248,6 +255,8 @@ export class ForceView extends DOMWidgetView {
         }
      */
   addNode(msgData: DynamicObject): void {
+    console.log("addNode: adding new node");
+    console.log(msgData);
     if (!msgData.hasOwnProperty("node_id")) {
       // message data must have an id to add a node
       return;
@@ -267,6 +276,11 @@ export class ForceView extends DOMWidgetView {
     if (!node.hasOwnProperty("label")) {
       // no label found, using node id
       node["label"] = id;
+    }
+
+    if (!node.hasOwnProperty("value")) {
+      // no label found, using node id
+      node["value"] = 0;
     }
 
     this.nodeDataset.update([node]);
@@ -350,6 +364,8 @@ export class ForceView extends DOMWidgetView {
   addEdge(msgData: DynamicObject): void {
     // To be able to add an edge, we require the message to have:
     // 'from_id', 'to_id', and 'edge_id'
+    console.log("addEdge: adding new edge");
+    console.log(msgData);
     if (
       !msgData.hasOwnProperty("from_id") ||
       !msgData.hasOwnProperty("to_id") ||
@@ -359,13 +375,19 @@ export class ForceView extends DOMWidgetView {
     }
 
     // check if we have a label. if we do not, use the edge id.
+
     const label = msgData.hasOwnProperty("label")
       ? msgData["label"]
       : msgData["edge_id"];
+
     const innerData = msgData.hasOwnProperty("data") ? msgData["data"] : {};
 
     const edgeID =
       msgData["from_id"] + ":" + msgData["to_id"] + ":" + msgData["edge_id"];
+
+    const value = msgData.hasOwnProperty("value")
+      ? msgData["value"]
+      : 0;
 
     // rearrange the data to add to a node to ensure it conforms to the format of a vis-edge.
     // More info found here: https://github.com/visjs/vis-network
@@ -374,6 +396,7 @@ export class ForceView extends DOMWidgetView {
       to: msgData["to_id"],
       id: edgeID,
       label: label,
+      value: value,
       ...innerData,
     };
     let edge = this.edgeDataset.get(edgeID);

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -32,7 +32,8 @@ class TestGremlinNetwork(unittest.TestCase):
                     'runways': '4',
                     'type': 'Airport'},
                 'title': 'airport'},
-            'node_id': '1234'}
+            'node_id': '1234',
+            'value': None}
 
         def add_node_callback(network, event_name, data):
             self.assertEqual(event_name, EVENT_ADD_NODE)

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -39,8 +39,10 @@ class TestOpenCypherNetwork(unittest.TestCase):
                     "~labels": ['airport'],
                     'code': 'SEA',
                     'runways': 3},
-                'title': "airport"},
-            'node_id': '22'}
+                'title': "airport"
+            },
+            'node_id': '22',
+            'value': None}
 
         def add_node_callback(network, event_name, data):
             self.assertEqual(event_name, EVENT_ADD_NODE)
@@ -51,6 +53,8 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(res)
         self.assertTrue(reached_callback[EVENT_ADD_NODE])
         node = gn.graph.nodes.get("22")
+        print(expected_data['data']['properties'])
+        print(node['properties'])
         self.assertEqual(expected_data['data']['properties'], node['properties'])
 
     def test_add_edge_with_callback(self):
@@ -87,6 +91,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
             'label': 'route',
             'from_id': "22",
             'to_id': '151',
+            'value': None,
             'edge_id': '7389'
         }
 

--- a/test/unit/network/sparql/test_sparql_network.py
+++ b/test/unit/network/sparql/test_sparql_network.py
@@ -100,9 +100,11 @@ class TestSPARQLNetwork(unittest.TestCase):
                 'data': {
                     'label': 'resourc...',
                     'prefix': 'resource',
-                    'title': 'resource:24'
+                    'title': 'resource:24',
+                    'value': '24'
                 },
-                'node_id': 'http://kelvinlawrence.net/air-routes/resource/24'
+                'node_id': 'http://kelvinlawrence.net/air-routes/resource/24',
+                'value': '24'
             }
             self.assertEqual(expected_data, data)
             node = network.graph.nodes.get(node_id)

--- a/test/unit/network/test_eventful_network.py
+++ b/test/unit/network/test_eventful_network.py
@@ -12,6 +12,7 @@ from graph_notebook.network.EventfulNetwork import EventfulNetwork, EVENT_ADD_NO
 class TestEventfulNetwork(TestCase):
     def test_add_node_callback_dispatch(self):
         node_id = '1'
+        node_value = '0.0'
         node_data = {
             'foo': 'bar'
         }
@@ -26,7 +27,7 @@ class TestEventfulNetwork(TestCase):
 
         en = EventfulNetwork()
         en.register_callback(EVENT_ADD_NODE, add_node_callback)
-        en.add_node(node_id, node_data)
+        en.add_node(node_id, node_value, node_data)
         self.assertIsNotNone(en.graph.nodes.get(node_id))
         self.assertTrue(callbacks_reached[EVENT_ADD_NODE])
 
@@ -59,6 +60,7 @@ class TestEventfulNetwork(TestCase):
         edge_label = edge_id
         edge_data = dict()
         edge_data['foo'] = 'bar'
+        edge_value = 0.0
 
         callback_reached = {}
 
@@ -69,6 +71,7 @@ class TestEventfulNetwork(TestCase):
                 'to_id': to_id,
                 'edge_id': edge_id,
                 'label': edge_label,
+                'value': edge_value,
                 'data': edge_data
             }
             self.assertEqual(expected_payload, data)
@@ -78,7 +81,7 @@ class TestEventfulNetwork(TestCase):
         en = EventfulNetwork(callbacks={EVENT_ADD_EDGE: [add_edge_callback]})
         en.add_node(from_id)
         en.add_node(to_id)
-        en.add_edge(from_id, to_id, edge_id, edge_label, edge_data)
+        en.add_edge(from_id, to_id, edge_id, edge_label, edge_value, edge_data)
         self.assertTrue(callback_reached[EVENT_ADD_EDGE])
 
     def test_add_node_data_callback_dispatched(self):


### PR DESCRIPTION
Issue #, if available: #28

Description of changes:
- Added `-sn`/`--node-scaling-property` and `-se`/`--edge-scaling-property` to query magics. These options are specified along with property names, the values of which will be used to scale the widths of edges, and size of nodes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.