### PR TITLE
Bugfix for displayed pagination options

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Support variable injection in `%%graph_notebook_config` magic ([Link to PR](https://github.com/aws/graph-notebook/pull/287))
+- Fix browser-specific bug in results pagination options menu ([Link to PR](https://github.com/aws/graph-notebook/pull/290))
 
 ## Release 3.3.0 (March 28, 2022)
 - Support rendering of widgets in JupyterLab ([Link to PR](https://github.com/aws/graph-notebook/pull/271))

--- a/src/graph_notebook/visualization/templates/gremlin_table.html
+++ b/src/graph_notebook/visualization/templates/gremlin_table.html
@@ -35,11 +35,26 @@
     <script type="text/javascript">
         require(["datatables"], function (datatables) {
             function sort_remove_dup_ary(ary) {
-                return ary.sort(function(a, b){return a-b}).filter(function(item, pos, ary) { return !pos || item != ary[pos - 1] })
+                return ary
+                    .sort(
+                        function(a, b){
+                            if (typeof a === 'string'){
+                                return -1
+                            }
+                            else if (typeof b === 'string'){
+                                return 1
+                            }
+                            else {
+                                const x = a-b;
+                                return a-b
+                            }
+                        }
+                        )
+                    .filter(function(item, pos, ary) {return !pos || item != ary[pos - 1]})
             }
 
-            var paginationAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, -1]);
-            var optionsAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, "All"]);
+            const paginationAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, -1]);
+            const optionsAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, "All"]);
 
             var dt = $('#{{guid}}').DataTable({
                 scrollY: true,

--- a/src/graph_notebook/visualization/templates/opencypher_table.html
+++ b/src/graph_notebook/visualization/templates/opencypher_table.html
@@ -42,11 +42,26 @@
     <script type="text/javascript">
         require(["datatables"], function (datatables) {
             function sort_remove_dup_ary(ary) {
-                return ary.sort(function(a, b){return a-b}).filter(function(item, pos, ary) { return !pos || item != ary[pos - 1] })
+                return ary
+                    .sort(
+                        function(a, b){
+                            if (typeof a === 'string'){
+                                return -1
+                            }
+                            else if (typeof b === 'string'){
+                                return 1
+                            }
+                            else {
+                                const x = a-b;
+                                return a-b
+                            }
+                        }
+                        )
+                    .filter(function(item, pos, ary) {return !pos || item != ary[pos - 1]})
             }
 
-            var paginationAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, -1]);
-            var optionsAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, "All"]);
+            const paginationAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, -1]);
+            const optionsAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, "All"]);
 
             $('#{{guid}}').DataTable({
                 scrollY: true,

--- a/src/graph_notebook/visualization/templates/sparql_table.html
+++ b/src/graph_notebook/visualization/templates/sparql_table.html
@@ -42,11 +42,26 @@
     <script type="text/javascript">
         require(["datatables"], function (datatables) {
             function sort_remove_dup_ary(ary) {
-                return ary.sort(function(a, b){return a-b}).filter(function(item, pos, ary) { return !pos || item != ary[pos - 1] })
+                return ary
+                    .sort(
+                        function(a, b){
+                            if (typeof a === 'string'){
+                                return -1
+                            }
+                            else if (typeof b === 'string'){
+                                return 1
+                            }
+                            else {
+                                const x = a-b;
+                                return a-b
+                            }
+                        }
+                        )
+                    .filter(function(item, pos, ary) {return !pos || item != ary[pos - 1]})
             }
 
-            var paginationAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, -1]);
-            var optionsAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, "All"]);
+            const paginationAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, -1]);
+            const optionsAry = sort_remove_dup_ary([{{amount}}, 10, 25, 50, 100, "All"]);
 
             $('#{{guid}}').DataTable({
                 scrollY: true,


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added manual check for string-integer comparisons in displayed pagination options array, this fixes inconsistencies caused by browser specific implementations of the JavaScript `sort` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.