### PR TITLE
Fix Gremlin visualizations failing to render with UUID type IDs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed Dockerfile builds breaking with AL2023 ([Link to PR](https://github.com/aws/graph-notebook/pull/466))
 - Fixed `--store-to` option for several magics ([Link to PR](https://github.com/aws/graph-notebook/pull/463))
 - Fixed broken documentation links in Neptune ML notebooks ([PR #1](https://github.com/aws/graph-notebook/pull/467)) ([PR #2](https://github.com/aws/graph-notebook/pull/468))
+- Fixed Gremlin graph tab not rendering with UUID type IDs ([Link to PR](https://github.com/aws/graph-notebook/pull/475))
 
 ## Release 3.7.3 (March 14, 2023)
 - Fixed detailed mode output for graph summary requests ([Link to PR](https://github.com/aws/graph-notebook/pull/461))

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -235,7 +235,7 @@ class TestGremlinNetwork(unittest.TestCase):
         self.assertIsNotNone(node)
         self.assertEqual(node['properties'][T.id], v_id)
 
-    def test_add_vertex_with_uuid_id(self): # TODO: fix UUID id processing for dict type vertices
+    def test_add_vertex_with_uuid_id(self):
         v_id = uuid4()
         vertex = {
             T.id: v_id,

--- a/test/unit/network/gremlin/test_gremlin_network.py
+++ b/test/unit/network/gremlin/test_gremlin_network.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import unittest
 from decimal import Decimal
+from uuid import uuid4
 from gremlin_python.structure.graph import Path, Edge, Vertex
 from gremlin_python.process.traversal import T, Direction
 from graph_notebook.network.EventfulNetwork import EVENT_ADD_NODE
@@ -190,6 +191,75 @@ class TestGremlinNetwork(unittest.TestCase):
         node1 = gn.graph.nodes.get('1')
         self.assertEqual(node1['label'], '1')
         self.assertEqual(node1['title'], '1')
+
+    def test_add_explicit_type_vertex_with_string_id(self):
+        v_id = 'a_id'
+        vertex = Vertex(id=v_id)
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(v_id)
+        self.assertIsNotNone(node)
+        self.assertEqual(node['properties']['id'], v_id)
+
+    def test_add_explicit_type_vertex_with_uuid_id(self):
+        v_id = uuid4()
+        vertex = Vertex(id=v_id)
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(str(v_id))
+        self.assertIsNotNone(node)
+        self.assertEqual(node['properties']['id'], str(v_id))
+
+    def test_add_explicit_type_vertex_with_integer_id(self):
+        v_id = 1
+        vertex = Vertex(id=v_id)
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(v_id)
+        self.assertIsNotNone(node)
+        self.assertEqual(node['properties']['id'], v_id)
+
+    def test_add_vertex_with_string_id(self):
+        v_id = 'a_id'
+        vertex = {
+            T.id: v_id,
+            T.label: 'label'
+        }
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(v_id)
+        self.assertIsNotNone(node)
+        self.assertEqual(node['properties'][T.id], v_id)
+
+    def test_add_vertex_with_uuid_id(self): # TODO: fix UUID id processing for dict type vertices
+        v_id = uuid4()
+        vertex = {
+            T.id: v_id,
+            T.label: 'label'
+        }
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(str(v_id))
+        self.assertIsNotNone(node)
+        self.assertEqual(node['properties'][T.id], str(v_id))
+
+    def test_add_vertex_with_integer_id(self):
+        v_id = 99
+        vertex = {
+            T.id: v_id,
+            T.label: 'label'
+        }
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex)
+        node = gn.graph.nodes.get(str(v_id))
+        self.assertIsNotNone(node)
+        self.assertEqual(node['properties'][T.id], v_id)
 
     def test_add_vertex_without_node_property(self):
         vertex = {
@@ -753,6 +823,51 @@ class TestGremlinNetwork(unittest.TestCase):
         self.assertIsInstance(final_lon_value, float)
         self.assertIsInstance(final_lat_value, float)
 
+    def test_add_explicit_type_single_edge_with_string_id(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        e_id = '1'
+
+        edge1 = Edge(id=e_id, outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertIsNotNone(edge)
+        self.assertEqual(edge[e_id]['properties']['id'], e_id)
+
+    def test_add_explicit_type_single_edge_with_uuid_id(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        e_id = uuid4()
+
+        edge1 = Edge(id=e_id, outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertIsNotNone(edge)
+        self.assertEqual(edge[str(e_id)]['properties']['id'], str(e_id))
+
+    def test_add_explicit_type_single_edge_with_integer_id(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        e_id = 1
+
+        edge1 = Edge(id=e_id, outV=vertex1, inV=vertex2, label='route')
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1)
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertIsNotNone(edge)
+        self.assertEqual(edge[e_id]['properties']['id'], e_id)
+
     def test_add_explicit_type_single_edge_without_edge_property(self):
         vertex1 = Vertex(id='1')
         vertex2 = Vertex(id='2')
@@ -980,6 +1095,51 @@ class TestGremlinNetwork(unittest.TestCase):
         edge = gn.graph.get_edge_data('1', '2')
         self.assertEqual(edge['1']['label'], 'v[2]')
         self.assertEqual(edge['1']['title'], 'v[2]')
+
+    def test_add_single_edge_with_string_id(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        e_id = '1'
+
+        edge1 = {T.id: e_id, T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertIsNotNone(edge)
+        self.assertEqual(edge[e_id]['properties'][T.id], e_id)
+
+    def test_add_single_edge_with_uuid_id(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        e_id = uuid4()
+
+        edge1 = {T.id: e_id, T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertIsNotNone(edge)
+        self.assertEqual(edge[str(e_id)]['properties'][T.id], str(e_id))
+
+    def test_add_single_edge_with_integer_id(self):
+        vertex1 = Vertex(id='1')
+        vertex2 = Vertex(id='2')
+        e_id = 1
+
+        edge1 = {T.id: e_id, T.label: 'route', 'outV': 'v[1]', 'inV': 'v[2]'}
+
+        gn = GremlinNetwork()
+        gn.add_vertex(vertex1)
+        gn.add_vertex(vertex2)
+        gn.add_path_edge(edge1, from_id='1', to_id='2')
+        edge = gn.graph.get_edge_data('1', '2')
+        self.assertIsNotNone(edge)
+        self.assertEqual(edge[str(e_id)]['properties'][T.id], e_id)
 
     def test_add_single_edge_without_edge_property(self):
         vertex1 = Vertex(id='1')
@@ -2212,6 +2372,26 @@ class TestGremlinNetwork(unittest.TestCase):
         self.assertEqual(edge_data, edge_expected)
         self.assertEqual(inv_data['properties'], edge_map[Direction.IN])
         self.assertEqual(outv_data['properties'], edge_map[Direction.OUT])
+
+    def test_add_elementmap_edge_with_direction_uuid_ids(self):
+        in_node_id = uuid4()
+        out_node_id = uuid4()
+        edge_map = {
+            T.id: '5298',
+            T.label: 'route',
+            Direction.IN: {T.id: in_node_id, T.label: 'airport'},
+            Direction.OUT: {T.id: out_node_id, T.label: 'airport'},
+            'dist': 763
+        }
+
+        gn = GremlinNetwork()
+        gn.insert_elementmap(edge_map, index=1)
+        inv_data = gn.graph.nodes.get(str(in_node_id))
+        outv_data = gn.graph.nodes.get(str(out_node_id))
+        self.assertIsNotNone(inv_data)
+        self.assertIsNotNone(outv_data)
+        self.assertEqual(inv_data['properties'][T.id], str(edge_map[Direction.IN][T.id]))
+        self.assertEqual(outv_data['properties'][T.id], str(edge_map[Direction.OUT][T.id]))
 
     def test_add_elementmap_edge_groupby_depth(self):
         edge_map = {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed an issue where the graph widget would fail to render for Gremlin query results containing vertex or edge IDs values of UUID type, due to a JSON serialization error.
- Catch exceptions from `gremlin_network` and Force widget generation separately, to make visualization debugging easier.
- Related question on StackOverflow: https://stackoverflow.com/questions/75986863/aws-jupyter-notebook-dont-show-graph-tab-after-changed-gremlin-settings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.