### PR TITLE
Bump Karma dependency to 6.3.16

### DIFF
--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-prettier": "3.1.3",
     "fs-extra": "9.0.0",
     "json-schema": "0.4.0",
-    "karma": "6.3.14",
+    "karma": "6.3.16",
     "karma-chai": "0.1.0",
     "karma-firefox-launcher": "1.3.0",
     "karma-mocha": "2.0.1",


### PR DESCRIPTION
Issue #, if available: CVE-2021-23495

Description of changes:
- Bumped `karma` npm package version to `6.3.14` for a vulnerability fix. Manually verified that all `graph_notebook_widgets` unit tests are passing after the upgrade.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.