### PR TITLE
Pin markupsafe<2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ traitlets~=4.3.3
 setuptools~=40.6.2
 nbconvert<6
 jedi<0.18.0
+markupsafe<2.1.0
 
 # requirements for testing
 botocore~=1.18.18

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,8 @@ setup(
         'rdflib==5.0.0',
         'ipykernel==5.3.4',
         'nbconvert==5.6.1',
-        'jedi<0.18.0'
+        'jedi<0.18.0',
+        'markupsafe<2.1.0'
     ],
     package_data={
         'graph_notebook': ['graph_notebook/widgets/nbextensions/static/*.js',


### PR DESCRIPTION
Issue #, if available: #267

Description of changes:
- Pinned `markupsafe` dependency to `<2.1.0`. This prevents our pinned version of the `Jinja2` parent dependency from installing the latest version, `markupsafe==2.1.0`, which it is incompatible with, breaking our user installation process.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.