### PR TITLE
Fix OC group-by-label, add OC group-by-depth

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -258,7 +258,7 @@ class Graph(Magics):
         parser.add_argument('-t', '--tooltip-property', type=str, default='',
                             help='Property to display the value of on each node tooltip.')
         parser.add_argument('-te', '--edge-tooltip-property', type=str, default='',
-                            help='Property to display the value of on each node tooltip.')
+                            help='Property to display the value of on each edge tooltip.')
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
                             help='Specifies max length of vertex labels, in characters. Default is 10')
         parser.add_argument('-le', '--edge-label-max-length', type=int, default=10,
@@ -447,7 +447,7 @@ class Graph(Magics):
                             help='Property to display the value of on each node tooltip. If not specified, tooltip '
                                  'will default to the node label value.')
         parser.add_argument('-te', '--edge-tooltip-property', type=str, default='',
-                            help='Property to display the value of on each node tooltip. If not specified, tooltip '
+                            help='Property to display the value of on each edge tooltip. If not specified, tooltip '
                                  'will default to the edge label value.')
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
                             help='Specifies max length of vertex label, in characters. Default is 10')
@@ -1591,7 +1591,7 @@ class Graph(Magics):
                             help='Property to display the value of on each node tooltip. If not specified, tooltip '
                                  'will default to the node label value.')
         parser.add_argument('-te', '--edge-tooltip-property', type=str, default='',
-                            help='Property to display the value of on each node tooltip. If not specified, tooltip '
+                            help='Property to display the value of on each edge tooltip. If not specified, tooltip '
                                  'will default to the edge label value.')
         parser.add_argument('-l', '--label-max-length', type=int, default=10,
                             help='Specifies max length of vertex label, in characters. Default is 10')

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -480,6 +480,75 @@ class TestOpenCypherNetwork(unittest.TestCase):
         self.assertEqual(node1['group'], 'US-AK')
         self.assertEqual(node2['group'], 'US-TX')
 
+    def test_group_with_groupby_depth(self):
+        res = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "3",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Austin Bergstrom International Airport",
+                            }
+                        },
+                        {
+                            "~id": "3820",
+                            "~entityType": "relationship",
+                            "~start": "3",
+                            "~end": "23",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 1500
+                            }
+                        },
+                        {
+                            "~id": "23",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "San Francisco International Airport",
+                            }
+                        },
+                        {
+                            "~id": "7541",
+                            "~entityType": "relationship",
+                            "~start": "23",
+                            "~end": "55",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 7420
+                            }
+                        },
+                        {
+                            "~id": "55",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Sydney Kingsford Smith",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(group_by_property='TRAVERSAL_DEPTH')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('3')
+        node2 = gn.graph.nodes.get('23')
+        node3 = gn.graph.nodes.get('55')
+        self.assertEqual(node1['group'], '__DEPTH-0__')
+        self.assertEqual(node2['group'], '__DEPTH-1__')
+        self.assertEqual(node3['group'], '__DEPTH-2__')
+
     def test_path_with_default_groupby(self):
         res = {
             "results": [
@@ -600,10 +669,151 @@ class TestOpenCypherNetwork(unittest.TestCase):
             ]
         }
 
-        gn = OCNetwork(group_by_property='{"airport":{"groupby":"code"}}')
+        gn = OCNetwork(group_by_property='{"airport":"code"}')
         gn.add_results(res)
         node1 = gn.graph.nodes.get('22')
         self.assertEqual(node1['group'], 'SEA')
+
+    def test_group_with_groupby_properties_json_label_value(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+
+        gn = OCNetwork(group_by_property='{"airport":"~labels"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['group'], 'airport')
+
+    def test_group_with_groupby_properties_json_ID_value(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+
+        gn = OCNetwork(group_by_property='{"airport":"~id"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['group'], '22')
+
+    def test_group_with_groupby_properties_json_depth(self):
+        res = {
+            "results": [
+                {
+                    "p": [
+                        {
+                            "~id": "3",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Austin Bergstrom International Airport",
+                            }
+                        },
+                        {
+                            "~id": "3820",
+                            "~entityType": "relationship",
+                            "~start": "3",
+                            "~end": "23",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 1500
+                            }
+                        },
+                        {
+                            "~id": "23",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "San Francisco International Airport",
+                            }
+                        },
+                        {
+                            "~id": "7541",
+                            "~entityType": "relationship",
+                            "~start": "23",
+                            "~end": "55",
+                            "~type": "route",
+                            "~properties": {
+                                "dist": 7420
+                            }
+                        },
+                        {
+                            "~id": "55",
+                            "~entityType": "node",
+                            "~labels": [
+                                "airport"
+                            ],
+                            "~properties": {
+                                "desc": "Sydney Kingsford Smith",
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+
+        gn = OCNetwork(group_by_property='{"airport":"TRAVERSAL_DEPTH"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('3')
+        node2 = gn.graph.nodes.get('23')
+        node3 = gn.graph.nodes.get('55')
+        self.assertEqual(node1['group'], '__DEPTH-0__')
+        self.assertEqual(node2['group'], '__DEPTH-1__')
+        self.assertEqual(node3['group'], '__DEPTH-2__')
+
+    def test_group_with_groupby_properties_json_invalid(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+
+        gn = OCNetwork(group_by_property='{"airport":"elevation"}')
+        gn.add_results(res)
+        node1 = gn.graph.nodes.get('22')
+        self.assertEqual(node1['group'], 'DEFAULT_GROUP')
 
     def test_group_with_groupby_properties_json_multiple_labels(self):
         path = {
@@ -654,7 +864,7 @@ class TestOpenCypherNetwork(unittest.TestCase):
             ]
         }
 
-        gn = OCNetwork(group_by_property='{"airport":{"groupby":"code"},"country":{"groupby":"desc"}}')
+        gn = OCNetwork(group_by_property='{"airport":"code","country":"desc"}')
         gn.add_results(path)
         node1 = gn.graph.nodes.get('2')
         node2 = gn.graph.nodes.get('3670')


### PR DESCRIPTION
Issue #, if available: #147

Description of changes:
- Modified `--group-by` on label for openCypher to bring it line with SPARQL and Gremlin (I.e. switched syntax from `{"airport":{"groupby":"code"}}` to `{"airport":"code"}`)
- Added grouping by node depth for openCypher queries. To color nodes bases on depth, the query must return a set of paths in list format, and users must specify `TRAVERSAL_DEPTH` as the grouping property. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.