### PR TITLE
Normalize stream endpoint names

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Changed the `%stream_viewer` magic to use `PropertyGraph` and `RDF` as the stream types. This better aligns with Gremlin and openCypher sharing the `PropertyGraph` stream. ([Link to PR](https://github.com/aws/graph-notebook/pull/261))
 - Updated the airports property graph seed files to the latest level and suffixed all doubles with 'd'. ([Link to PR](https://github.com/aws/graph-notebook/pull/257))
 - Added grouping by depth for Gremlin and openCypher queries ([PR #1](https://github.com/aws/graph-notebook/pull/241))([PR #2](https://github.com/aws/graph-notebook/pull/251))
 - Added grouping by raw node results ([Link to PR](https://github.com/aws/graph-notebook/pull/253))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -33,7 +33,7 @@ from graph_notebook.magics.ml import neptune_ml_magic_handler, generate_neptune_
 from graph_notebook.magics.streams import StreamViewer
 from graph_notebook.neptune.client import ClientBuilder, Client, VALID_FORMATS, PARALLELISM_OPTIONS, PARALLELISM_HIGH, \
     LOAD_JOB_MODES, MODE_AUTO, FINAL_LOAD_STATUSES, SPARQL_ACTION, FORMAT_CSV, FORMAT_OPENCYPHER, FORMAT_NTRIPLE, \
-    FORMAT_NQUADS, FORMAT_RDFXML, FORMAT_TURTLE
+    FORMAT_NQUADS, FORMAT_RDFXML, FORMAT_TURTLE, STREAM_RDF, STREAM_PG, STREAM_ENDPOINTS
 from graph_notebook.network import SPARQLNetwork
 from graph_notebook.network.gremlin.GremlinNetwork import parse_pattern_list_str, GremlinNetwork
 from graph_notebook.visualization.rows_and_columns import sparql_get_rows_and_columns, opencypher_get_rows_and_columns
@@ -227,9 +227,9 @@ class Graph(Magics):
     @line_magic
     def stream_viewer(self,line):
         parser = argparse.ArgumentParser()
-        parser.add_argument('language', type=str.lower, nargs='?', default='gremlin',
-                            help='language  (default=gremlin) [gremlin|sparql]',
-                            choices = ['gremlin','sparql'])
+        parser.add_argument('language', nargs='?', default=STREAM_PG,
+                            help=f'language  (default={STREAM_PG}) [{STREAM_PG}|{STREAM_RDF}]',
+                            choices = [STREAM_PG, STREAM_RDF])
 
         parser.add_argument('--limit', type=int, default=10, help='Maximum number of rows to display at a time')
 

--- a/src/graph_notebook/magics/streams.py
+++ b/src/graph_notebook/magics/streams.py
@@ -3,7 +3,8 @@ import json
 import ipywidgets as widgets
 import queue
 from IPython.display import display, HTML
-from graph_notebook.neptune.client import STREAM_AT, STREAM_AFTER, STREAM_TRIM, STREAM_EXCEPTION_NOT_FOUND,STREAM_EXCEPTION_NOT_ENABLED
+from graph_notebook.neptune.client import STREAM_AT, STREAM_AFTER, STREAM_TRIM, STREAM_EXCEPTION_NOT_FOUND,\
+                                          STREAM_EXCEPTION_NOT_ENABLED, STREAM_PG, STREAM_RDF, STREAM_ENDPOINTS
 
 
 class EventId:
@@ -99,7 +100,7 @@ class StreamViewer:
         self.back_button = widgets.Button(description='Back', tooltip='Back', disabled=True)
         self.back_button.layout.width = '10%'
         self.back_button.on_click(self.on_back)
-        self.dropdown = widgets.Dropdown(options=['gremlin', 'sparql'], value=language, disabled=False)
+        self.dropdown = widgets.Dropdown(options=[STREAM_PG, STREAM_RDF], value=language, disabled=False)
         self.dropdown.layout.width = '10%'
         self.dropdown.observe(self.on_dropdown_changed)
         self.out = widgets.Output()
@@ -159,6 +160,8 @@ class StreamViewer:
             self.last_displayed_event_id.update(last_event)
             
     def init_display(self, language):
+        # Map the selected stream type to the actual endpoint name
+        language = STREAM_ENDPOINTS[language] 
         self.history = queue.LifoQueue(100)
         self.back_button.disabled = True
         self.update_slider_min_max_values(language)

--- a/src/graph_notebook/magics/streams.py
+++ b/src/graph_notebook/magics/streams.py
@@ -101,7 +101,7 @@ class StreamViewer:
         self.back_button.layout.width = '10%'
         self.back_button.on_click(self.on_back)
         self.dropdown = widgets.Dropdown(options=[STREAM_PG, STREAM_RDF], value=language, disabled=False)
-        self.dropdown.layout.width = '10%'
+        self.dropdown.layout.width = '15%'
         self.dropdown.observe(self.on_dropdown_changed)
         self.out = widgets.Output()
         self.ui = widgets.HBox([self.slider, self.back_button, self.next_button, self.dropdown])

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -72,11 +72,21 @@ EXPORT_ACTION = 'neptune-export'
 EXTRA_HEADERS = {'content-type': 'application/json'}
 SPARQL_ACTION = 'sparql'
 
+# Constants used by the Stream Viewer.
 STREAM_AT = 'AT_SEQUENCE_NUMBER'
 STREAM_AFTER = 'AFTER_SEQUENCE_NUMBER'
 STREAM_TRIM = 'TRIM_HORIZON'
+STREAM_LATEST = 'LATEST'
 STREAM_EXCEPTION_NOT_FOUND = 'StreamRecordsNotFoundException'
 STREAM_EXCEPTION_NOT_ENABLED = 'UnsupportedOperationException'
+
+# A mapping from the name in the stream_viewer widget dropdown, to the actual Neptune
+# Streams endpoint (API) name. We do not map 'PropertyGraph' to 'pg' to maintain
+# compatability with older engine releases that did not have a 'pg' endpoint.
+
+STREAM_PG = 'PropertyGraph'
+STREAM_RDF = 'RDF'
+STREAM_ENDPOINTS = {STREAM_PG: 'gremlin', STREAM_RDF: 'sparql'}
 
 
 class Client(object):


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Normalize the options offered the user by the stream_viewer magic to be just `PropertyGraph` or `RDF`. These will then be mapped to either  the `gremlin` or `sparql`  Neptune Streams REST API endpoints. I did not map `PropertyGraph` to `pg` which would also work, to keep the notebooks compatible with older Neptune engine versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.