### PR TITLE
[Issue 336] Fixed %sparql_status magic to return query status without query ID.

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -553,7 +553,7 @@ class Graph(Magics):
         args = parser.parse_args(line.split())
 
         if not args.cancelQuery:
-            status_res = self.client.sparql_cancel(args.queryId)
+            status_res = self.client.sparql_status(query_id=args.queryId)
             status_res.raise_for_status()
             res = status_res.json()
         else:


### PR DESCRIPTION
Issue #, if available:  Issue 336

Description of changes:
Changed `%sparql_status` magic without query ID to call `sparql_status()` function instead of `sparql_cancel()` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.