### PR TITLE
Move JupyterLab IPython config to own module

### DIFF
--- a/src/graph_notebook/ipython_profile/__init__.py
+++ b/src/graph_notebook/ipython_profile/__init__.py
@@ -1,0 +1,4 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""

--- a/src/graph_notebook/ipython_profile/configure_ipython_profile.py
+++ b/src/graph_notebook/ipython_profile/configure_ipython_profile.py
@@ -1,0 +1,50 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import os
+import json
+
+HOME_PATH = os.path.expanduser("~")
+IPYTHON_DIR_TREE = HOME_PATH + '/.ipython/profile_default'
+IPYTHON_CFG_FILE_NAME = 'ipython_config.json'
+IPYTHON_CFG_PATH = IPYTHON_DIR_TREE + '/' + IPYTHON_CFG_FILE_NAME
+
+MAGICS_EXT_NAME = 'graph_notebook.magics'
+EXTENSIONS_CFG = {
+    "extensions": [
+        MAGICS_EXT_NAME
+    ]
+}
+
+
+def read_ipython_config():
+    try:
+        os.makedirs(IPYTHON_DIR_TREE, exist_ok=True)
+        with open(IPYTHON_CFG_PATH, 'r') as file:
+            ipython_cfg = json.load(file)
+    except (json.decoder.JSONDecodeError, FileNotFoundError) as e:
+        ipython_cfg = {}
+
+    return ipython_cfg
+
+
+def write_ipython_config(config):
+    with open(IPYTHON_CFG_PATH, 'w') as file:
+        json.dump(config, file, indent=2)
+
+
+def configure_magics_extension():
+    ipython_cfg = read_ipython_config()
+    try:
+        if MAGICS_EXT_NAME not in ipython_cfg["InteractiveShellApp"]["extensions"]:
+            ipython_cfg["InteractiveShellApp"]["extensions"].append(MAGICS_EXT_NAME)
+    except KeyError:
+        ipython_cfg["InteractiveShellApp"] = EXTENSIONS_CFG
+
+    write_ipython_config(ipython_cfg)
+
+
+if __name__ == '__main__':
+    configure_magics_extension()

--- a/src/graph_notebook/start_jupyterlab.py
+++ b/src/graph_notebook/start_jupyterlab.py
@@ -5,37 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import os
 import argparse
-import json
-
-HOME_PATH = os.path.expanduser("~")
-IPYTHON_DIR_TREE = HOME_PATH + '/.ipython/profile_default'
-IPYTHON_CFG_FILE_NAME = 'ipython_config.json'
-IPYTHON_CFG_PATH = IPYTHON_DIR_TREE + '/' + IPYTHON_CFG_FILE_NAME
-
-MAGICS_EXT_NAME = 'graph_notebook.magics'
-EXTENSIONS_CFG = {
-    "extensions": [
-        MAGICS_EXT_NAME
-    ]
-}
-
-
-def configure_ipython_profile():
-    try:
-        os.makedirs(IPYTHON_DIR_TREE, exist_ok=True)
-        with open(IPYTHON_CFG_PATH, 'r') as file:
-            ipython_cfg = json.load(file)
-    except (json.decoder.JSONDecodeError, FileNotFoundError) as e:
-        ipython_cfg = {}
-
-    try:
-        if MAGICS_EXT_NAME not in ipython_cfg["InteractiveShellApp"]["extensions"]:
-            ipython_cfg["InteractiveShellApp"]["extensions"].append(MAGICS_EXT_NAME)
-    except KeyError:
-        ipython_cfg["InteractiveShellApp"] = EXTENSIONS_CFG
-
-    with open(IPYTHON_CFG_PATH, 'w') as file:
-        json.dump(ipython_cfg, file, indent=2)
+from graph_notebook.ipython_profile.configure_ipython_profile import configure_magics_extension
 
 
 def main():
@@ -44,7 +14,7 @@ def main():
 
     args = parser.parse_args()
 
-    configure_ipython_profile()
+    configure_magics_extension()
 
     jupyter_dir = '~/notebook/destination/dir' if args.jupyter_dir == '' else args.jupyter_dir
     os.system(f'''jupyter lab {jupyter_dir}''')

--- a/src/graph_notebook/start_notebook.py
+++ b/src/graph_notebook/start_notebook.py
@@ -12,6 +12,7 @@ NBCONFIG_DIR_TREE = HOME_PATH + '/.jupyter/nbconfig'
 CFG_FILE_NAME = 'notebook.json'
 NOTEBOOK_CFG_PATH = NBCONFIG_DIR_TREE + '/' + CFG_FILE_NAME
 
+
 def patch_cm_cypher_config():
     cypher_cfg = {
         "cm_config": {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Refactored `start_jupyterlab.py` script. Moved the code for setting IPython extensions to new module `graph_notebook.ipython_profile.configure_ipython_profile`, so that we can call it independently of the startup script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.