### PR TITLE
Upgrade json-schema version to fix vulnerability

### DIFF
--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -32,7 +32,7 @@
     "eslint-loader": "4.0.2",
     "eslint-plugin-prettier": "3.1.3",
     "fs-extra": "9.0.0",
-    "json-schema": "0.2.5",
+    "json-schema": "0.4.0",
     "karma": "5.0.5",
     "karma-chai": "0.1.0",
     "karma-firefox-launcher": "1.3.0",


### PR DESCRIPTION
Issue #, if available: CVE-2021-3918

Description of changes:
- Move to `json-schema==0.4.0` to resolve a Dependabot alert

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.