### PR TITLE
Pin numpy<1.24.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Fixed failing endpoint creation step in [01-People-Analytics/People-Analytics-using-Neptune-ML](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb) ([Link to PR](https://github.com/aws/graph-notebook/pull/411))
+- Pinned `numpy<1.24.0` to fix conflicts with `networkx` dependency during installation ([Link to PR](https://github.com/aws/graph-notebook/pull/416))
 
 ## Release 3.7.0 (December 7, 2022)
 - Added Neo4J section to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/331))

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ You will need:
 
 * [Python](https://www.python.org/downloads/) 3.7.0-3.9.7
 * [RDFLib](https://pypi.org/project/rdflib/) 5.0.0
+* [NumPy](https://pypi.org/project/numpy) <=1.23.5
 * A graph database that provides one or more of:
   *  A SPARQL 1.1 endpoint 
   *  An Apache TinkerPop Gremlin Server compatible endpoint
@@ -107,6 +108,7 @@ Begin by installing `graph-notebook` and its prerequisites, then follow the rema
 ```
 # pin specific versions of required dependencies
 pip install rdflib==5.0.0
+pip install numpy==1.23.5
 
 # install the package
 pip install graph-notebook

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ jedi<0.18.0
 markupsafe<2.1.0
 itables>=1.0.0
 pandas
+numpy<1.24.0
 
 # requirements for testing
 botocore~=1.18.18

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,8 @@ setup(
         'jedi<0.18.0',
         'markupsafe<2.1.0',
         'itables>=1.0.0',
-        'pandas'
+        'pandas',
+        'numpy<1.24.0'
     ],
     package_data={
         'graph_notebook': ['graph_notebook/widgets/nbextensions/**',


### PR DESCRIPTION
Issue #, if available: #414

Description of changes:
- Pinning `numpy<1.24.0`. This ceiling restriction resolves a conflict with our dependency `networkx==2.4.0` , which requires the use of `np.int` removed in the latest version of numpy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.