### PR TITLE
Pin numpy<1.24.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Fixed failing endpoint creation step in [01-People-Analytics/People-Analytics-using-Neptune-ML](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb) ([Link to PR](https://github.com/aws/graph-notebook/pull/411))
 
 ## Release 3.7.0 (December 7, 2022)
 - Added Neo4J section to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/331))

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ jedi<0.18.0
 markupsafe<2.1.0
 itables>=1.0.0
 pandas
+numpy<1.24.0
 
 # requirements for testing
 botocore~=1.18.18

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,8 @@ setup(
         'jedi<0.18.0',
         'markupsafe<2.1.0',
         'itables>=1.0.0',
-        'pandas'
+        'pandas',
+        'numpy<1.24.0'
     ],
     package_data={
         'graph_notebook': ['graph_notebook/widgets/nbextensions/**',

--- a/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb
+++ b/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb
@@ -800,8 +800,8 @@
    "outputs": [],
    "source": [
     "endpoint_params=f\"\"\"\n",
-    "--job-id {training_job_name} \n",
-    "--model-job-id {training_job_name}\"\"\""
+    "--id {training_job_name}\n",
+    "--model-training-job-id {training_job_name}\"\"\""
    ]
   },
   {


### PR DESCRIPTION
Issue #, if available: #414

Description of changes:
- Pinning `numpy<1.24.0`. This ceiling restriction is required to resolve a conflict with our dependency `networkx==2.4.0` , which requires the use of `np.int` removed in the latest version of numpy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.