### PR TITLE
Add --profile-misc-args option to %%gremlin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - New Neptune ML notebook - Real Time Fraud Detection using Inductive Inference ([Link to PR](https://github.com/aws/graph-notebook/pull/338))
-  - Path: 04-Machine-Learning > Sample-Applications > 03-Real-Time-Fraud-Detection-Using-Inductive-Inference.ipynb 
+  - Path: 04-Machine-Learning > Sample-Applications > 03-Real-Time-Fraud-Detection-Using-Inductive-Inference.ipynb
+- Added `--profile-misc-args` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/443))
 
 ## Release 3.7.1 (January 25, 2023)
 - Added ECR auto-publish workflow ([Link to PR](https://github.com/aws/graph-notebook/pull/405))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -768,6 +768,8 @@ class Graph(Magics):
                                  'TinkerPop driver "Serializers" enum values. Default is application/json')
         parser.add_argument('--profile-indexOps', action='store_true', default=False,
                             help='Show a detailed report of all index operations.')
+        parser.add_argument('--profile-misc-args', type=str, default='{}',
+                            help='Additional profile options, passed in as a map.')
         parser.add_argument('-sp', '--stop-physics', action='store_true', default=False,
                             help="Disable visualization physics after the initial simulation stabilizes.")
         parser.add_argument('-sd', '--simulation-duration', type=int, default=1500,
@@ -839,6 +841,12 @@ class Graph(Magics):
                             "profile.chop": args.profile_chop,
                             "profile.serializer": serializer,
                             "profile.indexOps": args.profile_indexOps}
+            try:
+                profile_misc_args_dict = json.loads(args.profile_misc_args)
+                profile_args.update(profile_misc_args_dict)
+            except JSONDecodeError:
+                print('--profile-misc-args received invalid input, please check that you are passing in a valid '
+                      'string representation of a map, ex. "{\'profile.x\':\'true\'}"')
             res = self.client.gremlin_profile(query=cell, args=profile_args)
             res.raise_for_status()
             profile_bytes = res.content.replace(b'\xcc', b'-')


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added a new `--profile-misc-args` option for `%%gremlin profile` to allow passing custom data in the request. This argument accepts a map-format string via variable injection.

Example usage:

![Screen Shot 2023-02-06 at 8 27 13 PM](https://user-images.githubusercontent.com/10456376/217148353-f9b79d42-b624-41f5-a9ac-37f6e63d98a6.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.