### PR TITLE
Add edge tooltips, new query magic option for specifying edge label length

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Added tooltips for visualized edges ([Link to PR](https://github.com/aws/graph-notebook/pull/218))
 
 ## Release 3.0.7 (October 25, 2021)
 - Added full support for NeptuneML API command parameters to `%neptune_ml` ([Link to PR](https://github.com/aws/graph-notebook/pull/202))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
-- Added tooltips for visualized edges ([Link to PR](https://github.com/aws/graph-notebook/pull/218))
+- Added edge tooltips, and options for specifying edge label length ([Link to PR](https://github.com/aws/graph-notebook/pull/218))
 
 ## Release 3.0.7 (October 25, 2021)
 - Added full support for NeptuneML API command parameters to `%neptune_ml` ([Link to PR](https://github.com/aws/graph-notebook/pull/202))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -249,7 +249,9 @@ class Graph(Magics):
         parser.add_argument('--explain-format', default='text/html', help='response format for explain query mode',
                             choices=['text/csv', 'text/html'])
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
-                            help='Specifies max length of vertex label, in characters. Default is 10')
+                            help='Specifies max length of vertex labels, in characters. Default is 10')
+        parser.add_argument('-le', '--edge-label-max-length', type=int, default=10,
+                            help='Specifies max length of edge labels, in characters. Default is 10')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
         parser.add_argument('-sp', '--stop-physics', action='store_true', default=False,
                             help="Disable visualization physics after the initial simulation stabilizes.")
@@ -306,7 +308,8 @@ class Graph(Magics):
                     sparql_metadata = build_sparql_metadata_from_query(query_type='query', res=query_res,
                                                                        results=results, scd_query=True)
 
-                    sn = SPARQLNetwork(label_max_length=args.label_max_length, expand_all=args.expand_all)
+                    sn = SPARQLNetwork(label_max_length=args.label_max_length,
+                                       edge_label_max_length=args.edge_label_max_length, expand_all=args.expand_all)
                     sn.extract_prefix_declarations_from_query(cell)
                     try:
                         sn.add_results(results)
@@ -422,6 +425,8 @@ class Graph(Magics):
                             help='Property to display the value of on each edge, default is T.label')
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
                             help='Specifies max length of vertex label, in characters. Default is 10')
+        parser.add_argument('-le', '--edge-label-max-length', type=int, default=10,
+                            help='Specifies max length of edge labels, in characters. Default is 10')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
         parser.add_argument('--ignore-groups', action='store_true', default=False, help="Ignore all grouping options")
         parser.add_argument('--no-results', action='store_false', default=True,
@@ -502,7 +507,9 @@ class Graph(Magics):
                     logger.debug(f'ignore_groups: {args.ignore_groups}')
                     gn = GremlinNetwork(group_by_property=args.group_by, display_property=args.display_property,
                                         edge_display_property=args.edge_display_property,
-                                        label_max_length=args.label_max_length, ignore_groups=args.ignore_groups)
+                                        label_max_length=args.label_max_length,
+                                        edge_label_max_length=args.edge_label_max_length,
+                                        ignore_groups=args.ignore_groups)
 
                     if args.path_pattern == '':
                         gn.add_results(query_res)
@@ -1544,6 +1551,8 @@ class Graph(Magics):
                             help='Property to display the value of on each edge, default is ~type')
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
                             help='Specifies max length of vertex label, in characters. Default is 10')
+        parser.add_argument('-rel', '--rel-label-max-length', type=int, default=10,
+                            help='Specifies max length of edge labels, in characters. Default is 10')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
         parser.add_argument('--ignore-groups', action='store_true', default=False, help="Ignore all grouping options")
         parser.add_argument('-sp', '--stop-physics', action='store_true', default=False,
@@ -1573,7 +1582,9 @@ class Graph(Magics):
                 try:
                     gn = OCNetwork(group_by_property=args.group_by, display_property=args.display_property,
                                    edge_display_property=args.edge_display_property,
-                                   label_max_length=args.label_max_length, ignore_groups=args.ignore_groups)
+                                   label_max_length=args.label_max_length,
+                                   rel_label_max_length=args.rel_label_max_length,
+                                   ignore_groups=args.ignore_groups)
                     gn.add_results(res)
                     logger.debug(f'number of nodes is {len(gn.graph.nodes)}')
                     if len(gn.graph.nodes) > 0:

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -248,6 +248,8 @@ class Graph(Magics):
                             choices=['dynamic', 'static', 'details'])
         parser.add_argument('--explain-format', default='text/html', help='response format for explain query mode',
                             choices=['text/csv', 'text/html'])
+        parser.add_argument('-l', '--label-max-length', type=int, default=10,
+                            help='Specifies max length of vertex label, in characters. Default is 10')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
         parser.add_argument('-sp', '--stop-physics', action='store_true', default=False,
                             help="Disable visualization physics after the initial simulation stabilizes.")
@@ -304,7 +306,7 @@ class Graph(Magics):
                     sparql_metadata = build_sparql_metadata_from_query(query_type='query', res=query_res,
                                                                        results=results, scd_query=True)
 
-                    sn = SPARQLNetwork(expand_all=args.expand_all)
+                    sn = SPARQLNetwork(label_max_length=args.label_max_length, expand_all=args.expand_all)
                     sn.extract_prefix_declarations_from_query(cell)
                     try:
                         sn.add_results(results)

--- a/src/graph_notebook/network/EventfulNetwork.py
+++ b/src/graph_notebook/network/EventfulNetwork.py
@@ -43,10 +43,10 @@ class EventfulNetwork(Network):
         super().__init__(graph)
 
     def strip_and_truncate_label_and_title(self, old_label, max_len: int) -> Tuple[str, str]:
-        if isinstance(old_label, list) and len(old_label) > 1:
-            title = str(old_label)
-        else:
+        if isinstance(old_label, list) and len(old_label) == 1:
             title = str(old_label).strip("[]'")
+        else:
+            title = str(old_label)
         if len(title) <= max_len:
             label = title
         else:

--- a/src/graph_notebook/network/EventfulNetwork.py
+++ b/src/graph_notebook/network/EventfulNetwork.py
@@ -140,7 +140,7 @@ class EventfulNetwork(Network):
         }
         self.dispatch_callbacks(EVENT_ADD_NODE, payload)
 
-    def add_edge(self, from_id: str, to_id: str, edge_id: str, label: str, data: dict = None):
+    def add_edge(self, from_id: str, to_id: str, edge_id: str, label: str, title: str = None, data: dict = None):
         if data is None:
             data = {}
         super().add_edge(from_id, to_id, edge_id, label, data)
@@ -149,6 +149,7 @@ class EventfulNetwork(Network):
             'to_id': to_id,
             'edge_id': edge_id,
             'label': label,
+            'title': title,
             'data': data
         }
         self.dispatch_callbacks(EVENT_ADD_EDGE, payload)

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -455,36 +455,37 @@ class GremlinNetwork(EventfulNetwork):
                             if isinstance(self.edge_display_property[edge_label], tuple) and isinstance(edge[k],list):
                                 if str(k) == self.edge_display_property[edge_label][0]:
                                     try:
-                                        edge_label = str(edge[k][self.edge_display_property[edge_label][1]])
+                                        edge_label = edge[k][self.edge_display_property[edge_label][1]]
                                         display_is_set = True
                                     except (TypeError, IndexError) as e:
                                         logger.debug(f"Failed to index into edge sub-property for: {edge[k]} and "
                                                      f"{self.edge_display_property[edge_label]}")
                                         continue
                             elif str(k) == self.edge_display_property[edge_label]:
-                                edge_label = str(edge[k])
+                                edge_label = edge[k]
                                 display_is_set = True
                         except KeyError:
                             continue
                     elif isinstance(self.edge_display_property, tuple):
                         if str(k) == self.edge_display_property[0] and isinstance(edge[k], list):
                             try:
-                                edge_label = str(edge[k][self.edge_display_property[1]])
+                                edge_label = edge[k][self.edge_display_property[1]]
                                 display_is_set = True
                             except IndexError:
                                 logger.debug(f"Failed to index into edge sub-property for: {edge[k]} and "
                                              f"{self.edge_display_property[0]}")
                                 continue
                     elif str(k) == self.edge_display_property:
-                        edge_label = str(edge[k])
+                        edge_label = edge[k]
                         display_is_set = True
-
             data['properties'] = properties
-            data['title'] = edge_label
-            self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge_id, label=edge_label, title=edge_label, data=data)
+            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge_label, self.label_max_length)
+            data['title'] = edge_title
+            self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge_id, label=edge_label, title=edge_title, data=data)
         else:
