### PR TITLE
Use Gremlin as default for PropertyGraph samples in %seed

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -2543,6 +2543,8 @@ class Graph(Magics):
                     selected_model = 'propertygraph'
                     if normed_language in ['gremlin', 'opencypher']:
                         selected_language = normed_language
+                    elif normed_language == '':
+                        selected_language = 'gremlin'
                 else:
                     selected_model = 'rdf'
                     selected_language = 'sparql'

--- a/src/graph_notebook/notebooks/02-Visualization/Grouping-and-Appearance-Customization-Gremlin.ipynb
+++ b/src/graph_notebook/notebooks/02-Visualization/Grouping-and-Appearance-Customization-Gremlin.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%seed --model Property_Graph --dataset airports --run"
+    "%seed --model Property_Graph --language gremlin --dataset airports --run"
    ]
   },
   {

--- a/src/graph_notebook/notebooks/03-Sample-Applications/01-Fraud-Graphs/01-Building-a-Fraud-Graph-Application.ipynb
+++ b/src/graph_notebook/notebooks/03-Sample-Applications/01-Fraud-Graphs/01-Building-a-Fraud-Graph-Application.ipynb
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%seed --model Property_Graph --dataset fraud_graph --run"
+    "%seed --model Property_Graph --language gremlin --dataset fraud_graph --run"
    ]
   },
   {

--- a/src/graph_notebook/notebooks/03-Sample-Applications/02-Knowledge-Graphs/Building-a-Knowledge-Graph-Application-Gremlin.ipynb
+++ b/src/graph_notebook/notebooks/03-Sample-Applications/02-Knowledge-Graphs/Building-a-Knowledge-Graph-Application-Gremlin.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%seed --model Property_Graph --dataset knowledge-graph --run"
+    "%seed --model Property_Graph --language gremlin --dataset knowledge-graph --run"
    ]
   },
   {

--- a/src/graph_notebook/notebooks/03-Sample-Applications/03-Identity-Graphs/01-Building-an-Identity-Graph-Application.ipynb
+++ b/src/graph_notebook/notebooks/03-Sample-Applications/03-Identity-Graphs/01-Building-an-Identity-Graph-Application.ipynb
@@ -76,7 +76,7 @@
    },
    "outputs": [],
    "source": [
-    "%seed --model Property_Graph --dataset identity --run"
+    "%seed --model Property_Graph --language gremlin --dataset identity --run"
    ]
   },
   {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Use Gremlin as the default query language for samples if `--model propertygraph` is specified without a corresponding `--language` argument when `%seed` is run via line arguments.
- Modify Gremlin sample notebooks to use the new `--language` option for `%seed`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.