### PR TITLE
Upgrade jquery-ui to 1.13.2

### DIFF
--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -7,7 +7,7 @@
     "@jupyter-widgets/base": "^2 || ^3 || ^4",
     "feather-icons": "4.28.0",
     "jquery": "3.6.0",
-    "jquery-ui": "1.13.1",
+    "jquery-ui": "1.13.2",
     "lodash": "4.17.21",
     "vis-data": "6.5.1",
     "vis-network": "7.6.3",


### PR DESCRIPTION
Issue #, if available: CVE-2022-31160

Description of changes:
- Bumped `jquery-ui` npm package version to `1.13.2` for a vulnerability fix. Manually verified visualization widget functionality and passing `graph_notebook_widgets` unit tests following the upgrade.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.