-            data['title'] = str(edge)
-            self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge, label=str(edge), title=str(edge), data=data)
+            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge, self.label_max_length)
+            data['title'] = edge_title
+            self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge, label=edge_label, title=edge_title, data=data)
 
     def add_blank_edge(self, from_id, to_id, edge_id=None, undirected=True, label=''):
         """

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -99,14 +99,12 @@ class GremlinNetwork(EventfulNetwork):
     """
 
     def __init__(self, graph: MultiDiGraph = None, callbacks=None, label_max_length=DEFAULT_LABEL_MAX_LENGTH,
-                 group_by_property=T_LABEL, display_property=T_LABEL, edge_display_property=T_LABEL,
-                 ignore_groups=False):
+                 edge_label_max_length=DEFAULT_LABEL_MAX_LENGTH, group_by_property=T_LABEL, display_property=T_LABEL,
+                 edge_display_property=T_LABEL, ignore_groups=False):
         if graph is None:
             graph = MultiDiGraph()
-        if label_max_length < 3:
-            self.label_max_length = 3
-        else:
-            self.label_max_length = label_max_length
+        self.label_max_length = 3 if label_max_length < 3 else label_max_length
+        self.edge_label_max_length = 3 if edge_label_max_length < 3 else edge_label_max_length
         try:
             self.group_by_property = json.loads(group_by_property)
         except ValueError:
