### PR TITLE
Fix TypeError thrown for certain OC list type results

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,9 +4,9 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Added a new `%stream_viewer` magic that allows interactive exploration of the Neptune CDC stream (if enabled). ([Link to PR](https://github.com/aws/graph-notebook/pull/191))
-
 - Added support for multi-property values in vertex and edge labels ([Link to PR](https://github.com/aws/graph-notebook/pull/186))
 - Added new visualization physics options, toggle button ([Link to PR](https://github.com/aws/graph-notebook/pull/190))
+- Fix TypeError thrown for certain OC list type results ([Link to PR](https://github.com/aws/graph-notebook/pull/196)
 
 ## Release 3.0.5 (August 27, 2021)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1405,7 +1405,7 @@ class Graph(Magics):
         logger.debug(args)
         titles = []
         children = []
-        force_graph_output=None
+        force_graph_output = None
         res = None
         if args.mode == 'query':
             query_start = time.time() * 1000  # time.time() returns time in seconds w/high precision; x1000 to get in ms
@@ -1414,7 +1414,7 @@ class Graph(Magics):
             oc_http.raise_for_status()
             res = oc_http.json()
             oc_metadata = build_opencypher_metadata_from_query(query_type='query', results=res,
-                                                               query_time=query_time)            
+                                                               query_time=query_time)
             try:
                 gn = OCNetwork(group_by_property=args.group_by, display_property=args.display_property,
                                edge_display_property=args.edge_display_property,
@@ -1426,8 +1426,9 @@ class Graph(Magics):
                         = args.stop_physics
                     self.graph_notebook_vis_options['physics']['simulationDuration'] = args.simulation_duration
                     force_graph_output = Force(network=gn, options=self.graph_notebook_vis_options)
-            except ValueError as value_error:
-                logger.debug(f'unable to create network from result. Skipping from result set: {value_error}')
+            except (TypeError, ValueError) as network_creation_error:
+                logger.debug(f'Unable to create network from result. Skipping from result set: {res}')
+                logger.debug(f'Error: {network_creation_error}')
         elif args.mode == 'bolt':
             res = self.client.opencyper_bolt(cell)            
             # Need to eventually add code to parse and display a network for the bolt format here

--- a/src/graph_notebook/network/opencypher/OCNetwork.py
+++ b/src/graph_notebook/network/opencypher/OCNetwork.py
@@ -186,9 +186,14 @@ class OCNetwork(EventfulNetwork):
         """
         for res in results["results"]:
             if type(res) is dict:
-                for k in res.keys():            
+                for k in res.keys():
                     if type(res[k]) is dict:
                         self.process_result(res[k]) 
                     elif type(res[k]) is list:
                         for res_sublist in res[k]:
-                            self.process_result(res_sublist)
+                            try:
+                                self.process_result(res_sublist)
+                            except TypeError as e:
+                                logger.debug(f'Property {res_sublist} in list results set is invalid, skipping')
+                                logger.debug(f'Error: {e}')
+                                continue

--- a/src/graph_notebook/seed/load_query.py
+++ b/src/graph_notebook/seed/load_query.py
@@ -10,10 +10,10 @@ from os.path import join as pjoin
 def normalize_model_name(name):
     name = name.lower().replace('_', '')
     # handles legacy scenarios
-    if name=='gremlin':
-        name='propertygraph'
-    elif name=='sparql':
-        name='rdf' 
+    if name in ('gremlin', 'opencypher'):
+        name = 'propertygraph'
+    elif name == 'sparql':
+        name = 'rdf'
     return name
 
 

--- a/test/integration/without_iam/opencypher/test_opencypher_query_without_iam.py
+++ b/test/integration/without_iam/opencypher/test_opencypher_query_without_iam.py
@@ -2,136 +2,29 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 """
-import json
-import threading
+import pytest
 
-import logging
-import time
-import requests
-from requests import HTTPError
+from test.integration import IntegrationTest
 
-from test.integration.DataDrivenOpenCypherTest import DataDrivenOpenCypherTest
+class TestOpenCypher(IntegrationTest):
+    @pytest.mark.opencypher
+    @pytest.mark.neptune
+    def test_do_oc_query(self):
+        query = 'MATCH (n) RETURN n LIMIT 1'
+        oc_http = self.client.opencypher_http(query)
+        assert oc_http.status_code == 200
+        results = oc_http.json()
+        assert type(results["results"]) is list
 
-logger = logging.getLogger('TestOpenCypherStatusWithoutIam')
+        for r in results["results"]:
+            assert type(r) is dict
 
+        self.assertEqual(type(results["results"]), list)
 
-class TestOpenCypherStatusWithIam(DataDrivenOpenCypherTest):
-    def do_opencypher_query_save_result(self, query, res, bolt: bool = False):
-        try:
-            if bolt:
-                res['result'] = self.client.opencyper_bolt(query)
-            else:
-                res['result'] = self.client.opencypher_http(query)
-        except requests.HTTPError as exception:
-            res['error'] = exception.response.json()
+    @pytest.mark.opencypher
+    @pytest.mark.bolt
+    def test_do_oc_bolt_query(self):
+        query = 'MATCH (p) RETURN p LIMIT 10'
+        res = self.client.opencyper_bolt(query)
+        assert len(res) == 10
 
-    def setUp(self) -> None:
-        res = self.client.opencypher_status()
-        for q in res['queries']:
-            self.client.opencypher_cancel(q['queryId'])
-
-    def test_do_opencypher_status_nonexistent(self):
-        query_id = "ac7d5a03-00cf-4280-b464-edbcbf51ffce"
-        with self.assertRaises(HTTPError) as error:
-            self.client.opencypher_status(query_id)
-        err = json.loads(error.exception.response.content.decode('utf-8'))
-        self.assertEqual(err['code'], "InvalidParameterException")
-        expected_message = f'Supplied queryId {query_id} is invalid'
-        self.assertEqual(err['detailedMessage'], expected_message)
-
-    def test_do_opencypher_cancel_nonexistent(self):
-        query_id = "ac7d5a03-00cf-4280-b464-edbcbf51ffce"
-        with self.assertRaises(HTTPError) as error:
-            self.client.opencypher_cancel(query_id)
-        err = json.loads(error.exception.response.content.decode('utf-8'))
-        self.assertEqual(err['code'], "InvalidParameterException")
-        expected_message = f'Supplied queryId {query_id} is invalid'
-        self.assertEqual(err['detailedMessage'], expected_message)
-
-    def test_do_opencypher_cancel_empty_query_id(self):
-        with self.assertRaises(ValueError):
-            self.client.opencypher_cancel('')
-
-    def test_do_opencypher_cancel_non_str_query_id(self):
-        with self.assertRaises(ValueError):
-            self.client.opencypher_cancel(42)
-
-    def test_do_opencypher_status_and_cancel(self):
-        query = '''MATCH(a)-->(b)
-                    MATCH(c)-->(d)
-                    RETURN a,b,c,d'''
-        query_res = {}
-        oc_query_thread = threading.Thread(target=self.do_opencypher_query_save_result, args=(query, query_res,))
-        oc_query_thread.start()
-        time.sleep(3)
-
-        status_res = self.client.opencypher_status()
-        assert type(status_res) is dict
-        assert 'acceptedQueryCount' in status_res
-        assert 'runningQueryCount' in status_res
-        assert 1 == status_res['runningQueryCount']
-        assert 'queries' in status_res
-
-        query_id = ''
-        for q in status_res['queries']:
-            if query in q['queryString']:
-                query_id = q['queryId']
-
-        assert query_id != ''
-
-        cancel_res = self.client.opencypher_cancel(query_id)
-        assert type(cancel_res) is dict
-        assert cancel_res['status'] == '200 OK'
-
-        oc_query_thread.join()
-        assert 'result' not in query_res
-        assert 'error' in query_res
-        assert 'code' in query_res['error']
-        assert 'requestId' in query_res['error']
-        assert 'detailedMessage' in query_res['error']
-        assert 'CancelledByUserException' == query_res['error']['code']
-
-    def test_do_opencypher_status_and_cancel_silently(self):
-        query = '''MATCH(a)-->(b)
-                    MATCH(c)-->(d)
-                    RETURN a,b,c,d'''
-
-        query_res = {}
-        oc_query_thread = threading.Thread(target=self.do_opencypher_query_save_result, args=(query, query_res,))
-        oc_query_thread.start()
-        time.sleep(3)
-
-        query_id = ''
-        status = self.client.opencypher_status(query_id)
-        assert status.status_code == 200
-
-        status_res = status.json()
-        assert type(status_res) is dict
-        assert 'acceptedQueryCount' in status_res
-        assert 'runningQueryCount' in status_res
-        assert 1 == status_res['runningQueryCount']
-        assert 'queries' in status_res
-
-        query_id = ''
-        for q in status_res['queries']:
-            if query in q['queryString']:
-                query_id = q['queryId']
-
-        assert query_id != ''
-        self.assertNotEqual(query_id, '')
-
-        cancel = self.client.opencypher_cancel(query_id)
-        cancel_res = cancel.json()
-        assert type(cancel_res) is dict
-        assert cancel_res['status'] == '200 OK'
-
-        oc_query_thread.join()
-        assert type(query_res['result']) is dict
-        assert 'a' in query_res['result']['head']['vars']
-        assert 'b' in query_res['result']['head']['vars']
-        assert 'c' in query_res['result']['head']['vars']
-        assert 'd' in query_res['result']['head']['vars']
-        assert [] == query_res['result']['results']['bindings']
-
-    def test_opencypher_bolt_query_with_cancellation(self):
-        pass

--- a/test/integration/without_iam/opencypher/test_opencypher_query_without_iam.py
+++ b/test/integration/without_iam/opencypher/test_opencypher_query_without_iam.py
@@ -6,6 +6,7 @@ import pytest
 
 from test.integration import IntegrationTest
 
+
 class TestOpenCypher(IntegrationTest):
     @pytest.mark.opencypher
     @pytest.mark.neptune
@@ -27,4 +28,3 @@ class TestOpenCypher(IntegrationTest):
         query = 'MATCH (p) RETURN p LIMIT 10'
         res = self.client.opencyper_bolt(query)
         assert len(res) == 10
-

--- a/test/integration/without_iam/opencypher/test_opencypher_status_without_iam.py
+++ b/test/integration/without_iam/opencypher/test_opencypher_status_without_iam.py
@@ -136,3 +136,6 @@ class TestOpenCypherStatusWithoutIam(DataDrivenOpenCypherTest):
         assert 'c' in query_res['result']['head']['vars']
         assert 'd' in query_res['result']['head']['vars']
         assert [] == query_res['result']['results']['bindings']
+
+    def test_opencypher_bolt_query_with_cancellation(self):
+        pass

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -659,6 +659,25 @@ class TestOpenCypherNetwork(unittest.TestCase):
         self.assertEqual(node1['group'], 'ANC')
         self.assertEqual(node2['group'], 'United States')
 
+    def test_set_add_non_graphable_results_list(self):
+        res = {
+            'results': [
+                {
+                    'a': [1, 2, 3, 4, 5, 6, 7]
+                }
+            ]
+        }
+
+        gn = OCNetwork()
+        try:
+            gn.add_results(res)
+        except TypeError:
+            self.fail()
+        nodes_list = list(gn.graph.nodes)
+        edges_list = list(gn.graph.edges)
+        self.assertEqual(nodes_list, [])
+        self.assertEqual(edges_list, [])
+
     def test_do_not_set_vertex_label_property(self):
         res = {
             "results": [


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Implement additional checks to catch TypeError being thrown when attempting to create a visualization network from an invalid openCypher list-type results set.
- Fix some issues in openCypher integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.