### PR TITLE
Add neptune_config_allowlist magic

### DIFF
--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -8,7 +8,9 @@ import json
 import os
 from enum import Enum
 
-from graph_notebook.neptune.client import SPARQL_ACTION, DEFAULT_PORT, DEFAULT_REGION, NEPTUNE_CONFIG_HOST_IDENTIFIERS
+from graph_notebook.neptune.client import SPARQL_ACTION, DEFAULT_PORT, DEFAULT_REGION, \
+    NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_allowed_neptune_host
+
 DEFAULT_CONFIG_LOCATION = os.path.expanduser('~/graph_notebook_config.json')
 
 
@@ -75,11 +77,9 @@ class Configuration(object):
         self.proxy_host = proxy_host
         self.proxy_port = proxy_port
         self.sparql = sparql_section if sparql_section is not None else SparqlSection()
-        is_neptune_host = False
-        for host_snippet in neptune_hosts:
-            if host_snippet in self.host or host_snippet in self.proxy_host:
-                is_neptune_host = True
-                break
+
+        is_neptune_host = is_allowed_neptune_host(hostname=self.host, host_allowlist=neptune_hosts) \
+            or is_allowed_neptune_host(hostname=self.proxy_host, host_allowlist=neptune_hosts)
         if is_neptune_host:
             self.is_neptune_config = True
             self.auth_mode = auth_mode

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -7,7 +7,7 @@ import json
 
 from graph_notebook.configuration.generate_config import DEFAULT_CONFIG_LOCATION, Configuration, AuthModeEnum, \
     SparqlSection, GremlinSection
-from graph_notebook.neptune.client import NEPTUNE_CONFIG_HOST_IDENTIFIERS
+from graph_notebook.neptune.client import NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_allowed_neptune_host
 
 
 def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_IDENTIFIERS) -> Configuration:
@@ -16,11 +16,9 @@ def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_I
     gremlin_section = GremlinSection(**data['gremlin']) if 'gremlin' in data else GremlinSection('')
     proxy_host = str(data['proxy_host']) if 'proxy_host' in data else ''
     proxy_port = int(data['proxy_port']) if 'proxy_port' in data else 8182
-    is_neptune_host = False
-    for host_snippet in neptune_hosts:
-        if host_snippet in data["host"]:
-            is_neptune_host = True
-            break
+
+    is_neptune_host = is_allowed_neptune_host(hostname=data["host"], host_allowlist=neptune_hosts)
+
     if is_neptune_host:
         if gremlin_section.to_dict()['traversal_source'] != 'g':
             print('Ignoring custom traversal source, Amazon Neptune does not support this functionality.\n')

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -7,21 +7,28 @@ import json
 
 from graph_notebook.configuration.generate_config import DEFAULT_CONFIG_LOCATION, Configuration, AuthModeEnum, \
     SparqlSection, GremlinSection
+from graph_notebook.neptune.client import NEPTUNE_CONFIG_HOST_IDENTIFIERS
 
 
-def get_config_from_dict(data: dict) -> Configuration:
+def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_IDENTIFIERS) -> Configuration:
+
     sparql_section = SparqlSection(**data['sparql']) if 'sparql' in data else SparqlSection('')
     gremlin_section = GremlinSection(**data['gremlin']) if 'gremlin' in data else GremlinSection('')
     proxy_host = str(data['proxy_host']) if 'proxy_host' in data else ''
     proxy_port = int(data['proxy_port']) if 'proxy_port' in data else 8182
