### PR TITLE
Improve handling of JSON format string inputs for -d/-de query options

### DIFF
--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -112,13 +112,14 @@ class GremlinNetwork(EventfulNetwork):
         except ValueError:
             self.group_by_property = group_by_property
         try:
-            self.display_property = self.convert_multiproperties_to_tuples(json.loads(display_property))
+            self.display_property = self.convert_multiproperties_to_tuples(json.loads(display_property.strip('\'"')))
         except ValueError:
-            self.display_property = self.convert_multiproperties_to_tuples(display_property)
+            self.display_property = self.convert_multiproperties_to_tuples(display_property.strip('\'"'))
         try:
-            self.edge_display_property = self.convert_multiproperties_to_tuples(json.loads(edge_display_property))
+            self.edge_display_property = self.convert_multiproperties_to_tuples(
+                json.loads(edge_display_property.strip('\'"')))
         except ValueError:
-            self.edge_display_property = self.convert_multiproperties_to_tuples(edge_display_property)
+            self.edge_display_property = self.convert_multiproperties_to_tuples(edge_display_property.strip('\'"'))
         self.ignore_groups = ignore_groups
         super().__init__(graph, callbacks)
 

--- a/src/graph_notebook/network/opencypher/OCNetwork.py
+++ b/src/graph_notebook/network/opencypher/OCNetwork.py
@@ -46,13 +46,14 @@ class OCNetwork(EventfulNetwork):
         except ValueError:
             self.group_by_property = group_by_property
         try:
-            self.display_property = self.convert_multiproperties_to_tuples(json.loads(display_property))
+            self.display_property = self.convert_multiproperties_to_tuples(json.loads(display_property.strip('\'"')))
         except ValueError:
-            self.display_property = self.convert_multiproperties_to_tuples(display_property)
+            self.display_property = self.convert_multiproperties_to_tuples(display_property.strip('\'"'))
         try:
-            self.edge_display_property = self.convert_multiproperties_to_tuples(json.loads(edge_display_property))
+            self.edge_display_property = self.convert_multiproperties_to_tuples(
+                json.loads(edge_display_property.strip('\'"')))
         except ValueError:
-            self.edge_display_property = self.convert_multiproperties_to_tuples(edge_display_property)
+            self.edge_display_property = self.convert_multiproperties_to_tuples(edge_display_property.strip('\'"'))
         self.ignore_groups = ignore_groups
         super().__init__(graph, callbacks)
 


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Handle cases where some JSON format strings specified directly to the `-d` or `-de` query options were not being serialized correctly to dictionary format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.