### PR TITLE
Make max_content_length configurable via %%gremlin

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -520,6 +520,9 @@ class Graph(Magics):
                             help='Specifies how many query results to display per page in the output. Default is 10')
         parser.add_argument('--no-scroll', action='store_true', default=False,
                             help="Display the entire output without a scroll bar.")
+        parser.add_argument('-mcl', '--max-content-length', type=int, default=10*1024*1024,
+                            help="Specifies maximum size (in bytes) of results that can be returned to the "
+                                 "GremlinPython client. Default is 10MB")
 
         args = parser.parse_args(line.split())
         mode = str_to_query_mode(args.query_mode)
@@ -537,6 +540,8 @@ class Graph(Magics):
 
             first_tab_output = widgets.Output(layout=gremlin_layout)
             children.append(first_tab_output)
+
+        transport_args = {'max_content_length': args.max_content_length}
 
         if mode == QueryMode.EXPLAIN:
             res = self.client.gremlin_explain(cell)
@@ -585,7 +590,7 @@ class Graph(Magics):
                     first_tab_html = pre_container_template.render(content='No profile found')
         else:
             query_start = time.time() * 1000  # time.time() returns time in seconds w/high precision; x1000 to get in ms
-            query_res = self.client.gremlin_query(cell)
+            query_res = self.client.gremlin_query(cell, transport_args=transport_args)
             query_time = time.time() * 1000 - query_start
             if not args.silent:
                 gremlin_metadata = build_gremlin_metadata_from_query(query_type='query', results=query_res,

--- a/test/integration/without_iam/gremlin/test_gremlin_query.py
+++ b/test/integration/without_iam/gremlin/test_gremlin_query.py
@@ -20,6 +20,20 @@ class TestGremlin(IntegrationTest):
         self.assertEqual(type(results), list)
 
     @pytest.mark.gremlin
+    def test_do_gremlin_query_with_content_limit_exceeded(self):
+        query = 'g.V().limit(1)'
+        transport_args = {'max_content_length': 1}
+        with self.assertRaises(RuntimeError):
+            self.client.gremlin_query(query, transport_args=transport_args)
+
+    @pytest.mark.gremlin
+    def test_do_gremlin_query_with_content_limit_not_exceeded(self):
+        query = 'g.V().limit(1)'
+        transport_args = {'max_content_length': 10240}
+        results = self.client.gremlin_query(query, transport_args=transport_args)
+        self.assertEqual(type(results), list)
+
+    @pytest.mark.gremlin
     @pytest.mark.neptune
     def test_do_gremlin_explain(self):
         query = 'g.V().limit(1)'


### PR DESCRIPTION
Issue #, if available: #304

Description of changes:
- Added `-mcl`/`--max-content-length` option to `%%gremlin`. This option can be used to modify the the maximum byte size of query results accepted by the Gremlin Python client, which defaults to 10MB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.