### PR TITLE
Add manual trigger for ECR publish workflow

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,6 +1,16 @@
 name: Build Docker image and publish to ECR
 
 on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'ECR image tag type'
+        required: false
+        type: choice
+        options:
+          - 'latest'
+          - 'release'
+        default: 'latest'
   push:
     branches:
       - main
@@ -15,6 +25,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Get package version
+        uses: tyankatsu0105/read-package-version-actions@v1
+        with:
+          path: "./src/graph_notebook/widgets"
+        id: package-version
+
+      - name: Get image tag
+        id: get-image-tag
+        run: |
+          if true ; then
+            if true; then
+              echo "image_tag=${{ steps.package-version.outputs.version }}" >> $GITHUB_OUTPUT
+            else
+              echo "image_tag=latest" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "image_tag=latest" >> $GITHUB_OUTPUT
+          fi
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -37,7 +66,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           REGISTRY_ALIAS: neptune
           REPOSITORY: graph-notebook
-          IMAGE_TAG: latest
+          IMAGE_TAG: ${{ steps.get-image-tag.outputs.image_tag }}
         run: |
           docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added an option for manually triggering `docker_publish.yml`, to make it easier to deploy both latest and versioned release images to ECR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.