-    if "amazonaws.com" in data['host']:
+    is_neptune_host = False
+    for host_snippet in neptune_hosts:
+        if host_snippet in data["host"]:
+            is_neptune_host = True
+            break
+    if is_neptune_host:
         if gremlin_section.to_dict()['traversal_source'] != 'g':
             print('Ignoring custom traversal source, Amazon Neptune does not support this functionality.\n')
         config = Configuration(host=data['host'], port=data['port'], auth_mode=AuthModeEnum(data['auth_mode']),
                                ssl=data['ssl'], load_from_s3_arn=data['load_from_s3_arn'],
                                aws_region=data['aws_region'], sparql_section=sparql_section,
                                gremlin_section=gremlin_section, proxy_host=proxy_host,
-                               proxy_port=proxy_port)
+                               proxy_port=proxy_port, neptune_hosts=neptune_hosts)
     else:
         config = Configuration(host=data['host'], port=data['port'], ssl=data['ssl'], sparql_section=sparql_section,
                                gremlin_section=gremlin_section, proxy_host=proxy_host,
@@ -29,7 +36,8 @@ def get_config_from_dict(data: dict) -> Configuration:
     return config
 
 
-def get_config(path: str = DEFAULT_CONFIG_LOCATION) -> Configuration:
+def get_config(path: str = DEFAULT_CONFIG_LOCATION,
+               neptune_hosts: list = NEPTUNE_CONFIG_HOST_IDENTIFIERS) -> Configuration:
     with open(path) as config_file:
         data = json.load(config_file)
-        return get_config_from_dict(data)
+        return get_config_from_dict(data=data, neptune_hosts=neptune_hosts)

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -40,7 +40,7 @@ from graph_notebook.magics.streams import StreamViewer
 from graph_notebook.neptune.client import ClientBuilder, Client, VALID_FORMATS, PARALLELISM_OPTIONS, PARALLELISM_HIGH, \
     LOAD_JOB_MODES, MODE_AUTO, FINAL_LOAD_STATUSES, SPARQL_ACTION, FORMAT_CSV, FORMAT_OPENCYPHER, FORMAT_NTRIPLE, \
     FORMAT_NQUADS, FORMAT_RDFXML, FORMAT_TURTLE, STREAM_RDF, STREAM_PG, STREAM_ENDPOINTS, \
-    NEPTUNE_CONFIG_HOST_IDENTIFIERS
+    NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_allowed_neptune_host
 from graph_notebook.network import SPARQLNetwork
 from graph_notebook.network.gremlin.GremlinNetwork import parse_pattern_list_str, GremlinNetwork
 from graph_notebook.visualization.rows_and_columns import sparql_get_rows_and_columns, opencypher_get_rows_and_columns
@@ -205,11 +205,7 @@ class Graph(Magics):
         if self.client:
             self.client.close()
 
-        is_neptune_host = False
-        for host_snippet in self.neptune_cfg_allowlist:
-            if host_snippet in config.host:
-                is_neptune_host = True
-                break
+        is_neptune_host = is_allowed_neptune_host(hostname=config.host, host_allowlist=self.neptune_cfg_allowlist)
 
         if is_neptune_host:
             builder = ClientBuilder() \

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -13,7 +13,9 @@ import time
 import datetime
 import os
 import uuid
+import ast
 from enum import Enum
+from copy import copy
 from json import JSONDecodeError
 from graph_notebook.network.opencypher.OCNetwork import OCNetwork
 
@@ -37,7 +39,8 @@ from graph_notebook.magics.ml import neptune_ml_magic_handler, generate_neptune_
 from graph_notebook.magics.streams import StreamViewer
 from graph_notebook.neptune.client import ClientBuilder, Client, VALID_FORMATS, PARALLELISM_OPTIONS, PARALLELISM_HIGH, \
     LOAD_JOB_MODES, MODE_AUTO, FINAL_LOAD_STATUSES, SPARQL_ACTION, FORMAT_CSV, FORMAT_OPENCYPHER, FORMAT_NTRIPLE, \
-    FORMAT_NQUADS, FORMAT_RDFXML, FORMAT_TURTLE, STREAM_RDF, STREAM_PG, STREAM_ENDPOINTS
+    FORMAT_NQUADS, FORMAT_RDFXML, FORMAT_TURTLE, STREAM_RDF, STREAM_PG, STREAM_ENDPOINTS, \
+    NEPTUNE_CONFIG_HOST_IDENTIFIERS
 from graph_notebook.network import SPARQLNetwork
 from graph_notebook.network.gremlin.GremlinNetwork import parse_pattern_list_str, GremlinNetwork
 from graph_notebook.visualization.rows_and_columns import sparql_get_rows_and_columns, opencypher_get_rows_and_columns
@@ -182,11 +185,12 @@ class Graph(Magics):
         # You must call the parent constructor
         super(Graph, self).__init__(shell)
 
+        self.neptune_cfg_allowlist = copy(NEPTUNE_CONFIG_HOST_IDENTIFIERS)
         self.graph_notebook_config = generate_default_config()
         try:
             self.config_location = os.getenv('GRAPH_NOTEBOOK_CONFIG', DEFAULT_CONFIG_LOCATION)
             self.client: Client = None
-            self.graph_notebook_config = get_config(self.config_location)
+            self.graph_notebook_config = get_config(self.config_location, neptune_hosts=self.neptune_cfg_allowlist)
         except FileNotFoundError:
             print('Could not find a valid configuration. '
                   'Do not forget to validate your settings using %graph_notebook_config.')
@@ -201,7 +205,13 @@ class Graph(Magics):
         if self.client:
             self.client.close()
 
-        if "amazonaws.com" in config.host:
+        is_neptune_host = False
+        for host_snippet in self.neptune_cfg_allowlist:
+            if host_snippet in config.host:
+                is_neptune_host = True
+                break
+
+        if is_neptune_host:
             builder = ClientBuilder() \
                 .with_host(config.host) \
                 .with_port(config.port) \
@@ -212,6 +222,8 @@ class Graph(Magics):
                 .with_sparql_path(config.sparql.path)
             if config.auth_mode == AuthModeEnum.IAM:
                 builder = builder.with_iam(get_session())
+            if self.neptune_cfg_allowlist != NEPTUNE_CONFIG_HOST_IDENTIFIERS:
+                builder = builder.with_custom_neptune_hosts(self.neptune_cfg_allowlist)
         else:
             builder = ClientBuilder() \
                 .with_host(config.host) \
@@ -229,13 +241,13 @@ class Graph(Magics):
     def graph_notebook_config(self, line='', cell='', local_ns: dict = None):
         if cell != '':
             data = json.loads(cell)
-            config = get_config_from_dict(data)
+            config = get_config_from_dict(data, neptune_hosts=self.neptune_cfg_allowlist)
             self.graph_notebook_config = config
             self._generate_client_from_config(config)
             print('set notebook config to:')
             print(json.dumps(self.graph_notebook_config.to_dict(), indent=2))
         elif line == 'reset':
-            self.graph_notebook_config = get_config(self.config_location)
+            self.graph_notebook_config = get_config(self.config_location, neptune_hosts=self.neptune_cfg_allowlist)
             print('reset notebook config to:')
             print(json.dumps(self.graph_notebook_config.to_dict(), indent=2))
         elif line == 'silent':
@@ -251,6 +263,46 @@ class Graph(Magics):
 
         return self.graph_notebook_config
 
+    @line_cell_magic
+    def neptune_config_allowlist(self, line='', cell=''):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('mode', nargs='?', default='add',
+                            help='mode (default=add) [add|remove|overwrite|reset]')
+        args = parser.parse_args(line.split())
+
+        try:
+            cell_new = ast.literal_eval(cell)
+            input_type = 'list'
+        except:
+            cell_new = cell
+            input_type = 'string'
+
+        allowlist_modified = True
+        if args.mode == 'reset':
+            self.neptune_cfg_allowlist = copy(NEPTUNE_CONFIG_HOST_IDENTIFIERS)
+        elif cell != '':
+            if args.mode == 'add':
+                if input_type == 'string':
+                    self.neptune_cfg_allowlist.append(cell_new.strip())
+                else:
+                    self.neptune_cfg_allowlist = list(set(self.neptune_cfg_allowlist) | set(cell_new))
+            elif args.mode == 'remove':
+                if input_type == 'string':
+                    self.neptune_cfg_allowlist.remove(cell_new.strip())
+                else:
+                    self.neptune_cfg_allowlist = list(set(self.neptune_cfg_allowlist) - set(cell_new))
+            elif args.mode == 'overwrite':
+                if input_type == 'string':
+                    self.neptune_cfg_allowlist = [cell_new.strip()]
+                else:
+                    self.neptune_cfg_allowlist = cell_new
+        else:
+            allowlist_modified = False
+
+        if allowlist_modified:
+            print(f'Set Neptune config allow list to: {self.neptune_cfg_allowlist}')
+        else:
+            print(f'Current Neptune config allow list: {self.neptune_cfg_allowlist}')
 
     @line_magic
     def stream_viewer(self,line):

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -95,6 +95,13 @@ STREAM_ENDPOINTS = {STREAM_PG: 'gremlin', STREAM_RDF: 'sparql'}
 NEPTUNE_CONFIG_HOST_IDENTIFIERS = ["amazonaws.com"]
 
 
+def is_allowed_neptune_host(hostname: str, host_allowlist: list):
+    for host_snippet in host_allowlist:
+        if host_snippet in hostname:
+            return True
+    return False
+
+
 class Client(object):
     def __init__(self, host: str, port: int = DEFAULT_PORT, ssl: bool = True, region: str = DEFAULT_REGION,
                  sparql_path: str = '/sparql', gremlin_traversal_source: str = 'g', auth=None, session: Session = None,
@@ -130,10 +137,7 @@ class Client(object):
         return self.target_port
 
     def is_neptune_domain(self):
-        for host_snippet in self.neptune_hosts:
-            if host_snippet in self.target_host:
-                return True
-        return False
+        return is_allowed_neptune_host(hostname=self.target_host, host_allowlist=self.neptune_hosts)
 
     def get_uri_with_port(self, use_websocket=False, use_proxy=False):
         protocol = self._http_protocol

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -16,7 +16,9 @@ class TestGenerateConfiguration(unittest.TestCase):
         cls.generic_host = 'blah'
         cls.neptune_host_reg = 'instance.cluster.us-west-2.neptune.amazonaws.com'
         cls.neptune_host_cn = 'instance.cluster.neptune.cn-north-1.amazonaws.com.cn'
+        cls.neptune_host_custom = 'localhost'
         cls.port = 8182
+        cls.custom_hosts_list = ['localhost']
         cls.test_file_path = f'{os.path.abspath(os.path.curdir)}/test_configuration_file.json'
 
     def tearDown(self) -> None:
@@ -39,6 +41,13 @@ class TestGenerateConfiguration(unittest.TestCase):
         self.assertEqual(True, config.ssl)
         self.assertEqual('', config.load_from_s3_arn)
 
+    def test_configuration_default_auth_defaults_neptune_custom(self):
+        config = Configuration(self.neptune_host_custom, self.port, neptune_hosts=self.custom_hosts_list)
+        self.assertEqual(self.neptune_host_custom, config.host)
+        self.assertEqual(self.port, config.port)
+        self.assertEqual(DEFAULT_AUTH_MODE, config.auth_mode)
+        self.assertEqual(True, config.ssl)
+
     def test_configuration_default_auth_defaults_generic(self):
         config = Configuration(self.generic_host, self.port)
         self.assertEqual(self.generic_host, config.host)
@@ -49,7 +58,8 @@ class TestGenerateConfiguration(unittest.TestCase):
         auth_mode = AuthModeEnum.IAM
         ssl = False
         loader_arn = 'foo'
-        config = Configuration(self.neptune_host_reg, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn, ssl=ssl)
+        config = Configuration(self.neptune_host_reg, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn,
+                               ssl=ssl)
         self.assertEqual(auth_mode, config.auth_mode)
         self.assertEqual(ssl, config.ssl)
         self.assertEqual(loader_arn, config.load_from_s3_arn)
@@ -58,7 +68,18 @@ class TestGenerateConfiguration(unittest.TestCase):
         auth_mode = AuthModeEnum.IAM
         ssl = False
         loader_arn = 'foo'
-        config = Configuration(self.neptune_host_cn, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn, ssl=ssl)
+        config = Configuration(self.neptune_host_cn, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn,
+                               ssl=ssl)
+        self.assertEqual(auth_mode, config.auth_mode)
+        self.assertEqual(ssl, config.ssl)
+        self.assertEqual(loader_arn, config.load_from_s3_arn)
+
+    def test_configuration_override_defaults_neptune_custom(self):
+        auth_mode = AuthModeEnum.IAM
+        ssl = False
+        loader_arn = 'foo'
+        config = Configuration(self.neptune_host_custom, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn,
+                               ssl=ssl, neptune_hosts=self.custom_hosts_list)
         self.assertEqual(auth_mode, config.auth_mode)
         self.assertEqual(ssl, config.ssl)
         self.assertEqual(loader_arn, config.load_from_s3_arn)
@@ -82,6 +103,15 @@ class TestGenerateConfiguration(unittest.TestCase):
                             load_from_s3_arn=config.load_from_s3_arn, aws_region=config.aws_region)
         c.write_to_file(self.test_file_path)
         config_from_file = get_config(self.test_file_path)
+        self.assertEqual(config.to_dict(), config_from_file.to_dict())
+
+    def test_generate_configuration_with_defaults_neptune_custom(self):
+        config = Configuration(self.neptune_host_custom, self.port, neptune_hosts=self.custom_hosts_list)
+        c = generate_config(config.host, config.port, auth_mode=config.auth_mode, ssl=config.ssl,
+                            load_from_s3_arn=config.load_from_s3_arn, aws_region=config.aws_region,
+                            neptune_hosts=self.custom_hosts_list)
+        c.write_to_file(self.test_file_path)
+        config_from_file = get_config(self.test_file_path, neptune_hosts=self.custom_hosts_list)
         self.assertEqual(config.to_dict(), config_from_file.to_dict())
 
     def test_generate_configuration_with_defaults_generic(self):
@@ -117,6 +147,21 @@ class TestGenerateConfiguration(unittest.TestCase):
                             load_from_s3_arn=config.load_from_s3_arn, aws_region=config.aws_region)
         c.write_to_file(self.test_file_path)
         config_from_file = get_config(self.test_file_path)
