### PR TITLE
Support literal property values for Sparql visualization options

### DIFF
--- a/test/unit/network/sparql/data/010_airroutes_no_literals.json
+++ b/test/unit/network/sparql/data/010_airroutes_no_literals.json
@@ -1,0 +1,83 @@
+{
+  "head": {
+    "vars": [
+      "s",
+      "p",
+      "o"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "s": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/365"
+        },
+        "o": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/85"
+        },
+        "p": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/objectProperty/route"
+        }
+      },
+      {
+        "s": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/365"
+        },
+        "o": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/367"
+        },
+        "p": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/objectProperty/route"
+        }
+      },
+      {
+        "s": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/365"
+        },
+        "o": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/16"
+        },
+        "p": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/objectProperty/route"
+        }
+      },
+      {
+        "s": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/365"
+        },
+        "o": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/8"
+        },
+        "p": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/objectProperty/route"
+        }
+      },
+      {
+        "s": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/365"
+        },
+        "o": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/11"
+        },
+        "p": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/objectProperty/route"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Issue #, if available: #294

Description of changes:
- Allow use of node property values with SPARQL `--group-by`/`--display-property`/`--tooltip-property` visualization options. 
- Change default node group from value of binding `type` -> value of `*:type` property (if available). Group-by-label will also now use the `*:type` property value as the node class identifier.

The `P.` prefix must be added to the property name to signify that we want to look in the node property map, Ex. 

`rdf:type`-> `P.rdf:type`.

Previously, these options would only search within the subject node binding itself. Specifying a property without the `P.` indicator will continue to limit the property search to the binding.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.