### PR TITLE
Pin nbclient<=0.7.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed `%%gremlin` throwing error for result sets with multiple datatypes [Link to PR](https://github.com/aws/graph-notebook/pull/388))
 - Fixed edge label creation in `02-Using-Gremlin-to-Access-the-Graph` ([Link to PR](https://github.com/aws/graph-notebook/pull/390))
 - Bumped typescript to 4.1.x in graph_notebook_widgets ([Link to PR](https://github.com/aws/graph-notebook/pull/393))
-- Pinned ipywidgets to `<=7.x` ([Link to PR](https://github.com/aws/graph-notebook/pull/398))
+- Pinned `ipywidgets<=7.x` ([Link to PR](https://github.com/aws/graph-notebook/pull/398))
+- Pinned `nbclient<=0.7.0` ([Link to PR](https://github.com/aws/graph-notebook/pull/402))
 
 ## Release 3.6.2 (October 18, 2022)
 - New Sample Applications - Security Graphs notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/373))

--- a/additional-databases/sagemaker/install-graph-notebook-lc-cn.sh
+++ b/additional-databases/sagemaker/install-graph-notebook-lc-cn.sh
@@ -32,6 +32,7 @@ pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "jupyter-client<=6.1.12"
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "ipywidgets<=7.7.1"
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "notebook==6.4.12"
+pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "nbclient<=0.7.0"
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "awswrangler"
 
 if [[ ${VERSION} == "" ]]; then

--- a/additional-databases/sagemaker/install-graph-notebook-lc.sh
+++ b/additional-databases/sagemaker/install-graph-notebook-lc.sh
@@ -32,6 +32,7 @@ pip install "jupyter-console<=6.4.0"
 pip install "jupyter-client<=6.1.12"
 pip install "ipywidgets<=7.7.1"
 pip install "notebook==6.4.12"
+pip install "nbclient<=0.7.0"
 pip install awswrangler
 
 if [[ ${VERSION} == "" ]]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Jinja2==3.0.3
 jupyter
 notebook>=6.1.5,<6.5.0
 ipywidgets<=7.7.1
+nbclient<=0.7.0
 jupyter-contrib-nbextensions
 widgetsnbextension
 gremlinpython>=3.5.1

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         'networkx==2.4',
         'Jinja2==3.0.3',
         'notebook>=6.1.5,<6.5.0',
+        'nbclient<=0.7.0',
         'jupyter-contrib-nbextensions',
         'widgetsnbextension',
         'jupyter>=1.0.0',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Pinning `nbclient<=0.7.0` to avoid breaking changes in later versions. `nbclient>=0.7.1` replaces `nest_asyncio` usage with `run_sync` from `jupyter_core>=5.x`, which is incompatible with Python 3.7.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.