### PR TITLE
Bump jinja2 from 2.10.1 to 3.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 SPARQLWrapper==1.8.4
 networkx==2.4
-Jinja2==2.11.3
+Jinja2==3.0.3
 jupyter
 notebook>=6.1.5
 ipywidgets==7.5.1

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'requests',
         'ipywidgets',
         'networkx==2.4',
-        'Jinja2==2.11.3',
+        'Jinja2==3.0.3',
         'notebook>=6.1.5',
         'jupyter-contrib-nbextensions',
         'widgetsnbextension',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Bumped pinned version of `jinja2` to `3.0.3`. 

This resolves a dependency conflict between `graph-notebook` and `jupyterlab-server`, which now requires `jinja2>=3.0.3`: https://github.com/jupyterlab/jupyterlab_server/blob/main/setup.cfg#L32

We cannot allow newer versions of `jinja2` at this time. `jinja2>=3.1.0` [deprecates its older `contextfilter` class](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0); this is incompatible with with our pin of `nbconvert<6`, as a fix for the `contextfilter` deprecation is not implemented until `nbconvert==6.1.2`: https://github.com/jupyter/nbconvert/pull/1624

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.