### PR TITLE
Fix --store-to option for several magics

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Fixed `--store-to` option for several magics ([Link to PR](https://github.com/aws/graph-notebook/pull/463))
 
 ## Release 3.7.3 (March 14, 2023)
 - Fixed detailed mode output for graph summary requests ([Link to PR](https://github.com/aws/graph-notebook/pull/461))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -416,6 +416,8 @@ class Graph(Magics):
         viewer.show()
 
     @line_magic
+    @needs_local_scope
+    @display_exceptions
     def statistics(self, line, local_ns: dict = None):
         parser = argparse.ArgumentParser()
         parser.add_argument('language', nargs='?', type=str.lower, default="propertygraph",
@@ -453,10 +455,11 @@ class Graph(Magics):
         if not args.silent:
             print(json.dumps(statistics_res_json, indent=2))
 
-        if args.store_to != '' and local_ns is not None:
-            local_ns[args.store_to] = statistics_res_json
+        store_to_ns(args.store_to, statistics_res_json, local_ns)
 
     @line_magic
+    @needs_local_scope
+    @display_exceptions
     def summary(self, line, local_ns: dict = None):
         parser = argparse.ArgumentParser()
         parser.add_argument('language', nargs='?', type=str.lower, default="propertygraph",
@@ -484,8 +487,7 @@ class Graph(Magics):
         if not args.silent:
             print(json.dumps(summary_res_json, indent=2))
 
-        if args.store_to != '' and local_ns is not None:
-            local_ns[args.store_to] = summary_res_json
+        store_to_ns(args.store_to, summary_res_json, local_ns)
 
     @line_magic
     def graph_notebook_host(self, line):
@@ -1903,8 +1905,7 @@ class Graph(Magics):
             vbox = widgets.VBox(labels)
             display(vbox)
 
-        if args.store_to != '' and local_ns is not None:
-            local_ns[args.store_to] = res
+        store_to_ns(args.store_to, res, local_ns)
 
     @line_magic
     @display_exceptions
@@ -1934,8 +1935,7 @@ class Graph(Magics):
         if not args.silent:
             print(json.dumps(res, indent=2))
 
-        if args.store_to != '' and local_ns is not None:
-            local_ns[args.store_to] = res
+        store_to_ns(args.store_to, res, local_ns)
 
     @line_magic
     @display_exceptions
@@ -1984,8 +1984,7 @@ class Graph(Magics):
             else:
                 print("No cancellable load jobs were found.")
 
-        if args.store_to != '' and local_ns is not None:
-            local_ns[args.store_to] = raw_res
+        store_to_ns(args.store_to, raw_res, local_ns)
 
     @line_magic
     @display_exceptions


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed an issue where `--store-to` had no effect for `%statistics` and `%summary`, and moved a few other magics over to the newer assignment function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.