### PR TITLE
Reinstate Python 3.7 support

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
     strategy:
       matrix:
-        python-version: ['3.8', '3.10']
+        python-version: ['3.7', '3.8', '3.10']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Reinstate Python 3.7 support for compatibility with legacy AL1 Neptune Notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/479))
 
 ## Release 3.8.0 (April 16, 2023)
 - Added support for Python 3.10 ([Link to PR](https://github.com/aws/graph-notebook/pull/476))

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ It is recommended to check the [ChangeLog.md](ChangeLog.md) file periodically to
 
 You will need:
 
-* [Python](https://www.python.org/downloads/) 3.8.0-3.10.11
+* [Python](https://www.python.org/downloads/) 3.7.x-3.10.11
 * A graph database that provides one or more of:
   *  A SPARQL 1.1 endpoint 
   *  An Apache TinkerPop Gremlin Server compatible endpoint

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jupyter-contrib-nbextensions<=0.7.0
 widgetsnbextension<=3.6.1
 gremlinpython>=3.5.1,<=3.6.2
 requests>=2.27.0,<=2.28.2
-ipython==8.10.0
+ipython>=7.16.1,<=8.10.0
 ipykernel==5.3.4
 neo4j>=4.4.9,<5.0.0
 rdflib==5.0.0
@@ -19,9 +19,9 @@ nbconvert>=6.3.0,<=7.2.8
 jedi>=0.18.1,<=0.18.2
 markupsafe<2.1.0
 itables>=1.0.0,<=1.5.2,!=1.4.3,!=1.4.4
-pandas>=1.4.0,<=1.5.3
+pandas>=1.3.5,<=1.5.3
 numpy<1.24.0
-nest_asyncio==1.5.6
+nest_asyncio>=1.5.5,<=1.5.6
 
 # requirements for testing
 botocore~=1.21.49

--- a/setup.py
+++ b/setup.py
@@ -80,16 +80,16 @@ setup(
         'jupyter==1.0.0',
         'botocore>=1.21.49,<=1.29.53',
         'boto3>=1.18.49,<=1.26.53',
-        'ipython==8.10.0',
+        'ipython>=7.16.1,<=8.10.0',
         'neo4j>=4.4.9,<5.0.0',
         'rdflib==5.0.0',
         'ipykernel==5.3.4',
         'nbconvert>=6.3.0,<=7.2.8',
         'jedi>=0.18.1,<=0.18.2',
         'itables>=1.0.0,<=1.5.2,!=1.4.3,!=1.4.4',
-        'pandas>=1.4.0,<=1.5.3',
+        'pandas>=1.3.5,<=1.5.3',
         'numpy<1.24.0',
-        'nest_asyncio==1.5.6'
+        'nest_asyncio>=1.5.5,<=1.5.6'
     ],
     package_data={
         'graph_notebook': ['graph_notebook/widgets/nbextensions/**',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Loosened up some dependency minimum version requirements to reinstate support for Python 3.7. This continues support for legacy Neptune Notebooks on `notebook-al1-v1` platform that cannot be upgraded from Python 3.7.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.