+        self.assertEqual(config.to_dict(), config_from_file.to_dict())
+
+    def test_generate_configuration_override_defaults_neptune_custom(self):
+        auth_mode = AuthModeEnum.IAM
+        ssl = False
+        loader_arn = 'foo'
+        aws_region = 'cn-north-1'
+        config = Configuration(self.neptune_host_custom, self.port, auth_mode=auth_mode, load_from_s3_arn=loader_arn,
+                               ssl=ssl, aws_region=aws_region, neptune_hosts=self.custom_hosts_list)
+
+        c = generate_config(config.host, config.port, auth_mode=config.auth_mode, ssl=config.ssl,
+                            load_from_s3_arn=config.load_from_s3_arn, aws_region=config.aws_region,
+                            neptune_hosts=self.custom_hosts_list)
+        c.write_to_file(self.test_file_path)
+        config_from_file = get_config(self.test_file_path, neptune_hosts=self.custom_hosts_list)
         self.assertEqual(config.to_dict(), config_from_file.to_dict())
 
     def test_generate_configuration_override_defaults_generic(self):

--- a/test/unit/configuration/test_configuration_from_main.py
+++ b/test/unit/configuration/test_configuration_from_main.py
@@ -16,8 +16,10 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         cls.generic_host = 'blah'
         cls.neptune_host_reg = 'instance.cluster.us-west-2.neptune.amazonaws.com'
         cls.neptune_host_cn = 'instance.cluster.neptune.cn-north-1.amazonaws.com.cn'
