### PR TITLE
Truncate metadata request/query time metrics

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added support for list/tuple element access in cell variable injection ([Link to PR](https://github.com/aws/graph-notebook/pull/409))
 - Fixed failing endpoint creation step in [01-People-Analytics/People-Analytics-using-Neptune-ML](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb) ([Link to PR](https://github.com/aws/graph-notebook/pull/411))
 - Pinned `numpy<1.24.0` to fix conflicts with `networkx` dependency during installation ([Link to PR](https://github.com/aws/graph-notebook/pull/416))
+- Truncated metadata request/query time metrics ([Link to PR](https://github.com/aws/graph-notebook/pull/425))
 
 ## Release 3.7.0 (December 7, 2022)
 - Added Neo4J section to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/331))

--- a/src/graph_notebook/magics/metadata.py
+++ b/src/graph_notebook/magics/metadata.py
@@ -39,7 +39,8 @@ class Metadata(object):
         self.metrics[metric_name].set_value(value)
 
     def set_request_metrics(self, res: Response):
-        self.set_metric_value('request_time', 1000 * res.elapsed.total_seconds())
+        raw_request_time = 1000 * res.elapsed.total_seconds()
+        self.set_metric_value('request_time', round(raw_request_time, 2))
         self.set_metric_value('status', res.status_code)
         self.set_metric_value('status_ok', res.ok)
         self.set_metric_value('resp_size', sys.getsizeof(res.content))
@@ -230,7 +231,7 @@ def build_opencypher_metadata_from_query(query_type: str, results: any, results_
 
 def build_propertygraph_metadata_from_default_query(results: any, query_type: str = 'query', query_time: float = None) -> Metadata:
     propertygraph_metadata = create_propertygraph_metadata_obj(query_type)
-    propertygraph_metadata.set_metric_value('request_time', query_time)
+    propertygraph_metadata.set_metric_value('request_time', round(query_time, 2))
     if query_type != 'explain':
         propertygraph_metadata.set_metric_value('resp_size', sys.getsizeof(results))
         propertygraph_metadata.set_metric_value('results', len(results))


### PR DESCRIPTION
Issue #, if available: #422

Description of changes:
- Rounded down metadata metrics `Query execution time` and `Request execution time` to two decimal places. This will improve readability, and match the precision of most metrics returned from Neptune Profile and Explain APIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.