### PR TITLE
Pin notebook to <6.5.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed a Gremlin widgets error caused by empty individual results ([Link to PR](https://github.com/aws/graph-notebook/pull/367))
 - Fixed `%db_reset` timeout handling, made timeout limit configurable ([Link to PR](https://github.com/aws/graph-notebook/pull/369))
 - Fixed Sparql visualizations occasionally failing with VisJS group assignment error ([Link to PR](https://github.com/aws/graph-notebook/pull/375))
+- Fixed interface rendering issue in classic notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/378))
 - Added `--hide-index` option for query results ([Link to PR](https://github.com/aws/graph-notebook/pull/371))
 - Added result media type selection for SPARQL queries ([Link to PR](https://github.com/aws/graph-notebook/pull/313))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ SPARQLWrapper==1.8.4
 networkx==2.4
 Jinja2==3.0.3
 jupyter
-notebook>=6.1.5
+notebook>=6.1.5,<6.5.0
 ipywidgets==7.5.1
 jupyter-contrib-nbextensions
 widgetsnbextension

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'ipywidgets',
         'networkx==2.4',
         'Jinja2==3.0.3',
-        'notebook>=6.1.5',
+        'notebook>=6.1.5,<6.5.0',
         'jupyter-contrib-nbextensions',
         'widgetsnbextension',
         'jupyter>=1.0.0',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Pinning `notebook` dependency to `<6.5.0` to mitigate [a possible bug on `notebook==6.5.1`](https://github.com/jupyter/notebook/issues/6573) causing all CSS rendering to fail in notebook classic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.