### PR TITLE
Various results table improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - New Neptune ML - Text Encoding Tutorial notebook ([Link to PR](https://github.com/aws/graph-notebook/pull/338))
   - Path: 04-Machine-Learning > Neptune-ML-06-Text-Encoding-Tutorial
 - Added `--store-to` option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/347))
-
+- Various results table improvements ([Link to PR](https://github.com/aws/graph-notebook/pull/349))
 
 ## Release 3.5.3 (July 25, 2022)
 - Docker support. Docker image can be built using the command `docker build .` and through Docker's `buildx`, this can support non-x86 CPU Architectures  like ARM. ([Link to PR](https://github.com/aws/graph-notebook/pull/323))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -22,7 +22,7 @@ from graph_notebook.network.opencypher.OCNetwork import OCNetwork
 import ipywidgets as widgets
 import pandas as pd
 import itables.options as opt
-from itables import show
+from itables import show, JavascriptFunction
 from SPARQLWrapper import SPARQLWrapper
 from botocore.session import get_session
 from gremlin_python.driver.protocol import GremlinServerError
@@ -64,13 +64,27 @@ loading_wheel_template = retrieve_template("loading_wheel.html")
 error_template = retrieve_template("error.html")
 
 loading_wheel_html = loading_wheel_template.render()
-DEFAULT_LAYOUT = widgets.Layout(max_height='600px', overflow='scroll', width='100%')
+DEFAULT_LAYOUT = widgets.Layout(max_height='600px', max_width='940px', overflow='scroll')
 UNRESTRICTED_LAYOUT = widgets.Layout()
 
 DEFAULT_PAGINATION_OPTIONS = [10, 25, 50, 100, -1]
 DEFAULT_PAGINATION_MENU = [10, 25, 50, 100, "All"]
 opt.order = []
 opt.maxBytes = 0
+opt.classes = ["display", "hover", "nowrap"]
+index_col_js = """
+            function (td, cellData, rowData, row, col) {
+                $(td).css('font-weight', 'bold');
+                $(td).css('font-size', '12px');
+            }
+            """
+cell_style_js = """
+            function (td, cellData, rowData, row, col) {
+                $(td).css('font-family', 'monospace');
+                $(td).css('font-size', '12px');
+            }
+            """
+
 
 logging.basicConfig()
 root_logger = logging.getLogger()
@@ -543,10 +557,13 @@ class Graph(Magics):
                     visible_results, final_pagination_options, final_pagination_menu = generate_pagination_vars(
                         args.results_per_page)
                     show(results_df,
+                         scrollX=True,
                          scrollY=sparql_scrollY,
                          columnDefs=[
                              {"width": "5%", "targets": 0},
-                             {"className": "nowrap dt-left", "targets": "_all"}
+                             {"className": "nowrap dt-left", "targets": "_all"},
+                             {"createdCell": JavascriptFunction(index_col_js), "targets": 0},
+                             {"createdCell": JavascriptFunction(cell_style_js), "targets": "_all"}
                          ],
                          paging=sparql_paging,
                          scrollCollapse=sparql_scrollCollapse,
@@ -774,6 +791,8 @@ class Graph(Magics):
                 results_df.insert(0, "#", range(1, len(results_df) + 1))
                 if len(results_df.columns) == 2 and int(results_df.columns[1]) == 0:
                     results_df.rename({results_df.columns[1]: 'Result'}, axis='columns', inplace=True)
+                else:
+                    results_df.insert(1, "Result", [])
                 results_df.set_index('#', inplace=True)
                 results_df.columns.name = results_df.index.name
                 results_df.index.name = None
@@ -796,16 +815,19 @@ class Graph(Magics):
                     visible_results, final_pagination_options, final_pagination_menu = generate_pagination_vars(
                         args.results_per_page)
                     show(results_df,
+                         scrollX=True,
                          scrollY=gremlin_scrollY,
                          columnDefs=[
                              {"width": "5%", "targets": 0},
                              {"minWidth": "95%", "targets": 1},
-                             {"className": "nowrap dt-left", "targets": "_all"}
+                             {"className": "nowrap dt-left", "targets": "_all"},
+                             {"createdCell": JavascriptFunction(index_col_js), "targets": 0},
+                             {"createdCell": JavascriptFunction(cell_style_js), "targets": "_all"}
                          ],
                          paging=gremlin_paging,
                          scrollCollapse=gremlin_scrollCollapse,
                          lengthMenu=[final_pagination_options, final_pagination_menu],
-                         pageLength=visible_results
+                         pageLength=visible_results,
                          )
                 else:  # Explain/Profile
                     display(HTML(first_tab_html))
@@ -2040,10 +2062,13 @@ class Graph(Magics):
                     visible_results, final_pagination_options, final_pagination_menu = generate_pagination_vars(
                         args.results_per_page)
                     show(results_df,
+                         scrollX=True,
                          scrollY=oc_scrollY,
                          columnDefs=[
                              {"width": "5%", "targets": 0},
-                             {"className": "nowrap dt-left", "targets": "_all"}
+                             {"className": "nowrap dt-left", "targets": "_all"},
+                             {"createdCell": JavascriptFunction(index_col_js), "targets": 0},
+                             {"createdCell": JavascriptFunction(cell_style_js), "targets": "_all", }
                          ],
                          paging=oc_paging,
                          scrollCollapse=oc_scrollCollapse,


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Disabled line wrapping for result rows
- Reverted font of results to type `monospace` and size `12px`
- Fixed a bug where results table would display ambiguous `Loading...` message for empty results sets
- Fixed a JupyterLab-specific bug where the results table would render with a much greater width than the actual page size 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.