### PR TITLE
Add groupby raw node result option

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -260,6 +260,8 @@ class Graph(Magics):
                             choices=['text/csv', 'text/html'])
         parser.add_argument('-g', '--group-by', type=str, default='',
                             help='Property used to group nodes.')
+        parser.add_argument('-gr', '--group-by-raw', action='store_true', default=False,
+                            help="Group nodes by the raw binding")
         parser.add_argument('-d', '--display-property', type=str, default='',
                             help='Property to display the value of on each node.')
         parser.add_argument('-de', '--edge-display-property', type=str, default='',
@@ -344,7 +346,8 @@ class Graph(Magics):
                                        label_max_length=args.label_max_length,
                                        edge_label_max_length=args.edge_label_max_length,
                                        ignore_groups=args.ignore_groups,
-                                       expand_all=args.expand_all)
+                                       expand_all=args.expand_all,
+                                       group_by_raw=args.group_by_raw)
                     
                     sn.extract_prefix_declarations_from_query(cell)
                     try:
@@ -455,6 +458,8 @@ class Graph(Magics):
         parser.add_argument('-p', '--path-pattern', default='', help='path pattern')
         parser.add_argument('-g', '--group-by', type=str, default='T.label',
                             help='Property used to group nodes (e.g. code, T.region) default is T.label')
