### PR TITLE
Add Proxy Support for Graph Notebooks

### DIFF
--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -18,10 +18,10 @@ def get_config_from_dict(data: dict) -> Configuration:
         config = Configuration(host=data['host'], port=data['port'], auth_mode=AuthModeEnum(data['auth_mode']),
                                ssl=data['ssl'], load_from_s3_arn=data['load_from_s3_arn'],
                                aws_region=data['aws_region'], sparql_section=sparql_section,
-                               gremlin_section=gremlin_section)
+                               gremlin_section=gremlin_section, proxy_host=data['proxy_host'], proxy_port=data['proxy_port'])
     else:
         config = Configuration(host=data['host'], port=data['port'], ssl=data['ssl'], sparql_section=sparql_section,
-                               gremlin_section=gremlin_section)
+                               gremlin_section=gremlin_section, proxy_host=data['proxy_host'], proxy_port=data['proxy_port'])
     return config
 
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -67,11 +67,11 @@ logger = logging.getLogger("graph_magic")
 
 DEFAULT_MAX_RESULTS = 1000
 
-GREMLIN_CANCEL_HINT_MSG = '''You must supply a string queryId when using --cancelQuery, 
+GREMLIN_CANCEL_HINT_MSG = '''You must supply a string queryId when using --cancelQuery,
                             for example: %gremlin_status --cancelQuery --queryId my-query-id'''
-SPARQL_CANCEL_HINT_MSG = '''You must supply a string queryId when using --cancelQuery, 
+SPARQL_CANCEL_HINT_MSG = '''You must supply a string queryId when using --cancelQuery,
                             for example: %sparql_status --cancelQuery --queryId my-query-id'''
-OPENCYPHER_CANCEL_HINT_MSG = '''You must supply a string queryId when using --cancelQuery, 
+OPENCYPHER_CANCEL_HINT_MSG = '''You must supply a string queryId when using --cancelQuery,
                                 for example: %opencypher_status --cancelQuery --queryId my-query-id'''
 SEED_LANGUAGE_OPTIONS = ['', 'Property_Graph', 'RDF']
 
@@ -186,6 +186,8 @@ class Graph(Magics):
                 .with_port(config.port) \
                 .with_region(config.aws_region) \
                 .with_tls(config.ssl) \
+                .with_proxy_host(config.proxy_host) \
+                .with_proxy_port(config.proxy_port) \
                 .with_sparql_path(config.sparql.path)
             if config.auth_mode == AuthModeEnum.IAM:
                 builder = builder.with_iam(get_session())
@@ -227,7 +229,7 @@ class Graph(Magics):
             print(json.dumps(config_dict, indent=2))
 
         return self.graph_notebook_config
-    
+
 
     @line_magic
     def stream_viewer(self,line):
@@ -239,13 +241,13 @@ class Graph(Magics):
         parser.add_argument('--limit', type=int, default=10, help='Maximum number of rows to display at a time')
 
         args = parser.parse_args(line.split())
-        
+
         language = args.language
         limit = args.limit
         uri = self.client.get_uri_with_port()
         viewer = StreamViewer(self.client,uri,language,limit=limit)
         viewer.show()
-        
+
     @line_magic
     def graph_notebook_host(self, line):
         if line == '':
@@ -369,7 +371,7 @@ class Graph(Magics):
                                        ignore_groups=args.ignore_groups,
                                        expand_all=args.expand_all,
                                        group_by_raw=args.group_by_raw)
-                    
+
                     sn.extract_prefix_declarations_from_query(cell)
                     try:
                         sn.add_results(results)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Added 'proxy_host' and 'proxy_port' as configurable fields in the Neptune client.
- `proxy_port` and `proxy_host` follow the same flow as normal `host` and `port`
- Change client to use `@property` decorators on `host` and `port` methods. This allows dynamic switching between proxy and target_host (originally host) depending on the required context
- Used the `get_uri_with_port()` method where it made sense, and extended it so you can specify whether to use the websocket protocol or not
- Replaced some static values with global variables that were already in use. Things like `8182` or `us-east-1`
- Tested to be working for remote and local Graph DB.
- 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.