### PR TITLE
Pin AL2 image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 # Notebook Port
 EXPOSE 8888


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixing recent [ECR publish workflow failures](https://github.com/aws/graph-notebook/actions/runs/4434683458/jobs/7780915862#step:7:638). With its GA release on 3/15, AL2023 is now the default distribution for the `amazonlinux:latest` parent image used in our Dockerfile; this breaks the build process as NodeSource does not yet support AL2023. Moving back to the latest `amazonlinux` image tag on AL2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.