### PR TITLE
Enforce Neptune-specific config only for Neptune endpoints

### DIFF
--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -248,8 +248,6 @@ if __name__ == "__main__":
                         default=True)
     parser.add_argument("--neo4j_database", help="the name of the database to use for Neo4J",
                         default=DEFAULT_NEO4J_DATABASE)
-    parser.add_argument("--neptune_hosts", help="list of host snippets to use for identifying neptune endpoints",
-                        default=DEFAULT_CONFIG_LOCATION)
     args = parser.parse_args()
 
     auth_mode_arg = args.auth_mode if args.auth_mode != '' else AuthModeEnum.DEFAULT.value

--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -171,8 +171,9 @@ if __name__ == "__main__":
     parser.add_argument("--aws_region", help="aws region your ml cluster is in.", default=DEFAULT_REGION)
     parser.add_argument("--proxy_host", help="the proxy host url to route a connection through", default='')
     parser.add_argument("--proxy_port", help="the proxy port to use when creating proxy connection", default=8182)
-    parser.add_argument("--neptune_hosts", help="list of host snippets to use for identifying neptune endpoints",
-                        default=DEFAULT_CONFIG_LOCATION)
+    parser.add_argument("--neptune_hosts", nargs="*",
+                        help="list of host snippets to use for identifying neptune endpoints",
+                        default=NEPTUNE_CONFIG_HOST_IDENTIFIERS)
     args = parser.parse_args()
 
     auth_mode_arg = args.auth_mode if args.auth_mode != '' else AuthModeEnum.DEFAULT.value

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -92,14 +92,15 @@ STREAM_PG = 'PropertyGraph'
 STREAM_RDF = 'RDF'
 STREAM_ENDPOINTS = {STREAM_PG: 'gremlin', STREAM_RDF: 'sparql'}
 
-NEPTUNE_CONFIG_HOST_IDENTIFIERS = ["amazonaws.com"]
+NEPTUNE_CONFIG_HOST_IDENTIFIERS = ["neptune.amazonaws.com", "neptune.*.amazonaws.com.cn"]
 
 STATISTICS_MODES = ["status", "disableAutoCompute", "enableAutoCompute", "refresh", "delete"]
 STATISTICS_LANGUAGE_INPUTS = ["propertygraph", "pg", "gremlin", "sparql", "rdf"]
 
+
 def is_allowed_neptune_host(hostname: str, host_allowlist: list):
     for host_snippet in host_allowlist:
-        if host_snippet in hostname:
+        if re.search(host_snippet, hostname):
             return True
     return False
 

--- a/test/integration/IntegrationTest.py
+++ b/test/integration/IntegrationTest.py
@@ -9,12 +9,12 @@ from botocore.session import get_session
 
 from graph_notebook.configuration.generate_config import Configuration, AuthModeEnum
 from graph_notebook.configuration.get_config import get_config
-from graph_notebook.neptune.client import ClientBuilder
+from graph_notebook.neptune.client import ClientBuilder, NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_allowed_neptune_host
 from test.integration.NeptuneIntegrationWorkflowSteps import TEST_CONFIG_PATH
 
 
 def setup_client_builder(config: Configuration) -> ClientBuilder:
-    if "amazonaws.com" in config.host:
+    if is_allowed_neptune_host(config.host, NEPTUNE_CONFIG_HOST_IDENTIFIERS):
         builder = ClientBuilder() \
             .with_host(config.host) \
             .with_port(config.port) \

--- a/test/unit/configuration/test_configuration_from_main.py
+++ b/test/unit/configuration/test_configuration_from_main.py
@@ -75,7 +75,7 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '
                            f'--host "{expected_config.host}" --port "{expected_config.port}" --auth_mode "" --ssl "" '
                            f'--load_from_s3_arn "" --config_destination="{self.test_file_path}" '
-                           f'--neptune_hosts {self.custom_hosts_list}')
+                           f'--neptune_hosts {self.custom_hosts_list[0]}')
         self.assertEqual(0, result)
         config = get_config(self.test_file_path, neptune_hosts=self.custom_hosts_list)
         self.assertEqual(expected_config.to_dict(), config.to_dict())


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Changed `%%graph_notebook_config` default behavior to enforce Neptune-specific configuration options only when the host is a Neptune endpoint (i.e. `*.neptune.amazonaws.com` or `*.neptune.*.amazonaws.com.cn`), rather than any AWS endpoint (`*.amazonaws.com`). This allows non-Neptune configuration options to be used for AWS endpoints hosting separate graph databases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.