### PR TITLE
Escape HTML characters when generating results table

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added silent output option to additional magics ([Link to PR](https://github.com/aws/graph-notebook/pull/326))
 - Fixed %sparql_status magic to return query status without query ID ([Link to PR](https://github.com/aws/graph-notebook/pull/337))
 - Fixed incorrect Gremlin query --store-to output ([Link to PR](https://github.com/aws/graph-notebook/pull/334))
+- Fixed certain characters not displaying correctly in results table ([Link to PR](https://github.com/aws/graph-notebook/pull/341))
 - Reverted Gremlin console tab to single results column ([Link to PR](https://github.com/aws/graph-notebook/pull/330))
 - Bumped jquery-ui from 1.13.1 to 1.13.2 (([Link to PR](https://github.com/aws/graph-notebook/pull/328))
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -478,6 +478,8 @@ class Graph(Magics):
                     rows_and_columns = sparql_get_rows_and_columns(results)
                     if rows_and_columns is not None:
                         results_df = pd.DataFrame(rows_and_columns['rows'])
+                        results_df = results_df.astype(str)
+                        results_df = results_df.applymap(lambda x: replace_html_chars(x))
                         results_df.insert(0, "#", range(1, len(results_df) + 1))
                         for col_index, col_name in enumerate(rows_and_columns['columns']):
                             try:

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -178,6 +178,16 @@ def generate_pagination_vars(visible_results: int):
     return visible_results_fixed, pagination_options, pagination_menu
 
 
+def replace_html_chars(result):
+    html_char_map = {"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"}
+    fixed_result = str(result)
+
+    for k, v in iter(html_char_map.items()):
+        fixed_result = fixed_result.replace(k, v)
+
+    return fixed_result
+
+
 # TODO: refactor large magic commands into their own modules like what we do with %neptune_ml
 # noinspection PyTypeChecker
 @magics_class
@@ -743,7 +753,10 @@ class Graph(Magics):
                 # If not, then render our own HTML template.
                 results_df = pd.DataFrame(query_res)
                 if not results_df.empty:
-                    query_res_reformat = [[result] for result in query_res]
+                    query_res_reformat = []
+                    for result in query_res:
+                        fixed_result = replace_html_chars(result)
+                        query_res_reformat.append([fixed_result])
                     query_res_reformat.append([{'__DUMMY_KEY__': ['DUMMY_VALUE']}])
                     results_df = pd.DataFrame(query_res_reformat)
                     results_df.drop(results_df.index[-1], inplace=True)
@@ -1929,6 +1942,8 @@ class Graph(Magics):
                 if rows_and_columns:
                     titles.append('Console')
                     results_df = pd.DataFrame(rows_and_columns['rows'])
+                    results_df = results_df.astype(str)
+                    results_df = results_df.applymap(lambda x: replace_html_chars(x))
                     results_df.insert(0, "#", range(1, len(results_df) + 1))
                     for col_index, col_name in enumerate(rows_and_columns['columns']):
                         results_df.rename({results_df.columns[col_index + 1]: col_name},
@@ -1969,6 +1984,8 @@ class Graph(Magics):
                 if rows_and_columns:
                     titles.append('Console')
                     results_df = pd.DataFrame(rows_and_columns['rows'])
+                    results_df = results_df.astype(str)
+                    results_df = results_df.applymap(lambda x: replace_html_chars(x))
                     results_df.insert(0, "#", range(1, len(results_df) + 1))
                     for col_index, col_name in enumerate(rows_and_columns['columns']):
                         results_df.rename({results_df.columns[col_index + 1]: col_name},


### PR DESCRIPTION
Issue #, if available: #340

Description of changes:
- Replace certain characters in data with their HTML entity equivalent prior to rendering the Console tab.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.