### PR TITLE
Bump setuptools from 40.6.2 to >=65.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ ipython>=7.16.1,<7.17.0
 ipykernel==5.3.4
 neo4j==4.2.1
 rdflib~=5.0.0
-setuptools~=40.6.2
+setuptools>=65.5.1
 nbconvert>=6.3.0
 jedi<0.18.0
 markupsafe<2.1.0


### PR DESCRIPTION
Issue #, if available: CVE-2022-40897

Description of changes:
- Upgraded `setuptools` dependency for a vulnerability fix. This upgrade is inconsequential, as we have already been building our most recent PyPi releases on `setuptools==65.x`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.