### PR TITLE
Fix Webpack failure in CI builds

### DIFF
--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -87,7 +87,7 @@
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc",
-    "build:nbextension": "webpack",
+    "build:nbextension": "NODE_OPTIONS=--openssl-legacy-provider webpack",
     "clean": "npm run clean:lib && npm run clean:nbextension && npm run clean:labextension",
     "clean:lib": "rimraf lib",
     "clean:labextension": "rimraf labextension",


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed a CI builds error related to a conflict between Webpack 4.x and newer versions of NodeJS 18.x. See: https://github.com/webpack/webpack/issues/14532

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.