### PR TITLE
Pin ipython<7.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jupyter-contrib-nbextensions
 widgetsnbextension
 gremlinpython>=3.5.1
 requests==2.24.0
-ipython>=7.16.1
+ipython>=7.16.1,<7.17.0
 ipykernel==5.3.4
 neo4j==4.2.1
 rdflib~=5.0.0

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'requests-aws4auth==1.0.1',
         'botocore>=1.19.37',
         'boto3>=1.17.58',
-        'ipython>=7.16.1,<=7.19.0',
+        'ipython>=7.16.1,<7.17.0',
         'neo4j==4.3.2',
         'rdflib==5.0.0',
         'ipykernel==5.3.4',


### PR DESCRIPTION
Issue #, if available: GHSA-pq7m-3gw7-gq5x

Description of changes:
- Reduce upper bound of to `ipython` dependency to `<7.17.0` to resolve a vulnerability. Not upgrading to version `>=7.31.1` at this time to maintain support for Python 3.6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.