### PR TITLE
Pin itables<1.4.3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed failing endpoint creation step in [01-People-Analytics/People-Analytics-using-Neptune-ML](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb) ([Link to PR](https://github.com/aws/graph-notebook/pull/411))
 - Fixed browser-specific issues with fullscreen graph widget ([Link to PR](https://github.com/aws/graph-notebook/pull/427))
 - Pinned `numpy<1.24.0` to fix conflicts with `networkx` dependency during installation ([Link to PR](https://github.com/aws/graph-notebook/pull/416))
+- Pinned `itables<1.4.3` to fix error occurring when running query magics ([Link to PR](https://github.com/aws/graph-notebook/pull/429))
 - Truncated metadata request/query time metrics ([Link to PR](https://github.com/aws/graph-notebook/pull/425))
 
 ## Release 3.7.0 (December 7, 2022)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Begin by installing `graph-notebook` and its prerequisites, then follow the rema
 # pin specific versions of required dependencies
 pip install rdflib==5.0.0
 pip install numpy==1.23.5
+pip install itables==1.4.2
 
 # install the package
 pip install graph-notebook

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ setuptools>=65.5.1
 nbconvert>=6.3.0
 jedi<0.18.0
 markupsafe<2.1.0
-itables>=1.0.0
+itables>=1.0.0,<1.4.3
 pandas
 numpy<1.24.0
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         'nbconvert>=6.3.0',
         'jedi<0.18.0',
         'markupsafe<2.1.0',
-        'itables>=1.0.0',
+        'itables>=1.0.0,<1.4.3',
         'pandas',
         'numpy<1.24.0'
     ],


### PR DESCRIPTION
Issue #, if available: #428

Description of changes:
- Pinning ceiling of `itables` dependency to `<1.4.3`. This fixes an error occurring when attempting to render the results table widget via query magics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.