@@ -479,11 +477,11 @@ class GremlinNetwork(EventfulNetwork):
                         edge_label = edge[k]
                         display_is_set = True
             data['properties'] = properties
-            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge_label, self.label_max_length)
+            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge_label, self.edge_label_max_length)
             data['title'] = edge_title
             self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge_id, label=edge_label, title=edge_title, data=data)
         else:
-            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge, self.label_max_length)
+            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge, self.edge_label_max_length)
             data['title'] = edge_title
             self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge, label=edge_label, title=edge_title, data=data)
 

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -480,9 +480,11 @@ class GremlinNetwork(EventfulNetwork):
                         display_is_set = True
 
             data['properties'] = properties
-            self.add_edge(from_id, to_id, edge_id, edge_label, data)
+            data['title'] = edge_label
+            self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge_id, label=edge_label, title=edge_label, data=data)
         else:
-            self.add_edge(from_id, to_id, edge, str(edge), data)
+            data['title'] = str(edge)
+            self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge, label=str(edge), title=str(edge), data=data)
 
     def add_blank_edge(self, from_id, to_id, edge_id=None, undirected=True, label=''):
         """
@@ -498,7 +500,7 @@ class GremlinNetwork(EventfulNetwork):
         if edge_id is None:
             edge_id = str(uuid.uuid4())
         edge_data = UNDIRECTED_EDGE if undirected else {}
-        self.add_edge(from_id, to_id, edge_id, label, edge_data)
+        self.add_edge(from_id=from_id, to_id=to_id, edge_id=edge_id, label=label, title=label, data=edge_data)
 
     def insert_path_element(self, path, i):
         if i == 0:

--- a/src/graph_notebook/network/opencypher/OCNetwork.py
+++ b/src/graph_notebook/network/opencypher/OCNetwork.py
@@ -164,10 +164,11 @@ class OCNetwork(EventfulNetwork):
                 display_label = rel[EDGE_TYPE_KEY]
         else:
             display_label = rel[EDGE_TYPE_KEY]
-        data['label'] = str(display_label)
-        data['title'] = str(display_label)
-        self.add_edge(from_id=rel[START_KEY], to_id=rel[END_KEY], edge_id=rel[ID_KEY], label=str(display_label),
-                      title=str(display_label), data=data)
+        edge_title, edge_label = self.strip_and_truncate_label_and_title(display_label, self.label_max_length)
+        data['title'] = edge_title
+        data['label'] = edge_label
+        self.add_edge(from_id=rel[START_KEY], to_id=rel[END_KEY], edge_id=rel[ID_KEY], label=edge_label,
+                      title=edge_title, data=data)
 
     def process_result(self, res: dict):
         """Determines the type of element passed in and processes it appropriately

