### PR TITLE
Fix incorrect Gremlin query --store-to output

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -740,11 +740,10 @@ class Graph(Magics):
                 # If not, then render our own HTML template.
                 results_df = pd.DataFrame(query_res)
                 if not results_df.empty:
-                    query_res = [[result] for result in query_res]
-                    query_res.append([{'__DUMMY_KEY__': ['DUMMY_VALUE']}])
-                    results_df = pd.DataFrame(query_res)
+                    query_res_reformat = [[result] for result in query_res]
+                    query_res_reformat.append([{'__DUMMY_KEY__': ['DUMMY_VALUE']}])
+                    results_df = pd.DataFrame(query_res_reformat)
                     results_df.drop(results_df.index[-1], inplace=True)
-                    query_res.pop()
                 results_df.insert(0, "#", range(1, len(results_df) + 1))
                 if len(results_df.columns) == 2 and int(results_df.columns[1]) == 0:
                     results_df.rename({results_df.columns[1]: 'Result'}, axis='columns', inplace=True)

--- a/test/integration/without_iam/notebook/test_gremlin_graph_notebook.py
+++ b/test/integration/without_iam/notebook/test_gremlin_graph_notebook.py
@@ -9,7 +9,7 @@ from test.integration import GraphNotebookIntegrationTest
 
 class TestGraphMagicGremlin(GraphNotebookIntegrationTest):
     def tearDown(self) -> None:
-        delete_query = "g.V('graph-notebook-test').drop()"
+        delete_query = "g.V().hasLabel('graph-notebook-test').drop()"
         self.ip.run_cell_magic('gremlin', 'query', delete_query)
 
     @pytest.mark.jupyter
@@ -25,6 +25,23 @@ class TestGraphMagicGremlin(GraphNotebookIntegrationTest):
 
         # TODO: how can we get a look at the objects which were displayed?
         self.assertEqual(gremlin_res[0].label, label)
+
+    @pytest.mark.jupyter
+    @pytest.mark.gremlin
+    def test_gremlin_storeto_format_query(self):
+        label = 'graph-notebook-test'
+        test_id = '__TESTID__'
+        insert_query = f"g.addV('{label}').property(id, '{test_id}')"
+        get_query = f"g.V('{test_id}').elementMap()"
+
+        store_to_var = 'gremlin_res'
+        self.ip.run_cell_magic('gremlin', 'query', insert_query)
+        self.ip.run_cell_magic('gremlin', f'query --store-to {store_to_var}', get_query)
+
+        self.assertFalse('graph_notebook_error' in self.ip.user_ns)
+        gremlin_res = self.ip.user_ns[store_to_var]
+
+        self.assertEqual(type(gremlin_res[0]), dict)
 
     @pytest.mark.jupyter
     @pytest.mark.gremlin


### PR DESCRIPTION
Issue #, if available: #333

Description of changes:
- Fixed an issue with default `%%gremlin` queries where `--store-to` was not receiving results in the returned format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.