### PR TITLE
Make Gremlin traversal source configurable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Added support for specifying the Gremlin traversal source ([Link to PR](https://github.com/aws/graph-notebook/pull/221))
 
 ## Release 3.0.7 (October 25, 2021)
 - Added full support for NeptuneML API command parameters to `%neptune_ml` ([Link to PR](https://github.com/aws/graph-notebook/pull/202))

--- a/README.md
+++ b/README.md
@@ -124,14 +124,17 @@ python -m graph_notebook.start_notebook --notebooks-dir ~/notebook/destination/d
 
 ### Gremlin Server
 
-In a new cell in the Jupyter notebook, change the configuration using `%%graph_notebook_config` and modify the fields for `host`, `port`, and `ssl`.  For a local Gremlin server (HTTP or WebSockets), you can use the following command:
+In a new cell in the Jupyter notebook, change the configuration using `%%graph_notebook_config` and modify the fields for `host`, `port`, and `ssl`. Optionally, modify `traversal_source` if your graph traversal source name differs from the default value. For a local Gremlin server (HTTP or WebSockets), you can use the following command:
 
 ```
 %%graph_notebook_config
 {
   "host": "localhost",
   "port": 8182,
-  "ssl": false
+  "ssl": false,
+  "gremlin": {
+    "traversal_source": "g"
+  }
 }
 ```
 

--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -42,15 +42,36 @@ class SparqlSection(object):
         return self.__dict__
 
 
+class GremlinSection(object):
+    """
+    Used for gremlin-specific settings in a notebook's configuration
+    """
+
+    def __init__(self, traversal_source: str = ''):
+        """
+        :param traversal_source: used to specify the traversal source for a Gremlin traversal, in the case that we are
+        connected to an endpoint that can access multiple graphs.
+        """
+
+        if traversal_source == '':
+            traversal_source = 'g'
+
+        self.traversal_source = traversal_source
+
+    def to_dict(self):
+        return self.__dict__
+
+
 class Configuration(object):
     def __init__(self, host: str, port: int,
                  auth_mode: AuthModeEnum = AuthModeEnum.DEFAULT,
                  load_from_s3_arn='', ssl: bool = True, aws_region: str = 'us-east-1',
-                 sparql_section: SparqlSection = None):
+                 sparql_section: SparqlSection = None, gremlin_section: GremlinSection = None):
         self.host = host
         self.port = port
         self.ssl = ssl
         self.sparql = sparql_section if sparql_section is not None else SparqlSection()
+        self.gremlin = gremlin_section if gremlin_section is not None else GremlinSection()
         if ".neptune.amazonaws.com" in self.host:
             self.is_neptune_config = True
             self.auth_mode = auth_mode
@@ -68,14 +89,16 @@ class Configuration(object):
                 'load_from_s3_arn': self.load_from_s3_arn,
                 'ssl': self.ssl,
                 'aws_region': self.aws_region,
-                'sparql': self.sparql.to_dict()
+                'sparql': self.sparql.to_dict(),
+                'gremlin': self.gremlin.to_dict()
             }
         else:
             return {
                 'host': self.host,
                 'port': self.port,
                 'ssl': self.ssl,
-                'sparql': self.sparql.to_dict()
+                'sparql': self.sparql.to_dict(),
+                'gremlin': self.gremlin.to_dict()
             }
 
     def write_to_file(self, file_path=DEFAULT_CONFIG_LOCATION):

--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -71,14 +71,15 @@ class Configuration(object):
         self.port = port
         self.ssl = ssl
         self.sparql = sparql_section if sparql_section is not None else SparqlSection()
-        self.gremlin = gremlin_section if gremlin_section is not None else GremlinSection()
         if ".neptune.amazonaws.com" in self.host:
             self.is_neptune_config = True
             self.auth_mode = auth_mode
             self.load_from_s3_arn = load_from_s3_arn
             self.aws_region = aws_region
+            self.gremlin = GremlinSection()
         else:
             self.is_neptune_config = False
+            self.gremlin = gremlin_section if gremlin_section is not None else GremlinSection()
 
     def to_dict(self) -> dict:
         if self.is_neptune_config:

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -13,6 +13,8 @@ def get_config_from_dict(data: dict) -> Configuration:
     sparql_section = SparqlSection(**data['sparql']) if 'sparql' in data else SparqlSection('')
     gremlin_section = GremlinSection(**data['gremlin']) if 'gremlin' in data else GremlinSection('')
     if ".neptune.amazonaws.com" in data['host']:
+        if gremlin_section.to_dict()['traversal_source'] != 'g':
+            print('Ignoring custom traversal source, Amazon Neptune does not support this functionality.\n')
         config = Configuration(host=data['host'], port=data['port'], auth_mode=AuthModeEnum(data['auth_mode']),
                                ssl=data['ssl'], load_from_s3_arn=data['load_from_s3_arn'],
                                aws_region=data['aws_region'], sparql_section=sparql_section,

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -6,17 +6,20 @@ SPDX-License-Identifier: Apache-2.0
 import json
 
 from graph_notebook.configuration.generate_config import DEFAULT_CONFIG_LOCATION, Configuration, AuthModeEnum, \
-    SparqlSection
+    SparqlSection, GremlinSection
 
 
 def get_config_from_dict(data: dict) -> Configuration:
     sparql_section = SparqlSection(**data['sparql']) if 'sparql' in data else SparqlSection('')
+    gremlin_section = GremlinSection(**data['gremlin']) if 'gremlin' in data else GremlinSection('')
     if ".neptune.amazonaws.com" in data['host']:
         config = Configuration(host=data['host'], port=data['port'], auth_mode=AuthModeEnum(data['auth_mode']),
                                ssl=data['ssl'], load_from_s3_arn=data['load_from_s3_arn'],
-                               aws_region=data['aws_region'], sparql_section=sparql_section)
+                               aws_region=data['aws_region'], sparql_section=sparql_section,
+                               gremlin_section=gremlin_section)
     else:
-        config = Configuration(host=data['host'], port=data['port'], ssl=data['ssl'], sparql_section=sparql_section)
+        config = Configuration(host=data['host'], port=data['port'], ssl=data['ssl'], sparql_section=sparql_section,
+                               gremlin_section=gremlin_section)
     return config
 
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -163,7 +163,8 @@ class Graph(Magics):
                 .with_port(config.port) \
                 .with_region(config.aws_region) \
                 .with_tls(config.ssl) \
-                .with_sparql_path(config.sparql.path)
+                .with_sparql_path(config.sparql.path) \
+                .with_gremlin_traversal_source(config.gremlin.traversal_source)
             if config.auth_mode == AuthModeEnum.IAM:
                 builder = builder.with_iam(get_session())
         else:

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -163,8 +163,7 @@ class Graph(Magics):
                 .with_port(config.port) \
                 .with_region(config.aws_region) \
                 .with_tls(config.ssl) \
-                .with_sparql_path(config.sparql.path) \
-                .with_gremlin_traversal_source(config.gremlin.traversal_source)
+                .with_sparql_path(config.sparql.path)
             if config.auth_mode == AuthModeEnum.IAM:
                 builder = builder.with_iam(get_session())
         else:
@@ -172,7 +171,8 @@ class Graph(Magics):
                 .with_host(config.host) \
                 .with_port(config.port) \
                 .with_tls(config.ssl) \
-                .with_sparql_path(config.sparql.path)
+                .with_sparql_path(config.sparql.path) \
+                .with_gremlin_traversal_source(config.gremlin.traversal_source)
 
         self.client = builder.build()
 

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -79,11 +79,12 @@ STREAM_EXCEPTION_NOT_ENABLED = 'UnsupportedOperationException'
 
 class Client(object):
     def __init__(self, host: str, port: int = DEFAULT_PORT, ssl: bool = True, region: str = DEFAULT_REGION,
-                 sparql_path: str = '/sparql', auth=None, session: Session = None):
+                 sparql_path: str = '/sparql', gremlin_traversal_source: str = 'g', auth=None, session: Session = None):
         self.host = host
         self.port = port
         self.ssl = ssl
         self.sparql_path = sparql_path
+        self.gremlin_traversal_source = gremlin_traversal_source
         self.region = region
         self._auth = auth
         self._session = session
@@ -174,7 +175,8 @@ class Client(object):
         request = self._prepare_request('GET', uri)
 
         ws_url = f'{self._ws_protocol}://{self.host}:{self.port}/gremlin'
-        return client.Client(ws_url, 'g', headers=dict(request.headers))
+        # return client.Client(ws_url, 'g', headers=dict(request.headers))
+        return client.Client(ws_url, self.gremlin_traversal_source, headers=dict(request.headers))
 
     def gremlin_query(self, query, bindings=None):
         c = self.get_gremlin_connection()
@@ -665,6 +667,10 @@ class ClientBuilder(object):
 
     def with_sparql_path(self, path: str):
         self.args['sparql_path'] = path
+        return ClientBuilder(self.args)
+
+    def with_gremlin_traversal_source(self, traversal_source: str):
+        self.args['gremlin_traversal_source'] = traversal_source
         return ClientBuilder(self.args)
 
     def with_tls(self, tls: bool):

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -175,8 +175,9 @@ class Client(object):
         request = self._prepare_request('GET', uri)
 
         ws_url = f'{self._ws_protocol}://{self.host}:{self.port}/gremlin'
-        # return client.Client(ws_url, 'g', headers=dict(request.headers))
-        return client.Client(ws_url, self.gremlin_traversal_source, headers=dict(request.headers))
+
+        traversal_source = 'g' if "neptune.amazonaws.com" in self.host else self.gremlin_traversal_source
+        return client.Client(ws_url, traversal_source, headers=dict(request.headers))
 
     def gremlin_query(self, query, bindings=None):
         c = self.get_gremlin_connection()

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -13,6 +13,7 @@ from botocore.session import Session as botocoreSession
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from gremlin_python.driver import client
+from gremlin_python.driver.protocol import GremlinServerError
 from neo4j import GraphDatabase
 import nest_asyncio
 
@@ -188,6 +189,11 @@ class Client(object):
             c.close()
             return results
         except Exception as e:
+            if isinstance(e, GremlinServerError):
+                if e.status_code == 499:
+                    print("Error returned by the Gremlin Server for the traversal_source specified in notebook "
+                          "configuration. Please ensure that your graph database endpoint supports re-naming of "
+                          "GraphTraversalSource from the default of 'g' in Gremlin Server.")
             c.close()
             raise e
 

--- a/test/integration/IntegrationTest.py
+++ b/test/integration/IntegrationTest.py
@@ -19,7 +19,8 @@ def setup_client_builder(config: Configuration) -> ClientBuilder:
         .with_port(config.port) \
         .with_region(config.aws_region) \
         .with_tls(config.ssl) \
-        .with_sparql_path(config.sparql.path)
+        .with_sparql_path(config.sparql.path) \
+        .with_gremlin_traversal_source(config.gremlin.traversal_source)
 
     if config.auth_mode == AuthModeEnum.IAM:
         builder = builder.with_iam(get_session())

--- a/test/integration/iam/ml/__init__.py
+++ b/test/integration/iam/ml/__init__.py
@@ -16,6 +16,7 @@ def setup_iam_client(config: Configuration) -> Client:
         .with_region(config.aws_region) \
         .with_tls(config.ssl) \
         .with_sparql_path(config.sparql.path) \
+        .with_gremlin_traversal_source(config.gremlin.traversal_source) \
         .with_iam(get_session()) \
         .build()
 
@@ -23,5 +24,6 @@ def setup_iam_client(config: Configuration) -> Client:
     assert client.port == config.port
     assert client.region == config.aws_region
     assert client.sparql_path == config.sparql.path
+    assert client.gremlin_traversal_source == config.gremlin.traversal_source
     assert client.ssl is config.ssl
     return client


### PR DESCRIPTION
Issue #, if available: #206

Description of changes:
- Add new section to `%%graph_notebook_config` input for Gremlin-specific options
- Support for specifying the traversal source to use for Gremlin queries, in case the name of the traversal source differs from the previously hardcoded default of `g`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.