--- a/src/graph_notebook/network/opencypher/OCNetwork.py
+++ b/src/graph_notebook/network/opencypher/OCNetwork.py
@@ -139,7 +139,7 @@ class OCNetwork(EventfulNetwork):
         self.add_node(node[ID_KEY], data)
     
     def parse_rel(self, rel):
-        data = {'properties': self.flatten(rel), 'label': rel[EDGE_TYPE_KEY]}
+        data = {'properties': self.flatten(rel), 'label': rel[EDGE_TYPE_KEY], 'title': rel[EDGE_TYPE_KEY]}
         if self.edge_display_property is not EDGE_TYPE_KEY:
             try:
                 if isinstance(self.edge_display_property, dict):
@@ -164,7 +164,10 @@ class OCNetwork(EventfulNetwork):
                 display_label = rel[EDGE_TYPE_KEY]
         else:
             display_label = rel[EDGE_TYPE_KEY]
-        self.add_edge(rel[START_KEY], rel[END_KEY], rel[ID_KEY], str(display_label), data)
+        data['label'] = str(display_label)
+        data['title'] = str(display_label)
+        self.add_edge(from_id=rel[START_KEY], to_id=rel[END_KEY], edge_id=rel[ID_KEY], label=str(display_label),
+                      title=str(display_label), data=data)
 
     def process_result(self, res: dict):
         """Determines the type of element passed in and processes it appropriately

--- a/src/graph_notebook/network/opencypher/OCNetwork.py
+++ b/src/graph_notebook/network/opencypher/OCNetwork.py
@@ -33,14 +33,13 @@ class OCNetwork(EventfulNetwork):
     """
 
     def __init__(self, graph: MultiDiGraph = None, callbacks=None, label_max_length=DEFAULT_LABEL_MAX_LENGTH,
-                 group_by_property=LABEL_KEY, display_property=LABEL_KEY,
-                 edge_display_property=EDGE_TYPE_KEY, ignore_groups=False):
+                 rel_label_max_length=DEFAULT_LABEL_MAX_LENGTH, group_by_property=LABEL_KEY,
+                 display_property=LABEL_KEY, edge_display_property=EDGE_TYPE_KEY, ignore_groups=False):
         if graph is None:
             graph = MultiDiGraph()
-        if label_max_length < 3:
-            self.label_max_length = 3
-        else:
-            self.label_max_length = label_max_length
+
+        self.label_max_length = 3 if label_max_length < 3 else label_max_length
+        self.rel_label_max_length = 3 if rel_label_max_length < 3 else rel_label_max_length
         try:
             self.group_by_property = json.loads(group_by_property)
         except ValueError:
@@ -164,7 +163,7 @@ class OCNetwork(EventfulNetwork):
                 display_label = rel[EDGE_TYPE_KEY]
         else:
             display_label = rel[EDGE_TYPE_KEY]
