### PR TITLE
Add start_jupyterlab script

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,11 @@ python -m graph_notebook.notebooks.install --destination ~/notebook/destination/
 mkdir ~/.jupyter/nbconfig
 touch ~/.jupyter/nbconfig/notebook.json
 
-# start jupyter
+# start with jupyter classic notebook
 python -m graph_notebook.start_notebook --notebooks-dir ~/notebook/destination/dir
+
+# start with jupyterlab (>3.2.0 ONLY)
+python -m graph_notebook.start_jupyterlab —-jupyter-dir ~/notebook/destination/dir
 ```
 
 ## Connecting to a graph database

--- a/src/graph_notebook/start_jupyterlab.py
+++ b/src/graph_notebook/start_jupyterlab.py
@@ -1,0 +1,54 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import os
+import argparse
+import json
+
+HOME_PATH = os.path.expanduser("~")
+IPYTHON_DIR_TREE = HOME_PATH + '/.ipython/profile_default'
+IPYTHON_CFG_FILE_NAME = 'ipython_config.json'
+IPYTHON_CFG_PATH = IPYTHON_DIR_TREE + '/' + IPYTHON_CFG_FILE_NAME
+
+MAGICS_EXT_NAME = 'graph_notebook.magics'
+EXTENSIONS_CFG = {
+    "extensions": [
+        MAGICS_EXT_NAME
+    ]
+}
+
+
+def configure_ipython_profile():
+    try:
+        os.makedirs(IPYTHON_DIR_TREE, exist_ok=True)
+        with open(IPYTHON_CFG_PATH, 'r') as file:
+            ipython_cfg = json.load(file)
+    except (json.decoder.JSONDecodeError, FileNotFoundError) as e:
+        ipython_cfg = {}
+
+    try:
+        if MAGICS_EXT_NAME not in ipython_cfg["InteractiveShellApp"]["extensions"]:
+            ipython_cfg["InteractiveShellApp"]["extensions"].append(MAGICS_EXT_NAME)
+    except KeyError:
+        ipython_cfg["InteractiveShellApp"] = EXTENSIONS_CFG
+
+    with open(IPYTHON_CFG_PATH, 'w') as file:
+        json.dump(ipython_cfg, file, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--jupyter-dir', default='', type=str, help='The directory to start Jupyter from.')
+
+    args = parser.parse_args()
+
+    configure_ipython_profile()
+
+    jupyter_dir = '~/notebook/destination/dir' if args.jupyter_dir == '' else args.jupyter_dir
+    os.system(f'''jupyter lab {jupyter_dir}''')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Issue #, if available: #55

Description of changes:
- Added `start_jupyterlab.py` script for setting launch options with JupyterLab. Ensures that iPython is configured to auto-load the installed `graph_notebook.magics` extension for every new kernel.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.