### PR TITLE
Make proxy config fields optional

### DIFF
--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -12,18 +12,20 @@ from graph_notebook.configuration.generate_config import DEFAULT_CONFIG_LOCATION
 def get_config_from_dict(data: dict) -> Configuration:
     sparql_section = SparqlSection(**data['sparql']) if 'sparql' in data else SparqlSection('')
     gremlin_section = GremlinSection(**data['gremlin']) if 'gremlin' in data else GremlinSection('')
+    proxy_host = str(data['proxy_host']) if 'proxy_host' in data else ''
+    proxy_port = int(data['proxy_port']) if 'proxy_port' in data else 8182
     if "amazonaws.com" in data['host']:
         if gremlin_section.to_dict()['traversal_source'] != 'g':
             print('Ignoring custom traversal source, Amazon Neptune does not support this functionality.\n')
         config = Configuration(host=data['host'], port=data['port'], auth_mode=AuthModeEnum(data['auth_mode']),
                                ssl=data['ssl'], load_from_s3_arn=data['load_from_s3_arn'],
                                aws_region=data['aws_region'], sparql_section=sparql_section,
-                               gremlin_section=gremlin_section, proxy_host=data['proxy_host'],
-                               proxy_port=data['proxy_port'])
+                               gremlin_section=gremlin_section, proxy_host=proxy_host,
+                               proxy_port=proxy_port)
     else:
         config = Configuration(host=data['host'], port=data['port'], ssl=data['ssl'], sparql_section=sparql_section,
-                               gremlin_section=gremlin_section, proxy_host=data['proxy_host'],
-                               proxy_port=data['proxy_port'])
+                               gremlin_section=gremlin_section, proxy_host=proxy_host,
+                               proxy_port=proxy_port)
     return config
 
 


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Prevents errors from occurring when `proxy_host` or `proxy_port` are not specified in `~/graph_notebook_config.json` or when running `%%graph_notebook_config`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.