### PR TITLE
Integration test workflow updates

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pytest
+          pip install jupyterlab>=3
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Install
         run: |
@@ -57,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-stack-name, create-stack]
     steps:
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Updated `run-tests` step to use Python 3.7, due to previous deprecation of 3.6 support
- Updated `create-stack` step to install newer required dependencies for package build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.