### PR TITLE
Unpin requests-aws4auth version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Support variable injection in `%%graph_notebook_config` magic ([Link to PR](https://github.com/aws/graph-notebook/pull/287))
+- Removed `requests-aws4auth` requirement ([Link to PR](https://github.com/aws/graph-notebook/pull/291))
 
 ## Release 3.3.0 (March 28, 2022)
 - Support rendering of widgets in JupyterLab ([Link to PR](https://github.com/aws/graph-notebook/pull/271))

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -2591,36 +2591,6 @@ SOFTWARE.
 
 ------
 
-** requests-aws4auth 1.0.1; version 1.0.1 --
-https://pypi.org/project/requests-aws4auth/
-The MIT License (MIT)
-
-Copyright (c) 2015 Sam Washington
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Sam Washington
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------
-
 ** @types/webpack-env; version 1.15.2 --
 https://github.com/DefinitelyTyped/DefinitelyTyped
 Copyright (c) Microsoft Corporation. All rights reserved.

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         'jupyter-contrib-nbextensions',
         'widgetsnbextension',
         'jupyter>=1.0.0',
-        'requests-aws4auth==1.0.1',
         'botocore>=1.19.37',
         'boto3>=1.17.58',
         'ipython>=7.16.1,<7.17.0',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Remove unused `requests-aws4auth` dependency requirement from `setup.py`, and licensing information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.