### PR TITLE
Disable automatic collapsing of large explain results

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added `--all-in-queue` option to `%cancel_load` ([Link to PR](https://github.com/aws/graph-notebook/pull/355))
 - Deprecated Python 3.6 support ([Link to PR](https://github.com/aws/graph-notebook/pull/353))
 - Various results table improvements ([Link to PR](https://github.com/aws/graph-notebook/pull/349))
+- Disabled automatic collapsing of large explain results ([Link to PR](https://github.com/aws/graph-notebook/pull/363))
 - Fixed version-specific steps in SageMaker installation script ([Link to PR](https://github.com/aws/graph-notebook/pull/359))
 - Added new SageMaker installation script for China regions ([Link to PR](https://github.com/aws/graph-notebook/pull/361))
 

--- a/src/graph_notebook/visualization/templates/gremlin_explain_profile.html
+++ b/src/graph_notebook/visualization/templates/gremlin_explain_profile.html
@@ -8,6 +8,17 @@
                 font-size: 1em !important;
                 font-family: "Courier New", Courier, monospace !important;
             }
+
+            .jupyter-widgets-output-area .output_scroll {
+            height: unset !important;
+            border-radius: unset !important;
+            -webkit-box-shadow: unset !important;
+            box-shadow: unset !important;
+            }
+
+            .jupyter-widgets-output-area  {
+                height: auto !important;
+            }
         </style>
     {% endblock %}
     <a download="explain.txt" href={{link}} style="float:right">Download</a>

--- a/src/graph_notebook/visualization/templates/opencypher_explain.html
+++ b/src/graph_notebook/visualization/templates/opencypher_explain.html
@@ -37,6 +37,17 @@
             padding-bottom: 12px;
             text-align: left;
         }
+
+        .jupyter-widgets-output-area .output_scroll {
+            height: unset !important;
+            border-radius: unset !important;
+            -webkit-box-shadow: unset !important;
+            box-shadow: unset !important;
+        }
+
+        .jupyter-widgets-output-area  {
+            height: auto !important;
+        }
     </style>
 <div class="oc_explain">
     <form method="get" action="file.doc">

--- a/src/graph_notebook/visualization/templates/sparql_explain.html
+++ b/src/graph_notebook/visualization/templates/sparql_explain.html
@@ -37,6 +37,17 @@
             padding-bottom: 12px;
             text-align: left;
         }
+
+        .jupyter-widgets-output-area .output_scroll {
+            height: unset !important;
+            border-radius: unset !important;
+            -webkit-box-shadow: unset !important;
+            box-shadow: unset !important;
+        }
+
+        .jupyter-widgets-output-area  {
+            height: auto !important;
+        }
     </style>
     {% endblock %}
 <div class="sparql_explain">


### PR DESCRIPTION
Issue #, if available: #362

Description of changes:
- Modified profile/explain HTML templates to prevent ipywidgets from automatically collapsing large results. Applies the workaround found [here](https://github.com/jupyter-widgets/ipywidgets/issues/1791#issuecomment-578407750).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.