### PR TITLE
Fix browser-specific issues with fullscreen graph widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added ECR auto-publish workflow ([Link to PR](https://github.com/aws/graph-notebook/pull/405))
 - Added support for list/tuple element access in cell variable injection ([Link to PR](https://github.com/aws/graph-notebook/pull/409))
 - Fixed failing endpoint creation step in [01-People-Analytics/People-Analytics-using-Neptune-ML](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb) ([Link to PR](https://github.com/aws/graph-notebook/pull/411))
+- Fixed browser-specific issues with fullscreen graph widget ([Link to PR](https://github.com/aws/graph-notebook/pull/427))
 - Pinned `numpy<1.24.0` to fix conflicts with `networkx` dependency during installation ([Link to PR](https://github.com/aws/graph-notebook/pull/416))
 - Truncated metadata request/query time metrics ([Link to PR](https://github.com/aws/graph-notebook/pull/425))
 

--- a/src/graph_notebook/widgets/src/force_widget.ts
+++ b/src/graph_notebook/widgets/src/force_widget.ts
@@ -1089,10 +1089,43 @@ export class ForceView extends DOMWidgetView {
    */
   toggleExpand(): void {
     const elem = this.networkDiv;
+
+    const doc_fullScreenElement_multibrowser = document as Document & {
+      webkitFullscreenElement?: Element;
+      mozFullScreenElement?: Element;
+      msFullscreenElement?: Element;
+    }
+    const elem_requestFullscreen_multibrowser = document.documentElement as HTMLElement & {
+      mozRequestFullScreen(): Promise<void>;
+      webkitRequestFullscreen(): Promise<void>;
+      msRequestFullscreen(): Promise<void>;
+    };
+    const doc_exitFullscreen_multibrowser = document as Document & {
+      mozCancelFullScreen(): Promise<void>;
+      webkitExitFullscreen(): Promise<void>;
+      msExitFullscreen(): Promise<void>;
+    };
+
+    const fullScreenElement_multibrowser =
+      doc_fullScreenElement_multibrowser.fullscreenElement ||
+      doc_fullScreenElement_multibrowser.webkitFullscreenElement ||
+      doc_fullScreenElement_multibrowser.mozFullScreenElement ||
+      doc_fullScreenElement_multibrowser.msFullscreenElement;
+    const requestFullscreen_multibrowser =
+      elem_requestFullscreen_multibrowser.requestFullscreen ||
+      elem_requestFullscreen_multibrowser.mozRequestFullScreen ||
+      elem_requestFullscreen_multibrowser.webkitRequestFullscreen ||
+      elem_requestFullscreen_multibrowser.msRequestFullscreen;
+    const exitFullscreen_multibrowser =
+      doc_exitFullscreen_multibrowser.exitFullscreen ||
+      doc_exitFullscreen_multibrowser.webkitExitFullscreen ||
+      doc_exitFullscreen_multibrowser.msExitFullscreen ||
+      doc_exitFullscreen_multibrowser.mozCancelFullScreen;
+
     const fullscreenchange = (event) => {
       const detailsTop = parseInt(this.detailsPanel.style.top);
       const detailsLeft = parseInt(this.detailsPanel.style.left);
-      if (document.fullscreenElement) {
+      if (fullScreenElement_multibrowser) {
         this.detailsPanel.style.left =
           (detailsLeft / 650) * window.innerWidth + "px";
         this.detailsPanel.style.top =
@@ -1116,15 +1149,15 @@ export class ForceView extends DOMWidgetView {
       }
       this.expandBtn.classList.toggle("active");
     };
-    if (!document.fullscreenElement) {
-      if (elem.requestFullscreen) {
+    if (!fullScreenElement_multibrowser) {
+      if (requestFullscreen_multibrowser) {
         document.addEventListener("fullscreenchange", fullscreenchange);
-        elem.requestFullscreen();
+        requestFullscreen_multibrowser.call(elem);
         this.canvasDiv.style.height = "100%";
       }
     } else {
-      if (document.exitFullscreen) {
-        document.exitFullscreen();
+      if (exitFullscreen_multibrowser) {
+        exitFullscreen_multibrowser.call(document);
         this.canvasDiv.style.height = "600px";
       }
     }


### PR DESCRIPTION
Issue #, if available: #421

Description of changes:
- Modified graph widget to use [prefixed Fullscreen API attributes](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API/Guide#prefixing) to fix browser-specific issues. Derived from the solution provided by @jklap in the referenced issue. These changes have been verified on Safari 16.2, Firefox 102.5.0esr, Chrome 109.x, and Edge 109.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.