### PR TITLE
Bump typescript to 4.1.x in graph_notebook_widgets

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,9 +6,11 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added Neo4J section to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/331))
 - Added custom Gremlin authentication and serializer support ([Link to PR](https://github.com/aws/graph-notebook/pull/356))
 - Added `%statistics` magic for Neptune DFE engine ([Link to PR](https://github.com/aws/graph-notebook/pull/377))
-- Fixed results not being displayed for SPARQL ASK queries ([Link to PR](https://github.com/aws/graph-notebook/pull/385))
 - Updated [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) for openCypher ([Link to PR](https://github.com/aws/graph-notebook/pull/387))
+- Fixed results not being displayed for SPARQL ASK queries ([Link to PR](https://github.com/aws/graph-notebook/pull/385))
 - Fixed `%seed` failing to load SPARQL EPL dataset ([Link to PR](https://github.com/aws/graph-notebook/pull/389))
+- Fixed edge label creation in `02-Using-Gremlin-to-Access-the-Graph` ([Link to PR](https://github.com/aws/graph-notebook/pull/390))
+- Bumped typescript to 4.1.x in graph_notebook_widgets ([Link to PR](https://github.com/aws/graph-notebook/pull/393))
 
 ## Release 3.6.2 (October 18, 2022)
 - New Sample Applications - Security Graphs notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/373))

--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -52,7 +52,7 @@
     "source-map-loader": "0.2.4",
     "style-loader": "1.2.1",
     "ts-loader": "5.4.5",
-    "typescript": "3.8.3",
+    "typescript": "4.1.6",
     "webpack": "4.43.0",
     "webpack-cli": "3.3.11",
     "webpack-dev-server": "3.11.0"


### PR DESCRIPTION
Issue #, if available: #392

Description of changes:
- Upgraded `graph_notebook_widgets` dev dependency `typescript` from `3.8.3` to `4.1.6`. This brings us back in line the TypeScript version used by `@jupyterlab/buildutils`: https://github.com/jupyterlab/jupyterlab/blob/3.6.x/buildutils/package.json#L59

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.