### PR TITLE
Update sample notebooks with parallel, same-direction edges example

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Update sample notebooks with parallel, same-direction edges example ([Link to PR](https://github.com/aws/graph-notebook/pull/366))
 
 ## Release 3.6.0 (September 15, 2022)
 - New Language Tutorials - SPARQL Basics notebook ([Link to PR](https://github.com/aws/graph-notebook/pull/316))

--- a/src/graph_notebook/notebooks/02-Visualization/Grouping-and-Appearance-Customization-Gremlin.ipynb
+++ b/src/graph_notebook/notebooks/02-Visualization/Grouping-and-Appearance-Customization-Gremlin.ipynb
@@ -671,18 +671,19 @@
    "id": "mental-knowing",
    "metadata": {},
    "source": [
-    "Now that we know how to group our vertices together let's take a look at how to customize the appearance of these groups.\n",
+    "Now that we know how to group our vertices together let's take a look at how to customize the appearance of these groups, and other aspects of the graph.\n",
     "\n",
-    "## Group Customization\n",
+    "## Appearance Customization\n",
+    "\n",
     "The Amazon Neptune Notebooks use an open source library called [Vis.js](https://github.com/visjs) to assist with drawing the graph diagrams. Vis.js provides a rich set of customizable settings. The documentation for most of the visualization settings used in this notebook can be found [here](https://visjs.org/) and in particular the graph network drawing documentation can be found [here](https://visjs.github.io/vis-network/docs/network/).  \n",
     "\n",
     "To see the current settings used by your notebook you can use the `%graph_notebook_vis_options` line magic command. Try running the cell below.  \n",
     "\n",
     "To change any of these settings create a new cell and use `%%graph_notebook_vis_options` to change them (note the two percent signs indicating a cell magic).\n",
     "\n",
-    "To customize the appearance of the the groups we want to use the [groups](https://visjs.github.io/vis-network/docs/network/groups.html#) options.  Their is a nearly endless amount of customization you can make to the groups using the options provided but we will demonstrate some of the most common ones in the next few sections.\n",
+    "To customize the appearance of node groups, we want to use the [groups](https://visjs.github.io/vis-network/docs/network/groups.html#) options. There is a nearly endless amount of customization you can make to the groups using the options provided, but we will demonstrate some of the most common ones in the next few sections.\n",
     "\n",
-    "### Specifying Colors\n",
+    "### Specifying Group Colors\n",
     "\n",
     "Specifying the colors of groups is probably one of the most common customizations performed.  To accomplish this we specify the options using the `%%graph_notebook_vis_options` magic as shown below.  For each of the associated group names we use the exact property value followed by the options you would like to use for that group.\n",
     "\n",
@@ -724,7 +725,7 @@
    "id": "tough-vatican",
    "metadata": {},
    "source": [
-    "### Specifying Shape\n",
+    "### Specifying Group Shapes\n",
     "\n",
     "In addition to specifying the color of the groups you are also able to customize the shape of the vertex using one of the following options. \n",
     "\n",
@@ -768,7 +769,7 @@
    "id": "essential-jewel",
    "metadata": {},
    "source": [
-    "### Specifying Icons and Images\n",
+    "### Specifying Group Icons and Images\n",
     "\n",
     "In addition to specifying shapes icons and images can also be specified to represent our groups.  \n",
     "\n",
@@ -821,9 +822,9 @@
    "id": "transsexual-judgment",
    "metadata": {},
    "source": [
-    "### Specifying Size\n",
+    "### Specifying Group Sizes\n",
     "\n",
-    "The last customization we are going to demonstrate is the ability to set the size for the group.  This is accomplished by setting the `size` property of the group. \n",
+    "We can also specify a custom value for a group's node size. This is accomplished by setting the `size` property of the group.\n",
     "\n",
     "**Note** Only shapes that do not have the label inside them are impacted by this property."
    ]
@@ -871,10 +872,159 @@
    "id": "familiar-radical",
    "metadata": {},
    "source": [
+    "### Specifying Parallel Same-Direction Edge Behavior\n",
+    "\n",
+    "There is one more customization option, which allows for parallel, same-direction edges to either be drawn on top of each other (default), or spaced apart.\n",
+    "\n",
+    "Let's start by running the following cell to create such a scenario in the air-routes graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%gremlin\n",
+    "g.addV(\"airport\").property(id,\"10000\").property(\"type\",\"airport\").property(\"code\",\"FOO\").property(\"country\", \"BAR\").\n",
+    "  addE(\"route\").property(id,\"1\").from(V(\"365\")).to(V(\"10000\")).property(\"dist\",1000).\n",
+    "  addE(\"route\").property(id,\"2\").from(V(\"365\")).to(V(\"10000\")).property(\"dist\",2000).\n",
+    "  addE(\"route\").property(id,\"3\").from(V(\"365\")).to(V(\"10000\")).property(\"dist\",3000)."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Now, run the next cell to visualize the new node and edges."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%gremlin -g country -d code -de dist\n",
+    "g.V().hasLabel('airport').has('code','CZM').outE().inV().has('code','FOO').path().by(elementMap())"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Notice that three different edges are returned in the results, but the visualized graph only appears to have one edge.\n",
+    "\n",
+    "This is a result of the default value `straightCross` used for the `edges`->`smooth`->`type` vis setting. All of the parallel edges technically exist in the graph visualization, but the `straightCross` setting draws the edges on top of each other, obscuring all but one.\n",
+    "\n",
+    "To fix this, we can set the edge smoothing type to `dynamic`. Run the two cells below to observe the result."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%graph_notebook_vis_options\n",
+    "{\n",
+    "  \"edges\": {\n",
+    "    \"color\": {\n",
+    "      \"inherit\": false\n",
+    "    },\n",
+    "    \"smooth\": {\n",
+    "      \"enabled\": true,\n",
+    "      \"type\": \"dynamic\"\n",
+    "    },\n",
+    "    \"arrows\": {\n",
+    "      \"to\": {\n",
+    "        \"enabled\": true,\n",
+    "        \"type\": \"arrow\"\n",
+    "      }\n",
+    "    },\n",
+    "    \"font\": {\n",
+    "      \"face\": \"courier new\"\n",
+    "    }\n",
+    "  }\n",
+    "}"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%gremlin -g country -d code -de dist\n",
+    "g.V().hasLabel('airport').has('code','CZM').outE().inV().has('code','FOO').path().by(elementMap())"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "With the `dynamic` setting, all of the edges are now spaced out and clearly visible.\n",
+    "\n",
+    "Lastly, clean up the dummy data we inserted for this example."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%gremlin\n",
+    "g.V().hasId('10000').drop()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
     "## Conclusion\n",
     "\n",
     "What we have demonstrated in this notebook is only a small set of the options and combinations available for customizing the appearance of groups within the notebook.  Please refer to the [Vis.js groups](https://visjs.github.io/vis-network/docs/network/groups.html#) documentation for a complete list of the options available."
-   ]
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   }
  ],
  "metadata": {


### PR DESCRIPTION
Issue #, if available: #157

Description of changes:
- Updated the `Grouping-and-Appearance-Customization-Gremlin` sample notebook with an example of how to use the `dynamic` edge smoothing setting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.