### PR TITLE
Pin ipywidgets to <=7.7.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,11 +11,11 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Updated [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) for openCypher ([Link to PR](https://github.com/aws/graph-notebook/pull/387))
 - Fixed results not being displayed for SPARQL ASK queries ([Link to PR](https://github.com/aws/graph-notebook/pull/385))
 - Fixed `%seed` failing to load SPARQL EPL dataset ([Link to PR](https://github.com/aws/graph-notebook/pull/389))
-- Fixed `%db_reset` status output not displaying in JupyterLab ([Link to PR](https://github.com/aws/graph-notebook/pull/391)
+- Fixed `%db_reset` status output not displaying in JupyterLab ([Link to PR](https://github.com/aws/graph-notebook/pull/391))
 - Fixed `%%gremlin` throwing error for result sets with multiple datatypes [Link to PR](https://github.com/aws/graph-notebook/pull/388))
 - Fixed edge label creation in `02-Using-Gremlin-to-Access-the-Graph` ([Link to PR](https://github.com/aws/graph-notebook/pull/390))
-
 - Bumped typescript to 4.1.x in graph_notebook_widgets ([Link to PR](https://github.com/aws/graph-notebook/pull/393))
+- Pinned ipywidgets to `<=7.x` ([Link to PR](https://github.com/aws/graph-notebook/pull/398))
 
 ## Release 3.6.2 (October 18, 2022)
 - New Sample Applications - Security Graphs notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/373))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ networkx==2.4
 Jinja2==3.0.3
 jupyter
 notebook>=6.1.5,<6.5.0
-ipywidgets==7.5.1
+ipywidgets<=7.7.1
 jupyter-contrib-nbextensions
 widgetsnbextension
 gremlinpython>=3.5.1

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'gremlinpython>=3.5.1',
         'SPARQLWrapper==1.8.4',
         'requests',
-        'ipywidgets',
+        'ipywidgets<=7.7.1',
         'networkx==2.4',
         'Jinja2==3.0.3',
         'notebook>=6.1.5,<6.5.0',


### PR DESCRIPTION
Issue #, if available: #397

Description of changes:
- Pinned `ipywidgets` dependency to `<=7.x` to resolve issues caused by incompatibility with the latest major version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.