### PR TITLE
Fix %db_reset timeout handling, make timeout limit configurable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Fixed a Gremlin widgets error caused by empty individual results ([Link to PR](https://github.com/aws/graph-notebook/pull/367))
+- Fix `%db_reset` timeout handling, made timeout limit configurable ([Link to PR](https://github.com/aws/graph-notebook/pull/369))
 
 ## Release 3.6.0 (September 15, 2022)
 - New Language Tutorials - SPARQL Basics notebook ([Link to PR](https://github.com/aws/graph-notebook/pull/316))


### PR DESCRIPTION
Issue #, if available: #368

Description of changes:
- Fixed `UnboundLocalError` failure occurring when `%db_reset` is unable to retrieve database status within the allotted time limit
- Added new `--max-status-retries` option to `%db_reset`; allows the user to configure the maximum time limit for checking if the database reset has completed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.