### PR TITLE
Add store-to option to %%graph_notebook_config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
   - Path: 06-Language-Tutorials > 01-SPARQL > 01-SPARQL-Basics
 - New Neptune ML - Text Encoding Tutorial notebook ([Link to PR](https://github.com/aws/graph-notebook/pull/338))
   - Path: 04-Machine-Learning > Neptune-ML-06-Text-Encoding-Tutorial
+- Added `--store-to` option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/347))
+
 
 ## Release 3.5.3 (July 25, 2022)
 - Docker support. Docker image can be built using the command `docker build .` and through Docker's `buildx`, this can support non-x86 CPU Architectures  like ARM. ([Link to PR](https://github.com/aws/graph-notebook/pull/323))


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added the `--store-to` option to the `%%graph_notebook_config` magic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.