### PR TITLE
Fix Sparql visualizations failing with VisJS group assignment error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Fixed a Gremlin widgets error caused by empty individual results ([Link to PR](https://github.com/aws/graph-notebook/pull/367))
-- Fix `%db_reset` timeout handling, made timeout limit configurable ([Link to PR](https://github.com/aws/graph-notebook/pull/369))
+- Fixed `%db_reset` timeout handling, made timeout limit configurable ([Link to PR](https://github.com/aws/graph-notebook/pull/369))
+- Fixed Sparql visualizations occasionally failing with VisJS group assignment error ([Link to PR](https://github.com/aws/graph-notebook/pull/375))
 - Added `--hide-index` option for query results ([Link to PR](https://github.com/aws/graph-notebook/pull/371))
 
 ## Release 3.6.0 (September 15, 2022)

--- a/src/graph_notebook/network/sparql/SPARQLNetwork.py
+++ b/src/graph_notebook/network/sparql/SPARQLNetwork.py
@@ -212,11 +212,11 @@ class SPARQLNetwork(EventfulNetwork):
         if 'label' not in data:
             data = self.generate_node_label_title(node_id=node_id, data=data)
         if self.ignore_groups or not node_binding:
-            data['group'] = DEFAULT_GRP
+            node_group = DEFAULT_GRP
         elif str(self.group_by_property) == DEFAULT_RAW_GRP_KEY:
-            data['group'] = str(node_binding)
+            node_group = str(node_binding)
         else:
-            data['group'] = None
+            node_group = None
             node_type = self.get_node_class(data)
             if isinstance(self.group_by_property, dict):
                 # if rdf:type or similar node class identifier does not exist on the node, set group to the default.
@@ -225,29 +225,30 @@ class SPARQLNetwork(EventfulNetwork):
                         if node_type in self.group_by_property:
                             group_by_for_type = self.group_by_property[node_type]
                             if group_by_for_type == DEFAULT_RAW_GRP_KEY:
-                                data['group'] = str(node_binding)
+                                node_group = str(node_binding)
                             elif group_by_for_type[:2] == "P." and 'properties' in data:
-                                data['group'] = self.retrieve_object_property_value(group_by_for_type[2:],
-                                                                                    data['properties'])
+                                node_group = self.retrieve_object_property_value(group_by_for_type[2:],
+                                                                                 data['properties'])
                             else:
-                                data['group'] = node_binding[group_by_for_type]
+                                node_group = node_binding[group_by_for_type]
                         else:
-                            data['group'] = node_type
+                            node_group = node_type
                     except KeyError:
-                        data['group'] = node_type
+                        node_group = node_type
                 else:
-                    data['group'] = DEFAULT_GRP
+                    node_group = DEFAULT_GRP
             elif self.group_by_property[:2] == "P." and 'properties' in data:
-                data['group'] = self.retrieve_object_property_value(self.group_by_property[2:],
-                                                                    data['properties'])
+                node_group = self.retrieve_object_property_value(self.group_by_property[2:],
+                                                                 data['properties'])
             elif self.group_by_property in node_binding:
-                data['group'] = node_binding[self.group_by_property]
+                node_group = node_binding[self.group_by_property]
 
-            if not data['group']:
+            if not node_group:
                 if node_type:
-                    data['group'] = node_type
+                    node_group = node_type
                 else:
-                    data['group'] = DEFAULT_GRP
+                    node_group = DEFAULT_GRP
+        data['group'] = str(node_group)
 
         self.add_node(node_id=node_id, data=data)
 

--- a/test/unit/network/sparql/data/010_airroutes_no_literals.json
+++ b/test/unit/network/sparql/data/010_airroutes_no_literals.json
@@ -77,6 +77,34 @@
           "type": "uri",
           "value": "http://kelvinlawrence.net/air-routes/objectProperty/route"
         }
+      },
+      {
+        "s": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/400"
+        },
+        "o": {
+          "type": "uri",
+          "value": "http://www.example.com/example/ontology/airport"
+        },
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        }
+      },
+      {
+        "s": {
+          "type": "uri",
+          "value": "http://kelvinlawrence.net/air-routes/resource/400"
+        },
+        "o": {
+          "type": "uri",
+          "value": "http://www.example.com/example/ontology/regional"
+        },
+        "p": {
+          "type": "uri",
+          "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        }
       }
     ]
   }

--- a/test/unit/network/sparql/test_sparql_network.py
+++ b/test/unit/network/sparql/test_sparql_network.py
@@ -232,6 +232,13 @@ class TestSPARQLNetwork(unittest.TestCase):
         node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/365')
         self.assertEqual('DEFAULT_GROUP', node['group'])
 
+    def test_sparql_network_group_default_multiple_types(self):
+        sparql_network = SPARQLNetwork()
+        data = get_sparql_result('010_airroutes_no_literals.json')
+        sparql_network.add_results(data)
+        node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/400')
+        self.assertEqual("['ontology:airport', 'ontology:regional']", node['group'])
+
     def test_sparql_network_group_default_no_properties(self):
         sparql_network = SPARQLNetwork()
         data = get_sparql_result('010_airroutes_no_literals.json')
@@ -245,6 +252,13 @@ class TestSPARQLNetwork(unittest.TestCase):
         sparql_network.add_results(data)
         node = sparql_network.graph.nodes.get('http://www.example.com/soccer/resource#Newcastle_United')
         self.assertEqual("1892", node['group'])
+
+    def test_sparql_network_group_nested_properties_string_multiproperty(self):
+        sparql_network = SPARQLNetwork(group_by_property='P.rdf:type')
+        data = get_sparql_result('010_airroutes_no_literals.json')
+        sparql_network.add_results(data)
+        node = sparql_network.graph.nodes.get('http://kelvinlawrence.net/air-routes/resource/400')
+        self.assertEqual("['ontology:airport', 'ontology:regional']", node['group'])
 
     def test_sparql_network_group_nested_properties_string_invalid_prop(self):
         sparql_network = SPARQLNetwork(group_by_property='P.ontology:wins')


### PR DESCRIPTION
Issue #, if available: #374

Description of changes:
- Fixed an issue where the`%%sparql` graph tab would render blank or with the exception `Error: updateGroupOptions: group values in options don't match.`. Properties with multiple values for a single subject will now be handled correctly when used in node grouping.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.