### PR TITLE
Add silent option to %graph_notebook_vis_options

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
-- Added `--silent` option for suppressing query output ([Link to PR](https://github.com/aws/graph-notebook/pull/201))
+- Added `--silent` option for suppressing query output ([PR #1](https://github.com/aws/graph-notebook/pull/201)) ([PR #2](https://github.com/aws/graph-notebook/pull/203))
 
 ## Release 3.0.6 (September 20, 2021)
 - Added a new `%stream_viewer` magic that allows interactive exploration of the Neptune CDC stream (if enabled). ([Link to PR](https://github.com/aws/graph-notebook/pull/191))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1368,11 +1368,24 @@ class Graph(Magics):
     @line_cell_magic
     @display_exceptions
     def graph_notebook_vis_options(self, line='', cell=''):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--silent', action='store_true', default=False, help="Display no output.")
+        line_args = line.split()
+        if line_args:
+            if line_args[0] == 'reset':
+                line = 'reset'
+                if len(line_args) > 1:
+                    line_args = line_args[1:]
+                else:
+                    line_args = []
+        args = parser.parse_args(line_args)
+
         if line == 'reset':
             self.graph_notebook_vis_options = OPTIONS_DEFAULT_DIRECTED
 
         if cell == '':
-            print(json.dumps(self.graph_notebook_vis_options, indent=2))
+            if not args.silent:
+                print(json.dumps(self.graph_notebook_vis_options, indent=2))
         else:
             options_dict = json.loads(cell)
             self.graph_notebook_vis_options = vis_options_merge(self.graph_notebook_vis_options, options_dict)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added `--silent` option to `%graph_notebook_vis_options` line magic, suppresses output when specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.