### PR TITLE
Fix for #199

### DIFF
--- a/src/graph_notebook/magics/streams.py
+++ b/src/graph_notebook/magics/streams.py
@@ -204,6 +204,10 @@ class StreamViewer:
             self.out.clear_output(wait=True)
             with self.out:
                 display(HTML(html))
+        else:
+            self.out.clear_output(wait=True)
+            with self.out:
+                display(HTML('<b>No records found to display</b>'))
             
     def update_slider_min_max_values(self, language):
         new_min = self.stream_client.get_first_commit_num(language)


### PR DESCRIPTION
Issue #199

Description of changes:
When switching between the Gremlin and SPARQl streams, if there is no data on that stream, erase any displayed data from the other stream and display a message that the stream has no data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.