### PR TITLE
Add parserConfiguration options to %load

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added full support for NeptuneML API command parameters to `%neptune_ml` ([Link to PR](https://github.com/aws/graph-notebook/pull/202))
 - Allow `%%neptune_ml` to accept JSON blob as parameter input for most phases ([Link to PR](https://github.com/aws/graph-notebook/pull/202))
 - Added `--silent` option for suppressing query output ([PR #1](https://github.com/aws/graph-notebook/pull/201)) ([PR #2](https://github.com/aws/graph-notebook/pull/203))
+- Added all `parserConfiguration` options to `%load` ([Link to PR](https://github.com/aws/graph-notebook/pull/205))
 
 ## Release 3.0.6 (September 20, 2021)
 - Added a new `%stream_viewer` magic that allows interactive exploration of the Neptune CDC stream (if enabled). ([Link to PR](https://github.com/aws/graph-notebook/pull/191))


### PR DESCRIPTION
Issue #, if available: #204

Description of changes:
- Added `--named-graph-uri`, `--base-uri`, and `--allow-empty-strings` options to the `%load` magic. These enable usage of the `parserConfiguration` Neptune bulk loader parameter and its child elements.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.