### PR TITLE
Fix possible FileNotFoundError in Jupyter startup script

### DIFF
--- a/src/graph_notebook/start_notebook.py
+++ b/src/graph_notebook/start_notebook.py
@@ -8,8 +8,9 @@ import argparse
 import json
 
 HOME_PATH = os.path.expanduser("~")
-NOTEBOOK_CFG_PATH = HOME_PATH + '/.jupyter/nbconfig/notebook.json'
-
+NBCONFIG_DIR_TREE = HOME_PATH + '/.jupyter/nbconfig'
+CFG_FILE_NAME = 'notebook.json'
+NOTEBOOK_CFG_PATH = NBCONFIG_DIR_TREE + '/' + CFG_FILE_NAME
 
 def patch_cm_cypher_config():
     cypher_cfg = {
@@ -19,6 +20,7 @@ def patch_cm_cypher_config():
     }
 
     try:
+        os.makedirs(NBCONFIG_DIR_TREE, exist_ok=True)
         with open(NOTEBOOK_CFG_PATH, 'r') as file:
             notebook_cfg = json.load(file)
     except (json.decoder.JSONDecodeError, FileNotFoundError) as e:


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Covered cases where the `~/.jupyter/nbconfig` directory does not exist when attempting to launch with `start_notebook.py`. If missing, this directory tree will now be generated prior modifying/creating the `notebook.json` configuration file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.