### PR TITLE
Bump requests ceiling to 2.31.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ nbclient<=0.7.0
 jupyter-contrib-nbextensions<=0.7.0
 widgetsnbextension<=3.6.1
 gremlinpython>=3.5.1,<=3.6.2
-requests>=2.27.0,<=2.28.2
+requests>=2.27.0,<=2.31.0
 ipython>=7.16.1,<=8.10.0
 ipykernel==5.3.4
 ipyfilechooser==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     install_requires=[
         'gremlinpython>=3.5.1,<=3.6.2',
         'SPARQLWrapper==1.8.4',
-        'requests>=2.27.0,<=2.28.2',
+        'requests>=2.27.0,<=2.31.0',
         'ipywidgets==7.7.2',
         'jupyterlab_widgets>=1.0.0,<3.0.0',
         'networkx==2.4',


### PR DESCRIPTION
Issue #, if available: CVE-2023-32681

Description of changes:
- Upgraded `requests` dependency maximum version for a security fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.