### PR TITLE
Pin jupyterlab_widgets<3, bump to ipywidgets==7.7.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 
-## Release 3.7.0 (December 6, 2022)
+## Release 3.7.0 (December 7, 2022)
 - Added Neo4J section to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/331))
 - Added custom Gremlin authentication and serializer support ([Link to PR](https://github.com/aws/graph-notebook/pull/356))
 - Added `%statistics` magic for Neptune DFE engine ([Link to PR](https://github.com/aws/graph-notebook/pull/377))
@@ -18,7 +18,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed edge label creation in `02-Using-Gremlin-to-Access-the-Graph` ([Link to PR](https://github.com/aws/graph-notebook/pull/390))
 - Fixed igraph command error in `02-Logistics-Analysis-using-a-Transportation-Network` ([Link to PR](https://github.com/aws/graph-notebook/pull/404))
 - Bumped typescript to 4.1.x in graph_notebook_widgets ([Link to PR](https://github.com/aws/graph-notebook/pull/393))
-- Pinned `ipywidgets<=7.x` ([Link to PR](https://github.com/aws/graph-notebook/pull/398))
+- Pinned `ipywidgets==7.7.2` and `jupyterlab_widgets<3` ([Link to PR](https://github.com/aws/graph-notebook/pull/407))
 - Pinned `nbclient<=0.7.0` ([Link to PR](https://github.com/aws/graph-notebook/pull/402))
 
 ## Release 3.6.2 (October 18, 2022)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ networkx==2.4
 Jinja2==3.0.3
 jupyter
 notebook>=6.1.5,<6.5.0
-ipywidgets<=7.7.1
+ipywidgets==7.7.2
+jupyterlab_widgets>=1.0.0,<3.0.0
 nbclient<=0.7.0
 jupyter-contrib-nbextensions
 widgetsnbextension

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ setup(
         'gremlinpython>=3.5.1',
         'SPARQLWrapper==1.8.4',
         'requests',
-        'ipywidgets<=7.7.1',
+        'ipywidgets==7.7.2',
+        'jupyterlab_widgets>=1.0.0,<3.0.0'
         'networkx==2.4',
         'Jinja2==3.0.3',
         'notebook>=6.1.5,<6.5.0',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixes an issue with widgets failing to render in JupyterLab on the 3.7.0 pre-release build. This commit ensures that our `ipywidgets` 7.x dependency will not accidentally install an incompatible higher version of `jupyterlab_widgets`. 
- Related: https://github.com/jupyterlab/jupyterlab/issues/12977

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.