-        edge_title, edge_label = self.strip_and_truncate_label_and_title(display_label, self.label_max_length)
+        edge_title, edge_label = self.strip_and_truncate_label_and_title(display_label, self.rel_label_max_length)
         data['title'] = edge_title
         data['label'] = edge_label
         self.add_edge(from_id=rel[START_KEY], to_id=rel[END_KEY], edge_id=rel[ID_KEY], label=edge_label,

--- a/src/graph_notebook/network/sparql/SPARQLNetwork.py
+++ b/src/graph_notebook/network/sparql/SPARQLNetwork.py
@@ -341,4 +341,6 @@ class SPARQLNetwork(EventfulNetwork):
 
             if not self.graph.has_node(b[object_binding]['value']):
                 self.add_node(b[object_binding]['value'])
-            self.add_edge(b[subject_binding]['value'], b[object_binding]['value'], pred['value'], edge_label)
+            data = {'title': edge_label}
+            self.add_edge(from_id=b[subject_binding]['value'], to_id=b[object_binding]['value'], edge_id=pred['value'],
+                          label=edge_label, title=edge_label, data=data)

--- a/src/graph_notebook/network/sparql/SPARQLNetwork.py
+++ b/src/graph_notebook/network/sparql/SPARQLNetwork.py
@@ -55,7 +55,10 @@ class SPARQLNetwork(EventfulNetwork):
             graph = MultiDiGraph()
 
         self.expand_all = expand_all
-        self.label_max_length = label_max_length
+        if label_max_length < 3:
+            self.label_max_length = 3
+        else:
+            self.label_max_length = label_max_length
         super().__init__(graph, callbacks)
         self.namespace_to_prefix = {  # http://foo/bar/ -> bar
             NAMESPACE_RDFS: PREFIX_RDFS,
@@ -291,7 +294,7 @@ class SPARQLNetwork(EventfulNetwork):
                     data['title'] = title
                     data['label'] = label
 
-                # object is a literal. Check if data has this preciate already. If it does, turn its value into an
+                # object is a literal. Check if data has this predicate already. If it does, turn its value into an
                 # array and append the new value to it.
                 if 'properties' in data and f'{prefix}:{value}' in data['properties']:
                     if type(data['properties'][f'{prefix}:{value}']) is list:
@@ -301,7 +304,7 @@ class SPARQLNetwork(EventfulNetwork):
                 else:
                     data['properties'][f'{prefix}:{value}'] = obj_entry
             else:
-                # Check if data has this preciate already. If it does, turn its value into an
+                # Check if data has this predicate already. If it does, turn its value into an
                 # array and append the new value to it.
                 if 'properties' in data and pred['value'] in data['properties']:
                     if type(data['properties'][pred['value']]) is list:
@@ -341,6 +344,7 @@ class SPARQLNetwork(EventfulNetwork):
 
             if not self.graph.has_node(b[object_binding]['value']):
                 self.add_node(b[object_binding]['value'])
-            data = {'title': edge_label}
+            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge_label, self.label_max_length)
+            data = {'title': edge_title}
             self.add_edge(from_id=b[subject_binding]['value'], to_id=b[object_binding]['value'], edge_id=pred['value'],
-                          label=edge_label, title=edge_label, data=data)
+                          label=edge_label, title=edge_title, data=data)

--- a/src/graph_notebook/network/sparql/SPARQLNetwork.py
+++ b/src/graph_notebook/network/sparql/SPARQLNetwork.py
@@ -50,15 +50,15 @@ class SPARQLNetwork(EventfulNetwork):
                  graph: MultiDiGraph = None,
                  callbacks: list = None,
                  label_max_length: int = DEFAULT_LABEL_MAX_LENGTH,
+                 edge_label_max_length: int = DEFAULT_LABEL_MAX_LENGTH,
                  expand_all: bool = False):
         if graph is None:
             graph = MultiDiGraph()
 
         self.expand_all = expand_all
