### PR TITLE
Fixed recognition of CN region Neptune hosts

### DIFF
--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -51,7 +51,7 @@ class Configuration(object):
         self.port = port
         self.ssl = ssl
         self.sparql = sparql_section if sparql_section is not None else SparqlSection()
-        if ".neptune.amazonaws.com" in self.host:
+        if "amazonaws.com" in self.host:
             self.is_neptune_config = True
             self.auth_mode = auth_mode
             self.load_from_s3_arn = load_from_s3_arn

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -11,7 +11,7 @@ from graph_notebook.configuration.generate_config import DEFAULT_CONFIG_LOCATION
 
 def get_config_from_dict(data: dict) -> Configuration:
     sparql_section = SparqlSection(**data['sparql']) if 'sparql' in data else SparqlSection('')
-    if ".neptune.amazonaws.com" in data['host']:
+    if "amazonaws.com" in data['host']:
         config = Configuration(host=data['host'], port=data['port'], auth_mode=AuthModeEnum(data['auth_mode']),
                                ssl=data['ssl'], load_from_s3_arn=data['load_from_s3_arn'],
                                aws_region=data['aws_region'], sparql_section=sparql_section)

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -157,7 +157,7 @@ class Graph(Magics):
         if self.client:
             self.client.close()
 
-        if ".neptune.amazonaws.com" in config.host:
+        if "amazonaws.com" in config.host:
             builder = ClientBuilder() \
                 .with_host(config.host) \
                 .with_port(config.port) \

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -126,7 +126,7 @@ class Client(object):
             sparql_path = f'/{path}'
         elif self.sparql_path != '':
             sparql_path = f'/{self.sparql_path}'
-        elif "neptune.amazonaws.com" in self.host:
+        elif "amazonaws.com" in self.host:
             sparql_path = f'/{SPARQL_ACTION}'
         else:
             sparql_path = ''

--- a/src/graph_notebook/notebooks/04-Machine-Learning/neptune_ml_utils.py
+++ b/src/graph_notebook/notebooks/04-Machine-Learning/neptune_ml_utils.py
@@ -43,7 +43,7 @@ def load_configuration():
         data = json.load(f)
         host = data['host']
         port = data['port']
