### PR TITLE
Use correct endpoint arguments in People Analytics ML notebook

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Fixed failing endpoint creation step in [01-People-Analytics/People-Analytics-using-Neptune-ML](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb) ([Link to PR](https://github.com/aws/graph-notebook/pull/411))
 
 ## Release 3.7.0 (December 7, 2022)
 - Added Neo4J section to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/331))

--- a/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb
+++ b/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb
@@ -800,8 +800,8 @@
    "outputs": [],
    "source": [
     "endpoint_params=f\"\"\"\n",
-    "--job-id {training_job_name} \n",
-    "--model-job-id {training_job_name}\"\"\""
+    "--id {training_job_name}\n",
+    "--model-training-job-id {training_job_name}\"\"\""
    ]
   },
   {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed a bug in the [01-People-Analytics/People-Analytics-using-Neptune-ML](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb) sample notebook, where the endpoint creation step would fail due to invalid arguments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.