### PR TITLE
Pin JupyterLab<4.x

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pytest
-          pip install jupyterlab>=3
+          pip install "jupyterlab>=3,<4"
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Install
         run: |
@@ -75,7 +75,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install jupyterlab>=3
+          python -m pip install "jupyterlab>=3,<4"
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Install
         run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install wheel
           pip install flake8 pytest
-          pip install jupyterlab>=3
+          pip install "jupyterlab>=3,<4"
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added openCypher and local file path support to `%seed` ([Link to PR](https://github.com/aws/graph-notebook/pull/292))
 - Added `%toggle_traceback` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/486))
 - Added support for setting `%graph_notebook_vis_options` from a variable ([Link to PR](https://github.com/aws/graph-notebook/pull/487))
+- Pinned JupyterLab<4.x to fix Python 3.8/3.10 builds ([Link to PR](https://github.com/aws/graph-notebook/pull/490))
 
 ## Release 3.8.1 (April 17, 2023)
 - Reinstate Python 3.7 support for compatibility with legacy AL1 Neptune Notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/479))

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN mkdir -p "${WORKING_DIR}" && \
     pip3 install --upgrade pip setuptools wheel && \
     pip3 install twine==3.7.1 && \
     pip3 install -r requirements.txt && \
-    pip3 install "jupyterlab>=3" && \
+    pip3 install "jupyterlab>=3,<4" && \
     # Build the package
     python3 setup.py sdist bdist_wheel && \
     # install the copied repo

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ python -m graph_notebook.start_notebook --notebooks-dir ~/notebook/destination/d
 
 ```
 # install jupyterlab
-pip install "jupyterlab>=3"
+pip install "jupyterlab>=3,<4"
 
 # copy premade starter notebooks
 python -m graph_notebook.notebooks.install --destination ~/notebook/destination/dir
@@ -324,7 +324,7 @@ source /tmp/venv/bin/activate
 
 # 3) Install build dependencies
 pip install --upgrade pip setuptools wheel twine
-pip install jupyterlab>=3
+pip install "jupyterlab>=3,<4"
 
 # 4) Build the distribution
 python3 setup.py bdist_wheel


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- [JupyterLab 4.0.0](https://github.com/jupyterlab/jupyterlab/releases/tag/v4.0.0) was released yesterday, and is breaking some of our recent CI builds for Python 3.8/3.10 ([Example](https://github.com/aws/graph-notebook/actions/runs/4988030679/jobs/8930366762)). Pinning JupyterLab 3.x until we can officially add support for JupyterLab 4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.