### PR TITLE
Remove extra index column on Gremlin results table

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed %sparql_status magic to return query status without query ID ([Link to PR](https://github.com/aws/graph-notebook/pull/337))
 - Fixed incorrect Gremlin query --store-to output ([Link to PR](https://github.com/aws/graph-notebook/pull/334))
 - Fixed certain characters not displaying correctly in results table ([Link to PR](https://github.com/aws/graph-notebook/pull/341))
+- Fixed extra index column displaying in Gremlin results table on older Pandas versions ([Link to PR](https://github.com/aws/graph-notebook/pull/343))
 - Reverted Gremlin console tab to single results column ([Link to PR](https://github.com/aws/graph-notebook/pull/330))
 - Bumped jquery-ui from 1.13.1 to 1.13.2 (([Link to PR](https://github.com/aws/graph-notebook/pull/328))
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -765,6 +765,9 @@ class Graph(Magics):
                 results_df.insert(0, "#", range(1, len(results_df) + 1))
                 if len(results_df.columns) == 2 and int(results_df.columns[1]) == 0:
                     results_df.rename({results_df.columns[1]: 'Result'}, axis='columns', inplace=True)
+                results_df.set_index('#', inplace=True)
+                results_df.columns.name = results_df.index.name
+                results_df.index.name = None
 
         if not args.silent:
             metadata_output = widgets.Output(layout=gremlin_layout)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed a visual bug occurring with `pandas<=1.3.5` (on Python<=3.7.x), where the the default Dataframe index column was unexpectedly displayed in the Gremlin query results table.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.