+        parser.add_argument('-gr', '--group-by-raw', action='store_true', default=False,
+                            help="Group nodes by the raw result")
         parser.add_argument('-d', '--display-property', type=str, default='T.label',
                             help='Property to display the value of on each node, default is T.label')
         parser.add_argument('-de', '--edge-display-property', type=str, default='T.label',
@@ -555,6 +560,7 @@ class Graph(Magics):
                     logger.debug(f'label_max_length: {args.label_max_length}')
                     logger.debug(f'ignore_groups: {args.ignore_groups}')
                     gn = GremlinNetwork(group_by_property=args.group_by, display_property=args.display_property,
+                                        group_by_raw=args.group_by_raw,
                                         edge_display_property=args.edge_display_property,
                                         tooltip_property=args.tooltip_property,
                                         edge_tooltip_property=args.edge_tooltip_property,
@@ -1638,6 +1644,8 @@ class Graph(Magics):
         parser = argparse.ArgumentParser()
         parser.add_argument('-g', '--group-by', type=str, default='~labels',
                             help='Property used to group nodes (e.g. code, ~id) default is ~labels')
+        parser.add_argument('-gr', '--group-by-raw', action='store_true', default=False,
+                            help="Group nodes by the raw result")
         parser.add_argument('mode', nargs='?', default='query', help='query mode [query|bolt]',
                             choices=['query', 'bolt'])
         parser.add_argument('-d', '--display-property', type=str, default='~labels',
@@ -1689,6 +1697,7 @@ class Graph(Magics):
                                                                    query_time=query_time)
                 try:
                     gn = OCNetwork(group_by_property=args.group_by, display_property=args.display_property,
+                                   group_by_raw=args.group_by_raw,
                                    edge_display_property=args.edge_display_property,
                                    tooltip_property=args.tooltip_property,
                                    edge_tooltip_property=args.edge_tooltip_property,

--- a/src/graph_notebook/network/EventfulNetwork.py
+++ b/src/graph_notebook/network/EventfulNetwork.py
@@ -18,6 +18,7 @@ EVENT_ADD_NODE_PROPERTY = 'add_node_property'
 EVENT_ADD_EDGE = 'add_edge'
 EVENT_ADD_EDGE_DATA = 'add_edge_data'
 DEFAULT_GRP = 'DEFAULT_GROUP'
+DEFAULT_RAW_GRP_KEY = '__RAW_RESULT__'
 DEFAULT_LABEL_MAX_LENGTH = 10
 
 VALID_EVENTS = [EVENT_ADD_NODE, EVENT_ADD_NODE_DATA, EVENT_ADD_NODE_PROPERTY, EVENT_ADD_EDGE, EVENT_ADD_EDGE_DATA]
@@ -41,16 +42,19 @@ class EventfulNetwork(Network):
                  edge_label_max_length: int = DEFAULT_LABEL_MAX_LENGTH, group_by_property: str = '',
                  display_property: str = '', edge_display_property: str = '',
                  tooltip_property: str = '', edge_tooltip_property: str = '',
-                 ignore_groups=False):
+                 ignore_groups=False, group_by_raw=False):
         if callbacks is None:
             callbacks = defaultdict(list)
         self.callbacks = callbacks
         self.label_max_length = 3 if label_max_length < 3 else label_max_length
         self.edge_label_max_length = 3 if edge_label_max_length < 3 else edge_label_max_length
-        try:
-            self.group_by_property = json.loads(group_by_property)
-        except (TypeError, ValueError) as e:
-            self.group_by_property = group_by_property
+        if group_by_raw:
+            self.group_by_property = DEFAULT_RAW_GRP_KEY
+        else:
+            try:
+                self.group_by_property = json.loads(group_by_property)
+            except (TypeError, ValueError) as e:
+                self.group_by_property = group_by_property
         self.display_property = self.convert_property_name(display_property)
         self.edge_display_property = self.convert_property_name(edge_display_property)
         self.tooltip_property = self.convert_property_name(tooltip_property) if tooltip_property \

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -9,7 +9,7 @@ import uuid
 import logging
 from enum import Enum
 
-from graph_notebook.network.EventfulNetwork import EventfulNetwork, DEFAULT_GRP
+from graph_notebook.network.EventfulNetwork import EventfulNetwork, DEFAULT_GRP, DEFAULT_RAW_GRP_KEY
 from gremlin_python.process.traversal import T, Direction
 from gremlin_python.structure.graph import Path, Vertex, Edge
 from networkx import MultiDiGraph
@@ -99,12 +99,13 @@ class GremlinNetwork(EventfulNetwork):
 
     def __init__(self, graph: MultiDiGraph = None, callbacks=None, label_max_length=DEFAULT_LABEL_MAX_LENGTH,
                  edge_label_max_length=DEFAULT_LABEL_MAX_LENGTH, group_by_property=T_LABEL, display_property=T_LABEL,
-                 edge_display_property=T_LABEL, tooltip_property=None, edge_tooltip_property=None, ignore_groups=False):
+                 edge_display_property=T_LABEL, tooltip_property=None, edge_tooltip_property=None, ignore_groups=False,
+                 group_by_raw=False):
         if graph is None:
             graph = MultiDiGraph()
         super().__init__(graph, callbacks, label_max_length, edge_label_max_length, group_by_property,
                          display_property, edge_display_property, tooltip_property, edge_tooltip_property,
-                         ignore_groups)
+                         ignore_groups, group_by_raw)
 
     def get_dict_element_property_value(self, element, k, temp_label, custom_property):
         property_value = None
@@ -347,7 +348,9 @@ class GremlinNetwork(EventfulNetwork):
                 using_custom_tooltip = True
             vertex_dict = v.__dict__
             if not isinstance(self.group_by_property, dict):  # Handle string format group_by
-                if str(self.group_by_property) in [T_LABEL, 'label']:  # this handles if it's just a string
+                if str(self.group_by_property) == DEFAULT_RAW_GRP_KEY:
+                    group = str(v)
+                elif str(self.group_by_property) in [T_LABEL, 'label']:  # this handles if it's just a string
                     # This sets the group key to the label if either "label" is passed in or
                     # T.label is set in order to handle the default case of grouping by label
                     # when no explicit key is specified
@@ -359,7 +362,9 @@ class GremlinNetwork(EventfulNetwork):
             else:  # handle dict format group_by
                 try:
                     if str(v.label) in self.group_by_property:
-                        if self.group_by_property[str(v.label)] in [T_LABEL, 'label']:
+                        if self.group_by_property[str(v.label)] == DEFAULT_RAW_GRP_KEY:
+                            group = str(v)
+                        elif self.group_by_property[str(v.label)] in [T_LABEL, 'label']:
                             group = v.label
                         elif self.group_by_property[str(v.label)] in [T_ID, 'id']:
                             group = v.id
