### PR TITLE
Use updated authentication method for IAM Bolt queries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added support for list/tuple element access in cell variable injection ([Link to PR](https://github.com/aws/graph-notebook/pull/409))
 - Fixed failing endpoint creation step in [01-People-Analytics/People-Analytics-using-Neptune-ML](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/04-Machine-Learning/Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb) ([Link to PR](https://github.com/aws/graph-notebook/pull/411))
 - Fixed browser-specific issues with fullscreen graph widget ([Link to PR](https://github.com/aws/graph-notebook/pull/427))
+- Fixed IAM authenticated Bolt queries failing on certain Neptune engine versions ([Link to PR](https://github.com/aws/graph-notebook/pull/438))
 - Pinned `numpy<1.24.0` to fix conflicts with `networkx` dependency during installation ([Link to PR](https://github.com/aws/graph-notebook/pull/416))
 - Pinned `itables<1.4.3` to fix error occurring when running query magics ([Link to PR](https://github.com/aws/graph-notebook/pull/429))
 - Pinned version ceiling for all dependencies ([Link to PR](https://github.com/aws/graph-notebook/pull/431))

--- a/src/graph_notebook/neptune/bolt_auth_token.py
+++ b/src/graph_notebook/neptune/bolt_auth_token.py
@@ -1,0 +1,43 @@
+import json
+
+from neo4j import Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+from botocore.compat import urlsplit
+from botocore.auth import SigV4Auth
+
+SCHEME = "basic"
+REALM = "realm"
+SERVICE_NAME = "neptune-db"
+DUMMY_USERNAME = "username"
+HTTP_METHOD_HDR = "HttpMethod"
+HTTP_METHOD = "GET"
+AUTHORIZATION = "Authorization"
+X_AMZ_DATE = "X-Amz-Date"
+X_AMZ_SECURITY_TOKEN = "X-Amz-Security-Token"
+HOST = "Host"
+
+
+class NeptuneBoltAuthToken(Auth):
+    def __init__(
+        self,
+        credentials: Credentials,
+        region: str,
+        url: str,
+        **parameters
+    ):
+        request = AWSRequest(method=HTTP_METHOD, url=url)
+
+        url_parts = urlsplit(request.url)
+        host_part = url_parts.hostname
+        request.headers.add_header("Host", host_part)
+        sigv4 = SigV4Auth(credentials, SERVICE_NAME, region)
+        sigv4.add_auth(request)
+
+        auth_obj = {
+          hdr: request.headers[hdr]
+          for hdr in [AUTHORIZATION, X_AMZ_DATE, X_AMZ_SECURITY_TOKEN, HOST]
+        }
+        auth_obj[HTTP_METHOD_HDR] = request.method
+        creds: str = json.dumps(auth_obj)
+        super().__init__(SCHEME, DUMMY_USERNAME, creds, REALM, **parameters)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed a bug where `%%oc bolt` could fail with an authentication error when making queries to an IAM-enabled Neptune cluster with engine version 1.2.0.0 or later. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.