### PR TITLE
Suppress InsecureRequestWarning if SSL verification is disabled

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Changed datatype of "amount" from String to numeric for "Transaction" vertices in Fraud Graph sample notebook ([Link to PR](https://github.com/aws/graph-notebook/pull/489))
 - Replaced usages of deprecated DataFrame.append method in ML samples ([Link to PR](https://github.com/aws/graph-notebook/pull/495))
 - Set Gremlin as default language for PropertyGraph samples in `%seed` ([Link to PR](https://github.com/aws/graph-notebook/pull/497))
+- Suppress InsecureRequestWarning if SSL verification is disabled ([Link to PR](https://github.com/aws/graph-notebook/pull/499))
 
 ## Release 3.8.1 (April 17, 2023)
 - Reinstate Python 3.7 support for compatibility with legacy AL1 Neptune Notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/479))

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -8,6 +8,7 @@ import logging
 import re
 
 import requests
+import urllib3
 from urllib.parse import urlparse, urlunparse
 from SPARQLWrapper import SPARQLWrapper
 from boto3 import Session
@@ -146,6 +147,8 @@ class Client(object):
         self.target_port = port
         self.ssl = ssl
         self.ssl_verify = ssl_verify
+        if not self.ssl_verify:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         self.sparql_path = sparql_path
         self.gremlin_traversal_source = gremlin_traversal_source
         self.gremlin_username = gremlin_username

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -136,6 +136,25 @@ class TestGenerateConfiguration(unittest.TestCase):
         config_from_file = get_config(self.test_file_path)
         self.assertEqual(config.to_dict(), config_from_file.to_dict())
 
+    def test_generate_configuration_override_defaults_neptune_no_verify(self):
+        auth_mode = AuthModeEnum.IAM
+        ssl = True
+        ssl_verify = False
+        loader_arn = 'foo'
+        aws_region = 'us-iso-east-1'
+        config = Configuration(self.neptune_host_reg, self.port, auth_mode=auth_mode,
+                               load_from_s3_arn=loader_arn,
+                               ssl=ssl, ssl_verify=ssl_verify,
+                               aws_region=aws_region)
+
+        c = generate_config(config.host, config.port, auth_mode=config.auth_mode,
+                            load_from_s3_arn=config.load_from_s3_arn,
+                            ssl=config.ssl, ssl_verify=config.ssl_verify,
+                            aws_region=config.aws_region)
+        c.write_to_file(self.test_file_path)
+        config_from_file = get_config(self.test_file_path)
+        self.assertEqual(config.to_dict(), config_from_file.to_dict())
+
     def test_generate_configuration_override_defaults_neptune_cn(self):
         auth_mode = AuthModeEnum.IAM
         ssl = False

--- a/test/unit/configuration/test_configuration_from_main.py
+++ b/test/unit/configuration/test_configuration_from_main.py
@@ -52,6 +52,11 @@ class TestGenerateConfigurationMain(unittest.TestCase):
                                         load_from_s3_arn='loader_arn', ssl=False)
         self.generate_config_from_main_and_test(expected_config, host_type='neptune')
 
+    def test_generate_configuration_main_override_defaults_neptune_no_verify(self):
+        expected_config = Configuration(self.neptune_host_reg, self.port, auth_mode=AuthModeEnum.IAM,
+                                        load_from_s3_arn='loader_arn', ssl=True, ssl_verify=False)
+        self.generate_config_from_main_and_test(expected_config, host_type='neptune')
+
     def test_generate_configuration_main_override_defaults_neptune_cn(self):
         expected_config = Configuration(self.neptune_host_cn, self.port, auth_mode=AuthModeEnum.IAM,
                                         load_from_s3_arn='loader_arn', ssl=False)
@@ -95,8 +100,11 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         # Configuration object we get from the resulting file is what we expect.
         if host_type == 'neptune':
             result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '
-                               f'--host "{source_config.host}" --port "{source_config.port}" '
-                               f'--auth_mode "{source_config.auth_mode.value}" --ssl "{source_config.ssl}" '
+                               f'--host "{source_config.host}" '
+                               f'--port "{source_config.port}" '
+                               f'--auth_mode "{source_config.auth_mode.value}" '
+                               f'--ssl "{source_config.ssl}" '
+                               f'--ssl-verify "{source_config.ssl_verify}" '
                                f'--load_from_s3_arn "{source_config.load_from_s3_arn}" '
                                f'--proxy_host "{source_config.proxy_host}" '
                                f'--proxy_port "{source_config.proxy_port}" '
@@ -106,7 +114,9 @@ class TestGenerateConfigurationMain(unittest.TestCase):
                                f'--host "{source_config.host}" --port "{source_config.port}" '
                                f'--proxy_host "{source_config.proxy_host}" '
                                f'--proxy_port "{source_config.proxy_port}" '
-                               f'--ssl "{source_config.ssl}" --config_destination="{self.test_file_path}" ')
+                               f'--ssl "{source_config.ssl}" '
+                               f'--ssl-verify "{source_config.ssl_verify}" '
+                               f'--config_destination="{self.test_file_path}" ')
         self.assertEqual(result, 0)
         config = get_config(self.test_file_path)
         self.assertEqual(source_config.to_dict(), config.to_dict())


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Prevent `InsecureRequestWarning` from being displayed during magics execution, if `ssl_verify=False` is set in the notebook configuration.
- Added extra unit tests for the `ssl_verify` config option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.