@@ -416,6 +421,10 @@ class GremlinNetwork(EventfulNetwork):
             else:
                 title_plc = ''
                 group = DEFAULT_GRP
+
+            if str(self.group_by_property) == DEFAULT_RAW_GRP_KEY:
+                group = str(v)
+                group_is_set = True
             for k in v:
                 if str(k) == T_ID:
                     node_id = str(v[k])
@@ -423,7 +432,10 @@ class GremlinNetwork(EventfulNetwork):
                 if not group_is_set:
                     if isinstance(self.group_by_property, dict):
                         try:
-                            if str(k) == self.group_by_property[title_plc]:
+                            if self.group_by_property[title_plc] == DEFAULT_RAW_GRP_KEY:
+                                group = str(v)
+                                group_is_set = True
+                            elif str(k) == self.group_by_property[title_plc]:
                                 group = str(v[k])
                                 group_is_set = True
                         except KeyError:
@@ -468,8 +480,12 @@ class GremlinNetwork(EventfulNetwork):
         else:
             node_id = str(v)
             title = str(v)
+            if str(self.group_by_property) == DEFAULT_RAW_GRP_KEY:
+                group = str(v)
+            else:
+                group = DEFAULT_GRP
             label = title if len(title) <= self.label_max_length else title[:self.label_max_length - 3] + '...'
-            data = {'title': title, 'label': label, 'group': DEFAULT_GRP}
+            data = {'title': title, 'label': label, 'group': group}
 
         if self.ignore_groups:
             data['group'] = DEFAULT_GRP

--- a/src/graph_notebook/network/opencypher/OCNetwork.py
+++ b/src/graph_notebook/network/opencypher/OCNetwork.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 import json
 import logging
 
-from graph_notebook.network.EventfulNetwork import EventfulNetwork, DEFAULT_GRP
+from graph_notebook.network.EventfulNetwork import EventfulNetwork, DEFAULT_GRP, DEFAULT_RAW_GRP_KEY
 from networkx import MultiDiGraph
 
 logging.basicConfig()
@@ -35,12 +35,12 @@ class OCNetwork(EventfulNetwork):
                  edge_label_max_length=DEFAULT_LABEL_MAX_LENGTH, group_by_property=LABEL_KEY,
                  display_property=LABEL_KEY, edge_display_property=EDGE_TYPE_KEY,
                  tooltip_property=None, edge_tooltip_property=None,
-                 ignore_groups=False):
+                 ignore_groups=False, group_by_raw=False):
         if graph is None:
             graph = MultiDiGraph()
         super().__init__(graph, callbacks, label_max_length, edge_label_max_length, group_by_property,
                          display_property, edge_display_property, tooltip_property, edge_tooltip_property,
-                         ignore_groups)
+                         ignore_groups, group_by_raw)
 
     def get_node_property_value(self, node: dict, props: dict, title, custom_property):
         try:
@@ -127,7 +127,9 @@ class OCNetwork(EventfulNetwork):
 
         if not isinstance(self.group_by_property, dict):  # Handle string format group_by
             try:
-                if self.group_by_property in [LABEL_KEY, 'labels'] and len(node[LABEL_KEY]) > 0:
+                if self.group_by_property == DEFAULT_RAW_GRP_KEY:
+                    group = str(node)
+                elif self.group_by_property in [LABEL_KEY, 'labels'] and len(node[LABEL_KEY]) > 0:
                     group = node[LABEL_KEY][0]
                 elif self.group_by_property in [ID_KEY, 'id']:
                     group = node[ID_KEY]
@@ -143,7 +145,9 @@ class OCNetwork(EventfulNetwork):
             try:
                 if str(node[LABEL_KEY][0]) in self.group_by_property and len(node[LABEL_KEY]) > 0:
                     key = node[LABEL_KEY][0]
