### PR TITLE
Add silent output query option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Added `--silent` option for suppressing query output ([Link to PR](https://github.com/aws/graph-notebook/pull/201))
 
 ## Release 3.0.6 (September 20, 2021)
 - Added a new `%stream_viewer` magic that allows interactive exploration of the Neptune CDC stream (if enabled). ([Link to PR](https://github.com/aws/graph-notebook/pull/191))


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added `--silent` option to `%%gremlin`, `%%sparql`, and `%%opencypher`/`%%oc` to allow for suppressing the display of all query output widgets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.