### PR TITLE
Add error messaging for incompatible host-specific config params

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - New Neptune ML notebook - Real Time Fraud Detection using Inductive Inference ([Link to PR](https://github.com/aws/graph-notebook/pull/338))
   - Path: 04-Machine-Learning > Sample-Applications > 03-Real-Time-Fraud-Detection-Using-Inductive-Inference.ipynb
 - Added `--profile-misc-args` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/443))
+- Added error messaging for incompatible host-specific `%%graph_notebok_config` parameters ([Link to PR](https://github.com/aws/graph-notebook/pull/456))
 - Ensure default assignments for all Gremlin nodes when using grouping ([Link to PR](https://github.com/aws/graph-notebook/pull/448))
 
 ## Release 3.7.1 (January 25, 2023)

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -10,6 +10,7 @@ from graph_notebook.configuration.generate_config import DEFAULT_CONFIG_LOCATION
 from graph_notebook.neptune.client import NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_allowed_neptune_host, false_str_variants, \
     DEFAULT_NEO4J_USERNAME, DEFAULT_NEO4J_PASSWORD, DEFAULT_NEO4J_DATABASE
 
+neptune_params = ['auth_mode', 'load_from_s3_arn', 'aws_region']
 
 def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_IDENTIFIERS) -> Configuration:
 
@@ -39,6 +40,14 @@ def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_I
                                gremlin_section=gremlin_section, neo4j_section=neo4j_section,
                                proxy_host=proxy_host, proxy_port=proxy_port, neptune_hosts=neptune_hosts)
     else:
+        excluded_params = []
+        for p in neptune_params:
+            if p in data:
+                excluded_params.append(p)
+        if excluded_params:
+            print(f"The provided configuration contains the following parameters that are incompatible with the "
+                  f"specified host: {str(excluded_params)}. These parameters have not been saved.\n")
+
         config = Configuration(host=data['host'], port=data['port'], ssl=data['ssl'], ssl_verify=ssl_verify,
                                sparql_section=sparql_section, gremlin_section=gremlin_section, neo4j_section=neo4j_section,
                                proxy_host=proxy_host, proxy_port=proxy_port)


### PR DESCRIPTION
Issue #, if available: #452

Description of changes:
- Print a warning and list of ignored parameters when attempting to set `%%graph_notebook_config` with incompatible fields for a given non-Neptune host.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.