-        if data['auth_mode'] == 'IAM':
+        if data.get('auth_mode') == 'IAM':
             iam = True
         else:
             iam = False

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -14,7 +14,8 @@ class TestGenerateConfiguration(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.generic_host = 'blah'
-        cls.neptune_host = 'instance.cluster.us-west-2.neptune.amazonaws.com'
+        cls.neptune_host_reg = 'instance.cluster.us-west-2.neptune.amazonaws.com'
+        cls.neptune_host_cn = 'instance.cluster.neptune.cn-north-1.amazonaws.com.cn'
         cls.port = 8182
         cls.test_file_path = f'{os.path.abspath(os.path.curdir)}/test_configuration_file.json'
 
@@ -22,9 +23,17 @@ class TestGenerateConfiguration(unittest.TestCase):
         if os.path.exists(self.test_file_path):
             os.remove(self.test_file_path)
 
-    def test_configuration_default_auth_defaults_neptune(self):
-        config = Configuration(self.neptune_host, self.port)
-        self.assertEqual(self.neptune_host, config.host)
+    def test_configuration_default_auth_defaults_neptune_reg(self):
+        config = Configuration(self.neptune_host_reg, self.port)
+        self.assertEqual(self.neptune_host_reg, config.host)
+        self.assertEqual(self.port, config.port)
+        self.assertEqual(DEFAULT_AUTH_MODE, config.auth_mode)
+        self.assertEqual(True, config.ssl)
+        self.assertEqual('', config.load_from_s3_arn)
+
+    def test_configuration_default_auth_defaults_neptune_cn(self):
+        config = Configuration(self.neptune_host_cn, self.port)
+        self.assertEqual(self.neptune_host_cn, config.host)
         self.assertEqual(self.port, config.port)
         self.assertEqual(DEFAULT_AUTH_MODE, config.auth_mode)
         self.assertEqual(True, config.ssl)
@@ -36,11 +45,20 @@ class TestGenerateConfiguration(unittest.TestCase):
         self.assertEqual(self.port, config.port)
         self.assertEqual(True, config.ssl)
 
-    def test_configuration_override_defaults_neptune(self):
+    def test_configuration_override_defaults_neptune_reg(self):
         auth_mode = AuthModeEnum.IAM
         ssl = False
         loader_arn = 'foo'
-        config = Configuration(self.neptune_host, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn, ssl=ssl)
+        config = Configuration(self.neptune_host_reg, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn, ssl=ssl)
+        self.assertEqual(auth_mode, config.auth_mode)
+        self.assertEqual(ssl, config.ssl)
+        self.assertEqual(loader_arn, config.load_from_s3_arn)
+
+    def test_configuration_override_defaults_neptune_cn(self):
+        auth_mode = AuthModeEnum.IAM
+        ssl = False
+        loader_arn = 'foo'
+        config = Configuration(self.neptune_host_cn, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn, ssl=ssl)
         self.assertEqual(auth_mode, config.auth_mode)
         self.assertEqual(ssl, config.ssl)
         self.assertEqual(loader_arn, config.load_from_s3_arn)
@@ -50,8 +68,16 @@ class TestGenerateConfiguration(unittest.TestCase):
         config = Configuration(self.generic_host, self.port, ssl=ssl)
         self.assertEqual(ssl, config.ssl)
 
-    def test_generate_configuration_with_defaults_neptune(self):
-        config = Configuration(self.neptune_host, self.port)
+    def test_generate_configuration_with_defaults_neptune_reg(self):
+        config = Configuration(self.neptune_host_reg, self.port)
+        c = generate_config(config.host, config.port, auth_mode=config.auth_mode, ssl=config.ssl,
+                            load_from_s3_arn=config.load_from_s3_arn, aws_region=config.aws_region)
+        c.write_to_file(self.test_file_path)
+        config_from_file = get_config(self.test_file_path)
+        self.assertEqual(config.to_dict(), config_from_file.to_dict())
+
+    def test_generate_configuration_with_defaults_neptune_cn(self):
+        config = Configuration(self.neptune_host_cn, self.port)
         c = generate_config(config.host, config.port, auth_mode=config.auth_mode, ssl=config.ssl,
                             load_from_s3_arn=config.load_from_s3_arn, aws_region=config.aws_region)
         c.write_to_file(self.test_file_path)
@@ -65,12 +91,26 @@ class TestGenerateConfiguration(unittest.TestCase):
         config_from_file = get_config(self.test_file_path)
         self.assertEqual(config.to_dict(), config_from_file.to_dict())
 
-    def test_generate_configuration_override_defaults_neptune(self):
+    def test_generate_configuration_override_defaults_neptune_reg(self):
         auth_mode = AuthModeEnum.IAM
         ssl = False
         loader_arn = 'foo'
         aws_region = 'us-west-2'
-        config = Configuration(self.neptune_host, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn, ssl=ssl,
+        config = Configuration(self.neptune_host_reg, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn, ssl=ssl,
+                               aws_region=aws_region)
+
+        c = generate_config(config.host, config.port, auth_mode=config.auth_mode, ssl=config.ssl,
+                            load_from_s3_arn=config.load_from_s3_arn, aws_region=config.aws_region)
+        c.write_to_file(self.test_file_path)
+        config_from_file = get_config(self.test_file_path)
+        self.assertEqual(config.to_dict(), config_from_file.to_dict())
+
+    def test_generate_configuration_override_defaults_neptune_cn(self):
+        auth_mode = AuthModeEnum.IAM
+        ssl = False
+        loader_arn = 'foo'
+        aws_region = 'cn-north-1'
+        config = Configuration(self.neptune_host_cn, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn, ssl=ssl,
                                aws_region=aws_region)
 
         c = generate_config(config.host, config.port, auth_mode=config.auth_mode, ssl=config.ssl,

--- a/test/unit/configuration/test_configuration_from_main.py
+++ b/test/unit/configuration/test_configuration_from_main.py
@@ -14,7 +14,8 @@ class TestGenerateConfigurationMain(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.generic_host = 'blah'
-        cls.neptune_host = 'instance.cluster.us-west-2.neptune.amazonaws.com'
+        cls.neptune_host_reg = 'instance.cluster.us-west-2.neptune.amazonaws.com'
+        cls.neptune_host_cn = 'instance.cluster.neptune.cn-north-1.amazonaws.com.cn'
         cls.port = 8182
         cls.test_file_path = f'{os.path.abspath(os.path.curdir)}/test_generate_from_main.json'
         cls.python_cmd = os.environ.get('PYTHON_CMD', 'python3')  # environment variable to let ToD hosts specify
@@ -24,17 +25,33 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         if os.path.exists(self.test_file_path):
             os.remove(self.test_file_path)
 
-    def test_generate_configuration_main_defaults_neptune(self):
-        expected_config = Configuration(self.neptune_host, self.port, auth_mode=AuthModeEnum.DEFAULT,
-                                        load_from_s3_arn='', ssl=True)
+    def test_generate_configuration_main_defaults_neptune_reg(self):
+        expected_config = Configuration(self.neptune_host_reg,
+                                        self.port,
+                                        auth_mode=AuthModeEnum.DEFAULT,
+                                        load_from_s3_arn='',
+                                        ssl=True)
+        self.generate_config_from_main_and_test(expected_config, host_type='neptune')
+
+    def test_generate_configuration_main_defaults_neptune_cn(self):
+        expected_config = Configuration(self.neptune_host_cn,
+                                        self.port,
+                                        auth_mode=AuthModeEnum.DEFAULT,
+                                        load_from_s3_arn='',
+                                        ssl=True)
         self.generate_config_from_main_and_test(expected_config, host_type='neptune')
 
     def test_generate_configuration_main_defaults_generic(self):
         expected_config = Configuration(self.generic_host, self.port, ssl=True)
         self.generate_config_from_main_and_test(expected_config)
 
-    def test_generate_configuration_main_override_defaults_neptune(self):
-        expected_config = Configuration(self.neptune_host, self.port, auth_mode=AuthModeEnum.IAM,
+    def test_generate_configuration_main_override_defaults_neptune_reg(self):
+        expected_config = Configuration(self.neptune_host_reg, self.port, auth_mode=AuthModeEnum.IAM,
+                                        load_from_s3_arn='loader_arn', ssl=False)
+        self.generate_config_from_main_and_test(expected_config, host_type='neptune')
+
+    def test_generate_configuration_main_override_defaults_neptune_cn(self):
+        expected_config = Configuration(self.neptune_host_cn, self.port, auth_mode=AuthModeEnum.IAM,
                                         load_from_s3_arn='loader_arn', ssl=False)
         self.generate_config_from_main_and_test(expected_config, host_type='neptune')
 
@@ -43,7 +60,7 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         self.generate_config_from_main_and_test(expected_config)
 
     def test_generate_configuration_main_empty_args_neptune(self):
-        expected_config = Configuration(self.neptune_host, self.port)
+        expected_config = Configuration(self.neptune_host_reg, self.port)
         result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '
                            f'--host "{expected_config.host}" --port "{expected_config.port}" --auth_mode "" --ssl "" '
                            f'--load_from_s3_arn "" --config_destination="{self.test_file_path}" ')


### PR DESCRIPTION
Issue #, if available: #222

Description of changes:
- Fixed an issue where mandatory AWS configuration settings were being set correctly when setting `host` to a CN region Neptune cluster endpoint

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.