+        cls.neptune_host_custom = 'localhost'
         cls.port = 8182
         cls.test_file_path = f'{os.path.abspath(os.path.curdir)}/test_generate_from_main.json'
+        cls.custom_hosts_list = ['localhost']
         cls.python_cmd = os.environ.get('PYTHON_CMD', 'python3')  # environment variable to let ToD hosts specify
         # where the python command is that is being used for testing.
 
@@ -66,6 +68,16 @@ class TestGenerateConfigurationMain(unittest.TestCase):
                            f'--load_from_s3_arn "" --config_destination="{self.test_file_path}" ')
         self.assertEqual(0, result)
         config = get_config(self.test_file_path)
+        self.assertEqual(expected_config.to_dict(), config.to_dict())
+
+    def test_generate_configuration_main_empty_args_custom(self):
+        expected_config = Configuration(self.neptune_host_custom, self.port, neptune_hosts=self.custom_hosts_list)
+        result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '
+                           f'--host "{expected_config.host}" --port "{expected_config.port}" --auth_mode "" --ssl "" '
+                           f'--load_from_s3_arn "" --config_destination="{self.test_file_path}" '
+                           f'--neptune_hosts {self.custom_hosts_list}')
+        self.assertEqual(0, result)
+        config = get_config(self.test_file_path, neptune_hosts=self.custom_hosts_list)
         self.assertEqual(expected_config.to_dict(), config.to_dict())
 
     def test_generate_configuration_main_empty_args_generic(self):


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added `neptune_config_allowlist` line/cell magic. Allows users to modify the allow-list for identifying Neptune endpoints during creation of `graph_notebook_config`.

For example, the following command:
```
%%neptune_config_allowlist add

localhost
```
Outputs:
```
Set Neptune config allow list to: ['amazonaws.com', 'localhost']
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.