### PR TITLE
Docker: Fix Bash Script Comparisons and Permissions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Reverted Gremlin console tab to single results column ([Link to PR](https://github.com/aws/graph-notebook/pull/330))
 - Bumped jquery-ui from 1.13.1 to 1.13.2 (([Link to PR](https://github.com/aws/graph-notebook/pull/328))
 - Docker support. Docker image can be built using the command `docker build .` and through Docker's `buildx`, this can support non-x86 CPU Architectures  like ARM. ([Link to PR](https://github.com/aws/graph-notebook/pull/323))
+  - Fix `service.sh` conditional checks, SSL parameter can now be changed. Fix permissions error on `service.sh` experienced by some users. ([Link to PR](https://localhost))
 - Added `%%neptune_config_allowlist` magic ([Link to PR](https://github.com/aws/graph-notebook/pull/327))
 
 ## Release 3.5.1 (July 12, 2022)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Reverted Gremlin console tab to single results column ([Link to PR](https://github.com/aws/graph-notebook/pull/330))
 - Bumped jquery-ui from 1.13.1 to 1.13.2 (([Link to PR](https://github.com/aws/graph-notebook/pull/328))
 - Docker support. Docker image can be built using the command `docker build .` and through Docker's `buildx`, this can support non-x86 CPU Architectures  like ARM. ([Link to PR](https://github.com/aws/graph-notebook/pull/323))
-  - Fix `service.sh` conditional checks, SSL parameter can now be changed. Fix permissions error on `service.sh` experienced by some users. ([Link to PR](https://localhost))
+  - Fix `service.sh` conditional checks, SSL parameter can now be changed. Fix permissions error on `service.sh` experienced by some users. ([Link to PR](https://github.com/aws/graph-notebook/pull/335))
 - Added `%%neptune_config_allowlist` magic ([Link to PR](https://github.com/aws/graph-notebook/pull/327))
 
 ## Release 3.5.1 (July 12, 2022)

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,6 @@ RUN mkdir -p "${WORKING_DIR}" && \
 
 ADD "docker/Example-Remote-Server-Setup.ipynb" "${NOTEBOOK_DIR}/Example-Remote-Server-Setup.ipynb"
 ADD ./docker/service.sh /usr/bin/service.sh
+RUN chmod +x /usr/bin/service.sh
 
 ENTRYPOINT [ "bash","-c","service.sh" ]

--- a/docker/service.sh
+++ b/docker/service.sh
@@ -1,10 +1,10 @@
 source /tmp/venv/bin/activate
 cd "${WORKING_DIR}"
-if [[ ${GRAPH_NOTEBOOK_SSL} -eq "" ]]; then
+if [ ${GRAPH_NOTEBOOK_SSL} = "" ]; then
     GRAPH_NOTEBOOK_SSL="True"
 fi
 
-if [[ ${PROVIDE_EXAMPLES} -eq 1 ]]; then
+if [ ${PROVIDE_EXAMPLES} -eq 1 ]; then
     python3 -m graph_notebook.notebooks.install --destination "${EXAMPLE_NOTEBOOK_DIR}"
 fi
 


### PR DESCRIPTION
Issue brought up by customer where the `GRAPH_NOTEBOOK_SSL` environment variable didn't effect the graph_notebook_config. Then some users receive permission errors when running `service.sh`. 

Description of changes:
- Change the way bash script performs conditional checks, so now conditionals are functional
- Added `chmod +x` command to take care of permissions error during execution.
- Changelog update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.