### PR TITLE
Deprecate Python 3.6 support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-stack-name
     steps:
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
           python-version: 3.7

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python 3.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python 3.6
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
           python-version: 3.7

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - New Neptune ML - Text Encoding Tutorial notebook ([Link to PR](https://github.com/aws/graph-notebook/pull/338))
   - Path: 04-Machine-Learning > Neptune-ML-06-Text-Encoding-Tutorial
 - Added `--store-to` option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/347))
-
+- Deprecated Python 3.6 support ([Link to PR](https://github.com/aws/graph-notebook/pull/353))
 
 ## Release 3.5.3 (July 25, 2022)
 - Docker support. Docker image can be built using the command `docker build .` and through Docker's `buildx`, this can support non-x86 CPU Architectures  like ARM. ([Link to PR](https://github.com/aws/graph-notebook/pull/323))

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It is recommended to check the [ChangeLog.md](ChangeLog.md) file periodically to
 
 You will need:
 
-* [Python](https://www.python.org/downloads/) 3.6.13-3.9.7
+* [Python](https://www.python.org/downloads/) 3.7.0-3.9.7
 * [RDFLib](https://pypi.org/project/rdflib/) 5.0.0
 * A graph database that provides one or more of:
   *  A SPARQL 1.1 endpoint 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ neo4j==4.2.1
 rdflib~=5.0.0
 traitlets~=4.3.3
 setuptools~=40.6.2
-nbconvert<6
+nbconvert>=6.3.0
 jedi<0.18.0
 markupsafe<2.1.0
 itables>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ ipython>=7.16.1,<7.17.0
 ipykernel==5.3.4
 neo4j==4.2.1
 rdflib~=5.0.0
-traitlets~=4.3.3
 setuptools~=40.6.2
 nbconvert>=6.3.0
 jedi<0.18.0

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'neo4j==4.3.2',
         'rdflib==5.0.0',
         'ipykernel==5.3.4',
-        'nbconvert==5.6.1',
+        'nbconvert>=6.3.0',
         'jedi<0.18.0',
         'markupsafe<2.1.0',
         'itables>=1.0.0',
@@ -96,7 +96,7 @@ setup(
     cmdclass=cmd_class,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: Apache Software License'
     ],
     keywords='jupyter neptune gremlin sparql',


### PR DESCRIPTION
Issue #, if available: CVE-2021-32862

Description of changes:
- Upgraded minimum required Python version to 3.7.0
- Bumped `nbconvert` dependency to `>=6.3.0`
- Removed `traitlets` version pin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.