### PR TITLE
Add --all-in-queue option to %cancel_load

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - New Neptune ML - Text Encoding Tutorial notebook ([Link to PR](https://github.com/aws/graph-notebook/pull/338))
   - Path: 04-Machine-Learning > Neptune-ML-06-Text-Encoding-Tutorial
 - Added `--store-to` option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/347))
+- Added `--all-in-queue` option to `%cancel_load` ([Link to PR](https://github.com/aws/graph-notebook/pull/355))
 - Deprecated Python 3.6 support ([Link to PR](https://github.com/aws/graph-notebook/pull/353))
 - Various results table improvements ([Link to PR](https://github.com/aws/graph-notebook/pull/349))
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ We encourage others to contribute configurations they find useful. There is an [
 
 `%load_status` - Get the status of a provided `load_id`. [Documentation](https://docs.aws.amazon.com/neptune/latest/userguide/load-api-reference-status-examples.html)
 
+`%cancel_load` - Cancels a bulk load job. You can either provide a single `load_id`, or specify `--all-in-queue` to cancel all queued (and not actively running) jobs. [Documentation](https://docs.aws.amazon.com/neptune/latest/userguide/load-api-reference-cancel.html)
+
 `%neptune_ml` - Set of commands to integrate with NeptuneML functionality. You can find a set of tutorial notebooks [here](https://github.com/aws/graph-notebook/tree/main/src/graph_notebook/notebooks/04-Machine-Learning).
 [Documentation](https://aws.amazon.com/neptune/machine-learning/)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -202,6 +202,16 @@ def replace_html_chars(result):
     return fixed_result
 
 
+def get_load_ids(neptune_client):
+    load_status = neptune_client.load_status()
+    load_status.raise_for_status()
+    res = load_status.json()
+    ids = []
+    if 'payload' in res and 'loadIds' in res['payload']:
+        ids = res['payload']['loadIds']
+    return ids, res
+
+
 # TODO: refactor large magic commands into their own modules like what we do with %neptune_ml
 # noinspection PyTypeChecker
 @magics_class
@@ -1584,12 +1594,7 @@ class Graph(Magics):
         parser.add_argument('--store-to', type=str, default='')
         args = parser.parse_args(line.split())
 
-        load_status = self.client.load_status()
-        load_status.raise_for_status()
-        res = load_status.json()
-        ids = []
-        if 'payload' in res and 'loadIds' in res['payload']:
-            ids = res['payload']['loadIds']
+        ids, res = get_load_ids(self.client)
 
         labels = [widgets.Label(value=label_id) for label_id in ids]
 
@@ -1639,22 +1644,50 @@ class Graph(Magics):
     @needs_local_scope
     def cancel_load(self, line, local_ns: dict = None):
         parser = argparse.ArgumentParser()
-        parser.add_argument('load_id', default='', help='loader id to check status for')
+        parser.add_argument('load_id', nargs="?", default='', help='loader id to check status for')
+        parser.add_argument('--all-in-queue', action='store_true', default=False,
+                            help="Cancel all load jobs with LOAD_IN_QUEUE status.")
         parser.add_argument('--silent', action='store_true', default=False, help="Display no output.")
         parser.add_argument('--store-to', type=str, default='')
         args = parser.parse_args(line.split())
 
-        cancel_res = self.client.cancel_load(args.load_id)
-        cancel_res.raise_for_status()
-        res = cancel_res.json()
-        if not args.silent:
+        loads_to_cancel = []
+        raw_res = {}
+        print_res = {}
+
+        if args.load_id:
+            loads_to_cancel.append(args.load_id)
+        elif args.all_in_queue:
+            all_job_ids = get_load_ids(self.client)[0]
+            for job_id in all_job_ids:
+                load_status_res = self.client.load_status(job_id)
+                load_status_res.raise_for_status()
+                this_res = load_status_res.json()
+                if this_res["payload"]["overallStatus"]["status"] == "LOAD_IN_QUEUE":
+                    loads_to_cancel.append(job_id)
+        else:
+            print("Please specify either a single load_id or --all-in-queue.")
+            return
+
+        for load_id in loads_to_cancel:
+            cancel_res = self.client.cancel_load(load_id)
+            cancel_res.raise_for_status()
+            res = cancel_res.json()
             if res:
-                print('Cancelled successfully.')
+                raw_res[load_id] = res
+                print_res[load_id] = 'Cancelled successfully.'
             else:
-                print('Something went wrong cancelling bulk load job.')
+                raw_res[load_id] = 'Something went wrong cancelling bulk load job.'
+                print_res[load_id] = 'Something went wrong cancelling bulk load job.'
+
+        if not args.silent:
+            if print_res:
+                print(json.dumps(print_res, indent=2))
+            else:
+                print("No cancellable load jobs were found.")
 
         if args.store_to != '' and local_ns is not None:
-            local_ns[args.store_to] = res
+            local_ns[args.store_to] = raw_res
 
     @line_magic
     @display_exceptions


### PR DESCRIPTION
Issue #, if available: #351

Description of changes:
- Added `--all-in-queue` flag to `%cancel_load`. When specified, all bulk load jobs with `LOAD_IN_QUEUE` status will be cancelled.
- Added helpful error messaging for when `%cancel_load` receives insufficient arguments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.