### PR TITLE
Add support for variables to graph_notebook_config magic

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -199,9 +199,11 @@ class Graph(Magics):
 
         self.client = builder.build()
 
+    @magic_variables
     @line_cell_magic
+    @needs_local_scope
     @display_exceptions
-    def graph_notebook_config(self, line='', cell=''):
+    def graph_notebook_config(self, line='', cell='', local_ns: dict = None):
         if cell != '':
             data = json.loads(cell)
             config = get_config_from_dict(data)


### PR DESCRIPTION
This PR adds support for variables to the graph_notebook_config magic. This is very useful in scenarios where, for instance, the tooling launching graph_notebook pre-populates the environment with information about the DB endpoint:

```python
import os
neptune_host = os.getenv("NEPTUNE_HOST")
neptune_port = os.getenv("NEPTUNE_PORT")
```

```
%%graph_notebook_config
{
  "host": "${neptune_host}",
  "port": ${neptune_port},
  "auth_mode": "IAM",
  "iam_credentials_provider_type": "ENV",
  "load_from_s3_arn": "",
  "ssl": true,
  "aws_region": "eu-west-1"
}
```

That makes easier the creation of "generic" notebooks that do not hardcode any configuration parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.