### PR TITLE
Pin Jedi version to <0.18.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
+## Upcoming
+- Fixed error causing query autocompletion to fail ([Link to PR](https://github.com/aws/graph-notebook/pull/231))
+
 ## Release 3.0.8 (November 3, 2021)
 - Added support for specifying the Gremlin traversal source ([Link to PR](https://github.com/aws/graph-notebook/pull/221))
 - Added edge tooltips, and options for specifying edge label length ([Link to PR](https://github.com/aws/graph-notebook/pull/218))

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ rdflib~=5.0.0
 traitlets~=4.3.3
 setuptools~=40.6.2
 nbconvert<6
+jedi<0.18.0
 
 # requirements for testing
 botocore~=1.18.18

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ setup(
         'neo4j==4.3.2',
         'rdflib==5.0.0',
         'ipykernel==5.3.4',
-        'nbconvert==5.6.1'
+        'nbconvert==5.6.1',
+        'jedi<0.18.0'
     ],
     package_data={
         'graph_notebook': ['graph_notebook/widgets/nbextensions/static/*.js',


### PR DESCRIPTION
Issue #, if available: #229

Description of changes:
- Pinned Jedi version in setup to patch a dependency bug in `ipython<=7.19`. This resolves exceptions thrown when attempting to use the tab auto-completion hints in a query cell. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.