### PR TITLE
Update neptune_ml_utils.py

### DIFF
--- a/src/graph_notebook/notebooks/04-Machine-Learning/Neptune-ML-SPARQL/neptune_ml_sparql_utils.py
+++ b/src/graph_notebook/notebooks/04-Machine-Learning/Neptune-ML-SPARQL/neptune_ml_sparql_utils.py
@@ -292,7 +292,7 @@ class MovieLensProcessor:
         if not os.path.exists(f'{HOME_DIRECTORY}/data/formatted'):
             os.makedirs(f'{HOME_DIRECTORY}/data/formatted')
         # Download the MovieLens dataset
-        url = 'http://files.grouplens.org/datasets/movielens/ml-100k.zip'
+        url = 'https://files.grouplens.org/datasets/movielens/ml-100k.zip'
         r = requests.get(url, allow_redirects=True)
         open(os.path.join(self.raw_directory, 'ml-100k.zip'), 'wb').write(r.content)
 

--- a/src/graph_notebook/notebooks/04-Machine-Learning/neptune_ml_utils.py
+++ b/src/graph_notebook/notebooks/04-Machine-Learning/neptune_ml_utils.py
@@ -321,7 +321,7 @@ class MovieLensProcessor:
         if not os.path.exists(f'{HOME_DIRECTORY}/data/formatted'):
             os.makedirs(f'{HOME_DIRECTORY}/data/formatted')
         # Download the MovieLens dataset
-        url = 'http://files.grouplens.org/datasets/movielens/ml-100k.zip'
+        url = 'https://files.grouplens.org/datasets/movielens/ml-100k.zip'
         r = requests.get(url, allow_redirects=True)
         open(os.path.join(self.raw_directory, 'ml-100k.zip'), 'wb').write(r.content)
 


### PR DESCRIPTION
When I use the "prepare_movielens_data" method to prepare the test data it fails, I found out that the link "http://files.grouplens.org/datasets/movielens/ml-100k.zip" is not working. After changing to "https://files.grouplens.org/datasets/movielens/ml-100k.zip" it will work.

So I commit this change.

This commit from Amy from AWS.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.