### PR TITLE
Update sample SageMaker lifecycles to latest versions

### DIFF
--- a/additional-databases/sagemaker/install-graph-notebook-lc-cn.sh
+++ b/additional-databases/sagemaker/install-graph-notebook-lc-cn.sh
@@ -30,6 +30,8 @@ pip uninstall NeptuneGraphNotebook -y # legacy uninstall when we used to install
 
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "jupyter-console<=6.4.0"
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "jupyter-client<=6.1.12"
+pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "ipywidgets<=7.7.1"
+pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "notebook==6.4.12"
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "awswrangler"
 
 if [[ ${VERSION} == "" ]]; then

--- a/additional-databases/sagemaker/install-graph-notebook-lc.sh
+++ b/additional-databases/sagemaker/install-graph-notebook-lc.sh
@@ -30,6 +30,8 @@ pip uninstall NeptuneGraphNotebook -y # legacy uninstall when we used to install
 
 pip install "jupyter-console<=6.4.0"
 pip install "jupyter-client<=6.1.12"
+pip install "ipywidgets<=7.7.1"
+pip install "notebook==6.4.12"
 pip install awswrangler
 
 if [[ ${VERSION} == "" ]]; then


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added pre-installation of `notebook==6.4.12`; fixes CSS rendering issue when launching notebook classic on Sagemaker instances
- Added pre-installation of `ipywidgets<=7.7.1` to resolve conflicts between base `graph-notebook` package and `ipywidgets>=8.x`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.