### PR TITLE
Enforce Python 3.8 usage in Dockerfile

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed Dockerfile builds breaking with AL2023 ([Link to PR](https://github.com/aws/graph-notebook/pull/466))
 - Fixed `--store-to` option for several magics ([Link to PR](https://github.com/aws/graph-notebook/pull/463))
 - Fixed broken documentation links in Neptune ML notebooks ([PR #1](https://github.com/aws/graph-notebook/pull/467)) ([PR #2](https://github.com/aws/graph-notebook/pull/468))
+- Deprecated Python 3.7 support ([PR #1](https://github.com/aws/graph-notebook/pull/453)) ([PR #2](https://github.com/aws/graph-notebook/pull/473))
 
 ## Release 3.7.3 (March 14, 2023)
 - Fixed detailed mode output for graph summary requests ([Link to PR](https://github.com/aws/graph-notebook/pull/461))

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV pipargs=""
 ENV WORKING_DIR="/root"
 ENV NOTEBOOK_DIR="${WORKING_DIR}/notebooks"
 ENV EXAMPLE_NOTEBOOK_DIR="${NOTEBOOK_DIR}/Example Notebooks"
-ENV NODE_VERSION=12.x
+ENV NODE_VERSION=14.x
 ENV GRAPH_NOTEBOOK_AUTH_MODE="DEFAULT"
 ENV GRAPH_NOTEBOOK_HOST="neptune.cluster-XXXXXXXXXXXX.us-east-1.neptune.amazonaws.com"
 ENV GRAPH_NOTEBOOK_PROXY_PORT="8192"
@@ -36,12 +36,16 @@ RUN mkdir -p "${WORKING_DIR}" && \
     mkdir -p "${EXAMPLE_NOTEBOOK_DIR}" && \
     # Yum Update and install dependencies
     yum update -y && \
-    yum install tar gzip git -y && \
+    yum install tar gzip git amazon-linux-extras which -y && \
     # Install NPM/Node
     curl --silent --location https://rpm.nodesource.com/setup_${NODE_VERSION} | bash - && \
     yum install nodejs -y && \
     npm install -g opencollective && \
-    yum install python3 -y && \
+    # Install Python 3.8
+    amazon-linux-extras install python3.8 -y && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
+    echo 'Using python version:' && \
+    python3 --version && \
     python3 -m ensurepip --upgrade  && \
     python3 -m venv /tmp/venv && \
     source /tmp/venv/bin/activate && \
@@ -49,7 +53,8 @@ RUN mkdir -p "${WORKING_DIR}" && \
     # Clone the repo and install python dependencies
     git clone https://github.com/aws/graph-notebook && \
     cd "${WORKING_DIR}/graph-notebook" && \
-    pip3 install --upgrade pip setuptools wheel twine && \
+    pip3 install --upgrade pip setuptools wheel && \
+    pip3 install twine==3.7.1 && \
     pip3 install -r requirements.txt && \
     pip3 install "jupyterlab>=3" && \
     # Build the package


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed Dockerfile builds breaking due to `yum install python3` installing Python 3.7 by default, we now ensure that a compatible version of Python 3.8 is installed via `amazon-linux-extras` package.
- Upgraded Node to 14.x in Dockerfile.
- Pin `twine` to resolve a conflict with our required `urllib` version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.