### PR TITLE
Initialize security-graph seed data

### DIFF
--- a/src/graph_notebook/seed/queries/propertygraph/security-graph/__init__.py
+++ b/src/graph_notebook/seed/queries/propertygraph/security-graph/__init__.py
@@ -1,0 +1,4 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Add init file to `propertygraph/security-graph` seed data folder to allow `%seed` to find the files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.