### PR TITLE
Pin NodeJS 14.x in unit.yml

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,6 +12,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+      - name: Set up Node.js 14.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.17.4
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -87,7 +87,7 @@
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc",
-    "build:nbextension": "NODE_OPTIONS=--openssl-legacy-provider webpack",
+    "build:nbextension": "webpack",
     "clean": "npm run clean:lib && npm run clean:nbextension && npm run clean:labextension",
     "clean:lib": "rimraf lib",
     "clean:labextension": "rimraf labextension",


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Reverting #447 in favor of pinning to a stable Node version in the unit test workflow; the OpenSSL legacy support option breaks our ECR deployment workflow, which runs on Node 12.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.