### PR TITLE
Fix SPARQL EPL seed file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added custom Gremlin authentication and serializer support ([Link to PR](https://github.com/aws/graph-notebook/pull/356))
 - Added `%statistics` magic for Neptune DFE engine ([Link to PR](https://github.com/aws/graph-notebook/pull/377))
 - Updated [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) for openCypher ([Link to PR](https://github.com/aws/graph-notebook/pull/387))
+- Fixed `%seed` failing to load SPARQL EPL dataset ([Link to PR](https://github.com/aws/graph-notebook/pull/389))
 
 ## Release 3.6.2 (October 18, 2022)
 - New Sample Applications - Security Graphs notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/373))

--- a/src/graph_notebook/seed/queries/rdf/epl/0_epl_data.txt
+++ b/src/graph_notebook/seed/queries/rdf/epl/0_epl_data.txt
@@ -1,5 +1,3 @@
-%%sparql
-
 PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl:  <http://www.w3.org/2002/07/owl#>


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed an bug where `%seed` would fail to load SPARQL EPL due to a malformed query in the data file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.