-        if label_max_length < 3:
-            self.label_max_length = 3
-        else:
-            self.label_max_length = label_max_length
+        self.label_max_length = 3 if label_max_length < 3 else label_max_length
+        self.edge_label_max_length = 3 if edge_label_max_length < 3 else edge_label_max_length
+
         super().__init__(graph, callbacks)
         self.namespace_to_prefix = {  # http://foo/bar/ -> bar
             NAMESPACE_RDFS: PREFIX_RDFS,
@@ -344,7 +344,7 @@ class SPARQLNetwork(EventfulNetwork):
 
             if not self.graph.has_node(b[object_binding]['value']):
                 self.add_node(b[object_binding]['value'])
-            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge_label, self.label_max_length)
+            edge_title, edge_label = self.strip_and_truncate_label_and_title(edge_label, self.edge_label_max_length)
             data = {'title': edge_title}
             self.add_edge(from_id=b[subject_binding]['value'], to_id=b[object_binding]['value'], edge_id=pred['value'],
                           label=edge_label, title=edge_title, data=data)

--- a/src/graph_notebook/widgets/src/force_widget.ts
+++ b/src/graph_notebook/widgets/src/force_widget.ts
@@ -666,7 +666,6 @@ export class ForceView extends DOMWidgetView {
     if (edge === null) {
       return;
     }
-
     if (edge.title !== undefined && edge.title !== "") {
       this.detailsText.innerText = "Details - " + edge.title;
     } else {

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -878,18 +878,32 @@ class TestGremlinNetwork(unittest.TestCase):
         edge = gn.graph.get_edge_data('1', '2')
         self.assertEqual(edge['1']['label'], 'route')
 
-    def test_add_edge_with_label_length(self):
+    def test_add_edge_with_label_length_full(self):
         vertex1 = Vertex(id='1')
         vertex2 = Vertex(id='2')
 
         edge1 = {T.id: '1', T.label: 'commercial_airway', 'outV': 'v[1]', 'inV': 'v[2]'}
 
-        gn = GremlinNetwork(label_max_length=15)
+        gn = GremlinNetwork(edge_label_max_length=15)
         gn.add_vertex(vertex1)
         gn.add_vertex(vertex2)
         gn.add_path_edge(edge1, from_id='1', to_id='2')
         edge = gn.graph.get_edge_data('1', '2')
         self.assertEqual(edge['1']['label'], 'commercial_a...')
+        self.assertEqual(edge['1']['title'], 'commercial_airway')
+
+    def test_add_edge_with_label_length_truncated(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'commercial_airway', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(edge_label_max_length=10)
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'commerc...')
         self.assertEqual(edge['1']['title'], 'commercial_airway')
 
     def test_add_edge_with_label_length_less_than_3(self):
@@ -898,7 +912,7 @@ class TestGremlinNetwork(unittest.TestCase):
 
         edge1 = {T.id: '1', T.label: 'commercial_airway', 'outV': 'v[1]', 'inV': 'v[2]'}
 
-        gn = GremlinNetwork(label_max_length=-50)
+        gn = GremlinNetwork(edge_label_max_length=-50)
         gn.add_vertex(vertex1)
         gn.add_vertex(vertex2)
         gn.add_path_edge(edge1, from_id='1', to_id='2')

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -1666,7 +1666,8 @@ class TestGremlinNetwork(unittest.TestCase):
                     Direction.OUT: '2',
                     'dist': 763
                 },
-                'label': 'route'
+                'label': 'route',
+                'title': 'route'
             }
         }
 
@@ -1841,7 +1842,8 @@ class TestGremlinNetwork(unittest.TestCase):
                     Direction.OUT: '2',
                     'dist': 763
                 },
-                'label': 'route'
+                'label': 'route',
+                'title': 'route'
             }
         }
 
@@ -1914,7 +1916,8 @@ class TestGremlinNetwork(unittest.TestCase):
                 Direction.OUT: '2',
                 'dist': 763
             },