-                    if self.group_by_property[key] in [LABEL_KEY, 'labels']:
+                    if self.group_by_property[key] == DEFAULT_RAW_GRP_KEY:
+                        group = str(node)
+                    elif self.group_by_property[key] in [LABEL_KEY, 'labels']:
                         group = node[LABEL_KEY][0]
                     elif self.group_by_property[key] in [ID_KEY, 'id']:
                         group = node[ID_KEY]

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -1448,6 +1448,22 @@ class TestGremlinNetwork(unittest.TestCase):
         self.assertEqual(node1['group'], 'Seattle-Tacoma International Airport')
         self.assertEqual(node2['group'], 'Austria')
 
+    def test_group_with_groupby_raw_string(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        expected = "{<T.id: 1>: '1234', <T.label: 4>: 'airport', 'type': 'Airport', 'runways': '4', 'code': 'SEA'}"
+
+        gn = GremlinNetwork(group_by_property='__RAW_RESULT__')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['group'], expected)
+
     def test_group_with_groupby_properties_json_single_label(self):
         vertex1 = {
             T.id: '1234',
@@ -1486,6 +1502,21 @@ class TestGremlinNetwork(unittest.TestCase):
         node2 = gn.graph.nodes.get(vertex2[T.id])
         self.assertEqual(node1['group'], 'SEA')
         self.assertEqual(node2['group'], 'Europe')
+
+    def test_group_with_groupby_raw_json(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        expected = "{<T.id: 1>: '1234', <T.label: 4>: 'airport', 'type': 'Airport', 'runways': '4', 'code': 'SEA'}"
+        gn = GremlinNetwork(group_by_property='{"airport":"__RAW_RESULT__"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['group'], expected)
 
     def test_group_with_groupby_invalid_json_single_label(self):
         vertex1 = {
@@ -1949,6 +1980,36 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['group'], '1')
+
+    def test_group_by_raw_explicit(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        expected = "{<T.id: 1>: '1234', <T.label: 4>: 'airport', 'type': 'Airport', 'runways': '4', 'code': 'SEA'}"
+        gn = GremlinNetwork(group_by_raw=True)
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['group'], expected)
+
+    def test_group_by_raw_explicit_overrule_gbp(self):
+        vertex = {
+            T.id: '1234',
+            T.label: 'airport',
+            'type': 'Airport',
+            'runways': '4',
+            'code': 'SEA'
+        }
+
+        expected = "{<T.id: 1>: '1234', <T.label: 4>: 'airport', 'type': 'Airport', 'runways': '4', 'code': 'SEA'}"
+        gn = GremlinNetwork(group_by_raw=True, group_by_property='{"airport":"code"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(vertex[T.id])
+        self.assertEqual(node['group'], expected)
 
     def test_add_elementmap_edge(self):
         edge_map = {

--- a/test/unit/network/opencypher/test_opencypher_network.py
+++ b/test/unit/network/opencypher/test_opencypher_network.py
@@ -480,6 +480,114 @@ class TestOpenCypherNetwork(unittest.TestCase):
         self.assertEqual(node1['group'], 'US-AK')
         self.assertEqual(node2['group'], 'US-TX')
 
+    def test_group_by_raw_string(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+
+        expected = "{'~id': '22', '~entityType': 'node', '~labels': ['airport'], " \
+                   "'~properties': {'runways': 3, 'code': 'SEA'}}"
+
+        gn = OCNetwork(group_by_property='__RAW_RESULT__')
+        gn.add_results(res)
+        node = gn.graph.nodes.get('22')
+        self.assertEqual(node['group'], expected)
+
+    def test_group_by_raw_json(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+
+        expected = "{'~id': '22', '~entityType': 'node', '~labels': ['airport'], " \
+                   "'~properties': {'runways': 3, 'code': 'SEA'}}"
+
+        gn = OCNetwork(group_by_property='{"airport":"__RAW_RESULT__"}')
+        gn.add_results(res)
+        node = gn.graph.nodes.get('22')
+        self.assertEqual(node['group'], expected)
+
+    def test_group_by_raw_explicit(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+
+        expected = "{'~id': '22', '~entityType': 'node', '~labels': ['airport'], " \
+                   "'~properties': {'runways': 3, 'code': 'SEA'}}"
+
+        gn = OCNetwork(group_by_raw=True)
+        gn.add_results(res)
+        node = gn.graph.nodes.get('22')
+        self.assertEqual(node['group'], expected)
+
+    def test_group_by_raw_explicit_overrule_gbp(self):
+        res = {
+            "results": [
+                {
+                    "a": {
+                        "~id": "22",
+                        "~entityType": "node",
+                        "~labels": [
+                            "airport"
+                        ],
+                        "~properties": {
+                            "runways": 3,
+                            "code": "SEA"
+                        }
+                    }
+                }
+            ]
+        }
+
+        expected = "{'~id': '22', '~entityType': 'node', '~labels': ['airport'], " \
+                   "'~properties': {'runways': 3, 'code': 'SEA'}}"
+
+        gn = OCNetwork(group_by_raw=True, group_by_property='{"airport":"code"}')
+        gn.add_results(res)
+        node = gn.graph.nodes.get('22')
+        self.assertEqual(node['group'], expected)
+
     def test_group_with_groupby_depth(self):
         res = {
             "results": [

--- a/test/unit/network/sparql/test_sparql_network.py
+++ b/test/unit/network/sparql/test_sparql_network.py
@@ -239,6 +239,13 @@ class TestSPARQLNetwork(unittest.TestCase):
         node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
         self.assertEqual('uri', node['group'])
 
+    def test_sparql_network_group_by_raw_string(self):
+        sparql_network = SPARQLNetwork(group_by_raw='__RAW_RESULT__')
+        data = get_sparql_result('008_duplicate_s_and_p_bindings.json')
+        sparql_network.add_results(data)
+        node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
+        self.assertEqual("{'type': 'uri', 'value': 'http://kelvinlawrence.net/air-routes/resource/24'}", node['group'])
+
     def test_sparql_network_group_map(self):
         sparql_network = SPARQLNetwork(group_by_property='{"uri":"value"}')
         data = get_sparql_result('008_duplicate_s_and_p_bindings.json')
@@ -266,6 +273,27 @@ class TestSPARQLNetwork(unittest.TestCase):
         sparql_network.add_results(data)
         node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
         self.assertEqual('uri', node['group'])
+
+    def test_sparql_network_group_by_raw_json(self):
+        sparql_network = SPARQLNetwork(group_by_raw='{"uri":"__RAW_RESULT__"}')
+        data = get_sparql_result('008_duplicate_s_and_p_bindings.json')
+        sparql_network.add_results(data)
+        node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
+        self.assertEqual("{'type': 'uri', 'value': 'http://kelvinlawrence.net/air-routes/resource/24'}", node['group'])
+
+    def test_sparql_network_group_by_raw_explicit(self):
+        sparql_network = SPARQLNetwork(group_by_raw=True)
+        data = get_sparql_result('008_duplicate_s_and_p_bindings.json')
+        sparql_network.add_results(data)
+        node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
+        self.assertEqual("{'type': 'uri', 'value': 'http://kelvinlawrence.net/air-routes/resource/24'}", node['group'])
+
+    def test_sparql_network_group_by_raw_explicit_overrule_gbp(self):
+        sparql_network = SPARQLNetwork(group_by_raw=True, group_by_property='value')
+        data = get_sparql_result('008_duplicate_s_and_p_bindings.json')
+        sparql_network.add_results(data)
+        node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/24')
+        self.assertEqual("{'type': 'uri', 'value': 'http://kelvinlawrence.net/air-routes/resource/24'}", node['group'])
 
     def test_sparql_network_ignore_groups(self):
         sparql_network = SPARQLNetwork(group_by_property='{"uri":"value"}', ignore_groups=True)


### PR DESCRIPTION
Issue #, if available: #64

Description of changes:
- Added `-gr`/`--group-by-raw` option to `%%sparql`/`%%gremlin`/`%%oc`. If specified, nodes will be grouped based based on the raw result returned. This option will override any input to `--group-by-property`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.