### PR TITLE
Fix `start jupyterlab` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ pip install "jupyterlab>=3"
 python -m graph_notebook.notebooks.install --destination ~/notebook/destination/dir
 
 # start jupyterlab
-python -m graph_notebook.start_jupyterlab —-jupyter-dir ~/notebook/destination/dir
+python -m graph_notebook.start_jupyterlab --jupyter-dir ~/notebook/destination/dir
 ```
 
 #### Loading magic extensions in JupyterLab


### PR DESCRIPTION
Issue #, if available:

Description of changes: Fix `start jupyterlab` command in README

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.