### PR TITLE
Ensure default assignments for all Gremlin nodes when using grouping

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - New Neptune ML notebook - Real Time Fraud Detection using Inductive Inference ([Link to PR](https://github.com/aws/graph-notebook/pull/338))
   - Path: 04-Machine-Learning > Sample-Applications > 03-Real-Time-Fraud-Detection-Using-Inductive-Inference.ipynb
 - Added `--profile-misc-args` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/443))
+- Ensure default assignments for all Gremlin nodes when using grouping ([Link to PR](https://github.com/aws/graph-notebook/pull/448))
 
 ## Release 3.7.1 (January 25, 2023)
 - Added ECR auto-publish workflow ([Link to PR](https://github.com/aws/graph-notebook/pull/405))

--- a/src/graph_notebook/network/gremlin/GremlinNetwork.py
+++ b/src/graph_notebook/network/gremlin/GremlinNetwork.py
@@ -491,6 +491,9 @@ class GremlinNetwork(EventfulNetwork):
             if not tooltip_display_is_set and label_full:
                 title = label_full
 
+            if not group and not group_is_set:
+                group = DEFAULT_GRP
+
             # handle when there is no id in a node. In this case, we will generate one which
             # is consistently regenerated so that duplicate dicts will be reduced to the same vertex.
             if node_id == '':
@@ -503,14 +506,13 @@ class GremlinNetwork(EventfulNetwork):
                     title += str(v[key])
             if label == '':
                 label = title if len(title) <= self.label_max_length else title[:self.label_max_length - 3] + '...'
-
             data = {'properties': properties, 'label': label, 'title': title, 'group': group}
         else:
             node_id = str(v)
             title = str(v)
             if self.group_by_property == DEPTH_GRP_KEY:
                 group = depth_group
-            if self.group_by_property == DEFAULT_RAW_GRP_KEY:
+            elif self.group_by_property == DEFAULT_RAW_GRP_KEY:
                 group = str(v)
             else:
                 group = DEFAULT_GRP

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -2117,7 +2117,6 @@ class TestGremlinNetwork(unittest.TestCase):
         gn = GremlinNetwork(group_by_property='{"vertex":"bar"}')
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
-        print(gn.graph.nodes)
         self.assertEqual(node['group'], 'DEFAULT_GROUP')
 
     def test_group_returnmisctype_default(self):

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -1589,7 +1589,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn = GremlinNetwork(group_by_property='{"airport":{"code"}}')
         gn.add_vertex(vertex1)
         node1 = gn.graph.nodes.get(vertex1[T.id])
-        self.assertEqual(node1['group'], '')
+        self.assertEqual(node1['group'], 'DEFAULT_GROUP')
 
     def test_group_with_groupby_invalid_json_multiple_labels(self):
         vertex1 = {
@@ -1613,8 +1613,8 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex2)
         node1 = gn.graph.nodes.get(vertex1[T.id])
         node2 = gn.graph.nodes.get(vertex2[T.id])
-        self.assertEqual(node1['group'], '')
-        self.assertEqual(node2['group'], '')
+        self.assertEqual(node1['group'], 'DEFAULT_GROUP')
+        self.assertEqual(node2['group'], 'DEFAULT_GROUP')
 
     def test_group_nonexistent_groupby(self):
         vertex = {
@@ -1628,7 +1628,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn = GremlinNetwork(group_by_property='foo')
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get(vertex[T.id])
-        self.assertEqual(node['group'], '')
+        self.assertEqual(node['group'], 'DEFAULT_GROUP')
 
     def test_group_nonexistent_groupby_properties_json_single_label(self):
         vertex1 = {
@@ -1642,7 +1642,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn = GremlinNetwork(group_by_property='{"airport":{"groupby":"foo"}}')
         gn.add_vertex(vertex1)
         node1 = gn.graph.nodes.get(vertex1[T.id])
-        self.assertEqual(node1['group'], '')
+        self.assertEqual(node1['group'], 'DEFAULT_GROUP')
 
     def test_group_nonexistent_groupby_properties_json_multiple_labels(self):
         vertex1 = {
@@ -1666,7 +1666,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex2)
         node1 = gn.graph.nodes.get(vertex1[T.id])
         node2 = gn.graph.nodes.get(vertex2[T.id])
-        self.assertEqual(node1['group'], '')
+        self.assertEqual(node1['group'], 'DEFAULT_GROUP')
         self.assertEqual(node2['group'], 'Europe')
 
     def test_group_nonexistent_label_properties_json_single_label(self):
@@ -1681,7 +1681,7 @@ class TestGremlinNetwork(unittest.TestCase):
         gn = GremlinNetwork(group_by_property='{"air_port":{"groupby":"code"}')
         gn.add_vertex(vertex1)
         node1 = gn.graph.nodes.get(vertex1[T.id])
-        self.assertEqual(node1['group'], '')
+        self.assertEqual(node1['group'], 'DEFAULT_GROUP')
 
     def test_group_nonexistent_label_properties_json_multiple_labels(self):
         vertex1 = {
@@ -1706,7 +1706,7 @@ class TestGremlinNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get(vertex1[T.id])
         node2 = gn.graph.nodes.get(vertex2[T.id])
         self.assertEqual(node1['group'], 'SEA')
-        self.assertEqual(node2['group'], '')
+        self.assertEqual(node2['group'], 'DEFAULT_GROUP')
 
     def test_group_without_groupby(self):
         vertex = {
@@ -2094,6 +2094,63 @@ class TestGremlinNetwork(unittest.TestCase):
         gn.add_vertex(vertex)
         node = gn.graph.nodes.get('1')
         self.assertEqual(node['group'], '1')
+
+    def test_group_returnvertex_groupby_missing_property(self):
+        vertex = Vertex(id='1')
+
+        gn = GremlinNetwork(group_by_property="foo")
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], 'DEFAULT_GROUP')
+
+    def test_group_returnvertex_groupby_missing_property_key_json(self):
+        vertex = Vertex(id='1')
+
+        gn = GremlinNetwork(group_by_property='{"foo":"label"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        self.assertEqual(node['group'], 'DEFAULT_GROUP')
+
+    def test_group_returnvertex_groupby_missing_property_value_json(self):
+        vertex = Vertex(id='1')
+
+        gn = GremlinNetwork(group_by_property='{"vertex":"bar"}')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('1')
+        print(gn.graph.nodes)
+        self.assertEqual(node['group'], 'DEFAULT_GROUP')
+
+    def test_group_returnmisctype_default(self):
+        vertex = 'a_vertex'
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('a_vertex')
+        self.assertEqual(node['group'], 'DEFAULT_GROUP')
+
+    def test_group_returnmisctype_groupby_property(self):
+        vertex = 'a_vertex'
+
+        gn = GremlinNetwork(group_by_property="foo")
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('a_vertex')
+        self.assertEqual(node['group'], 'DEFAULT_GROUP')
+
+    def test_group_returnmisctype_groupby_raw(self):
+        vertex = 'a_vertex'
+
+        gn = GremlinNetwork(group_by_raw=True)
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('a_vertex')
+        self.assertEqual(node['group'], 'a_vertex')
+
+    def test_group_returnmisctype_groupby_depth(self):
+        vertex = 'a_vertex'
+
+        gn = GremlinNetwork(group_by_property='TRAVERSAL_DEPTH')
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get('a_vertex')
+        self.assertEqual(node['group'], '__DEPTH--1__')
 
     def test_group_by_raw_explicit(self):
         vertex = {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Modified `%%gremlin --group-by` behavior for map type vertices. If a vertex does not contain the property specified by `--group-by`, it will be assigned to group `DEFAULT_GROUP` instead of having no group assignment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.