-            'label': 'route'
+            'label': 'route',
+            'title': 'route'
         }
 
         path = Path([], [edge_map, out_vertex, in_vertex])

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -531,7 +531,7 @@ class TestGremlinNetwork(unittest.TestCase):
     def test_add_vertex_with_bracketed_label_and_label_length(self):
         vertex = {
             T.id: '1234',
-            T.label: "['Seattle-Tacoma International Airport']",
+            T.label: ['Seattle-Tacoma International Airport'],
             'type': 'Airport',
             'runways': '4',
             'code': 'SEA'
@@ -878,6 +878,34 @@ class TestGremlinNetwork(unittest.TestCase):
         edge = gn.graph.get_edge_data('1', '2')
         self.assertEqual(edge['1']['label'], 'route')
 
+    def test_add_edge_with_label_length(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'commercial_airway', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(label_max_length=15)
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], 'commercial_a...')
+        self.assertEqual(edge['1']['title'], 'commercial_airway')
+
+    def test_add_edge_with_label_length_less_than_3(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+
+        edge1 = {T.id: '1', T.label: 'commercial_airway', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork(label_max_length=-50)
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertEqual(edge['1']['label'], '...')
+        self.assertEqual(edge['1']['title'], 'commercial_airway')
+
     def test_add_multiple_edges_with_edge_property_string(self):
         vertex1 = Vertex(id='1')
         vertex2 = Vertex(id='2')
@@ -1041,7 +1069,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex2)
         gn.add_path_edge(edge1, from_id='1', to_id='2')
         edge = gn.graph.get_edge_data('1', '2')
-        self.assertEqual(edge['1']['label'], "['foo', 'bar']")
+        self.assertEqual(edge['1']['label'], "['foo',...")
 
     def test_add_single_edge_with_edge_property_json_and_multiproperty_access_with_non_multiproperty(self):
         vertex1 = Vertex(id='1')

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -75,6 +75,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         expected_data = {
             'data': {
                 "label": 'route',
+                "title": 'route',
                 "properties": {
                     "~id": "7389",
                     "~entityType": "relationship",
@@ -85,6 +86,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
                 }
             },
             'label': 'route',
+            'title': 'route',
             'from_id': "22",
             'to_id': '151',
             'edge_id': '7389'

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -2397,7 +2397,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         edge_route = gn.graph.get_edge_data('365', '136', '30601')
         self.assertEqual(edge_route['label'], 'route')
 
-    def test_set_edge_label_length(self):
+    def test_set_relation_label_length_full(self):
         path = {
             "results": [
                 {
@@ -2440,10 +2440,108 @@ class TestOpenCypherNetwork(unittest.TestCase):
             ]
         }
 
-        gn = OCNetwork(label_max_length=4)
+        gn = OCNetwork(rel_label_max_length=5)
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], 'route')
+        self.assertEqual(edge_route['title'], 'route')
+
+    def test_set_relation_label_length_truncated(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(rel_label_max_length=4)
         gn.add_results(path)
         edge_route = gn.graph.get_edge_data('365', '136', '30601')
         self.assertEqual(edge_route['label'], 'r...')
+        self.assertEqual(edge_route['title'], 'route')
+
+    def test_set_relation_label_length_less_than_3(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(rel_label_max_length=-100)
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], '...')
         self.assertEqual(edge_route['title'], 'route')
 
     def test_add_multiple_edge_with_property_string(self):

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -2251,7 +2251,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn = OCNetwork(edge_display_property='{"route":"endpoints"}')
         gn.add_results(path)
         edge_route = gn.graph.get_edge_data('365', '136', '30601')
-        self.assertEqual(edge_route['label'], "['365', '136']")
+        self.assertEqual(edge_route['label'], "['365',...")
 
     def test_add_edge_with_property_json_and_multiproperty_access_with_non_multiproperty(self):
         path = {
@@ -2396,6 +2396,55 @@ class TestOpenCypherNetwork(unittest.TestCase):
         gn.add_results(path)
         edge_route = gn.graph.get_edge_data('365', '136', '30601')
         self.assertEqual(edge_route['label'], 'route')
+
+    def test_set_edge_label_length(self):
+        path = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "365",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "CZM",
+                            }
+                        },
+                        {
+                            "~id": "30601",
+                            "~entityType": "relationship",
+                            "~start": "365",
+                            "~end": "136",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 792,
+                                "endpoints": ['365', '136']
+                            }
+                        },
+                        {
+                            "~id": "136",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "runways": 2,
+                                "code": "MEX",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(label_max_length=4)
+        gn.add_results(path)
+        edge_route = gn.graph.get_edge_data('365', '136', '30601')
+        self.assertEqual(edge_route['label'], 'r...')
+        self.assertEqual(edge_route['title'], 'route')
 
     def test_add_multiple_edge_with_property_string(self):
         path = {

--- a/test/unit/network/sparql/test_sparql_network.py
+++ b/test/unit/network/sparql/test_sparql_network.py
@@ -190,11 +190,11 @@ class TestSPARQLNetwork(unittest.TestCase):
         self.assertEqual('resource:24', node['title'])
 
     def test_sparql_network_label_length_truncated(self):
-        sparql_network = SPARQLNetwork(label_max_length=10)
+        sparql_network = SPARQLNetwork(label_max_length=5)
         data = get_sparql_result('008_duplicate_s_and_p_bindings.json')
         sparql_network.add_results(data)
         node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
-        self.assertEqual('resourc...', node['label'])
+        self.assertEqual('re...', node['label'])
         self.assertEqual('resource:24', node['title'])
 
 

--- a/test/unit/network/sparql/test_sparql_network.py
+++ b/test/unit/network/sparql/test_sparql_network.py
@@ -181,6 +181,22 @@ class TestSPARQLNetwork(unittest.TestCase):
         self.assertEqual(['value1', 'value2'], node['properties']['example:prop'])
         self.assertEqual(['value3', 'value4'], node['properties']['propLiteral'])
 
+    def test_sparql_network_label_length_full(self):
+        sparql_network = SPARQLNetwork(label_max_length=20)
+        data = get_sparql_result('008_duplicate_s_and_p_bindings.json')
+        sparql_network.add_results(data)
+        node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
+        self.assertEqual('resource:24', node['label'])
+        self.assertEqual('resource:24', node['title'])
+
+    def test_sparql_network_label_length_truncated(self):
+        sparql_network = SPARQLNetwork(label_max_length=10)
+        data = get_sparql_result('008_duplicate_s_and_p_bindings.json')
+        sparql_network.add_results(data)
+        node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
+        self.assertEqual('resourc...', node['label'])
+        self.assertEqual('resource:24', node['title'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/network/test_eventful_network.py
+++ b/test/unit/network/test_eventful_network.py
@@ -69,6 +69,7 @@ class TestEventfulNetwork(TestCase):
                 'to_id': to_id,
                 'edge_id': edge_id,
                 'label': edge_label,
+                'title': edge_label,
                 'data': edge_data
             }
             self.assertEqual(expected_payload, data)
@@ -78,7 +79,7 @@ class TestEventfulNetwork(TestCase):
         en = EventfulNetwork(callbacks={EVENT_ADD_EDGE: [add_edge_callback]})
         en.add_node(from_id)
         en.add_node(to_id)
-        en.add_edge(from_id, to_id, edge_id, edge_label, edge_data)
+        en.add_edge(from_id=from_id, to_id=to_id, edge_id=edge_id, label=edge_label, title=edge_label, data=edge_data)
         self.assertTrue(callback_reached[EVENT_ADD_EDGE])
 
     def test_add_node_data_callback_dispatched(self):


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added edge tooltips matching the corresponding edge label, displayed when hovering over any graph edge.
- Added new `-le`/`--edge-label-max-length` (`-rel`/`--rel-label-max-length` for `%%oc`) parameter to query magics for extending and truncating edge labels
- Added the vertex-specific `--label-max-length` parameter to `%%sparql`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.