### PR TITLE
Fix/published ports not accessible in host mode

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,33 @@
-
-
 Run `%load_ext graph_notebook.magics` at the top of a notebook to enable gremlin magic like `%%gremlin`
 
 Default password is `admin`.
 
 ## Example Runs
+
+```sh
+docker run --network="host" -p 8888:8888 -t graph-notebook
+
+# Sharing directories
+docker run --network="host" -p 8889:8889 -p 8888:8888 -v $(pwd)/out:/working 
+
+
+# For connecting with IAM Auth
+docker run -p 8888:8888 \
+ -e AWS_ACCESS_KEY_ID \
+ -e AWS_SECRET_ACCESS_KEY \ 
+ -e AWS_SESSION_TOKEN \ 
+ -e AWS_REGION="us-east-1" \
+ graph-notebook
+```
+
+## [Host Networking Mode (--network="host")](url=https://docs.docker.com/network/host/)
+
+Host mode networking can be useful to optimize performance, and in situations where a container needs to handle a large range of ports, as it does not require network address translation (NAT), and no “userland-proxy” is created for each port.
+
+The host networking driver only works on **Linux hosts**, and is **not supported on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server**.
+
+## Example Local Mac/Windows Runs
+
 ```sh
 docker run -p 8888:8888 -t graph-notebook
 
@@ -24,7 +47,8 @@ Example Notebooks are placed in the `Example Notebooks` sub-directory
 
 Within the Jupyter Notebook you must configure the Notebook settings to account for `localhost` or `remote` connections.
 
-### Example Localhost Connection:
+### Example Localhost Connection
+
 ```ipynb
 %%graph_notebook_config
     {
@@ -40,7 +64,8 @@ Within the Jupyter Notebook you must configure the Notebook settings to account 
     }
 ```
 
-### Example Neptune Proxy Connection:
+### Example Neptune Proxy Connection
+
 ```ipynb
     {
         "host": "clustername.cluster-ididididid.us-east-1.neptune.amazonaws.com",
@@ -53,8 +78,6 @@ Within the Jupyter Notebook you must configure the Notebook settings to account 
         "load_from_s3_arn": ""
     }
 ```
-
-
 
 ## Configurable Properties
 
@@ -77,7 +100,3 @@ Within the Jupyter Notebook you must configure the Notebook settings to account 
 | PROVIDE_EXAMPLES   | Whether or not to automatically copy example notebooks over when a volume is being shared.        |
 | GRAPH_NOTEBOOK_PROXY_HOST   | Host that will proxy requests to Neptune. Will not proxy if not provided.        |
 | GRAPH_NOTEBOOK_PROXY_PORT   | Port for proxy host.        |
-
-
-
-

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,10 +6,10 @@ Default password is `admin`.
 
 ## Example Runs
 ```sh
-docker run --network="host"  -p 8888:8888 -t graph-notebook
+docker run -p 8888:8888 -t graph-notebook
 
 # Sharing directories
-docker run --network="host"  -p 8889:8889 -p 8888:8888 -v $(pwd)/out:/working 
+docker run -p 8889:8889 -p 8888:8888 -v $(pwd)/out:/working 
 
 # For connecting with IAM Auth
 docker run -p 8888:8888 \

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,9 @@ Default password is `admin`.
 
 ## Example Runs
 
+### On Linux:
+- Note that these commands invoke [host networking mode](https://docs.docker.com/network/host/). This mode is only compatible with Linux, and may cause issues if run on a Mac or Windows host.
+
 ```sh
 docker run --network="host" -p 8888:8888 -t graph-notebook
 
@@ -20,13 +23,7 @@ docker run -p 8888:8888 \
  graph-notebook
 ```
 
-## [Host Networking Mode (--network="host")](url=https://docs.docker.com/network/host/)
-
-Host mode networking can be useful to optimize performance, and in situations where a container needs to handle a large range of ports, as it does not require network address translation (NAT), and no “userland-proxy” is created for each port.
-
-The host networking driver only works on **Linux hosts**, and is **not supported on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server**.
-
-## Example Local Mac/Windows Runs
+### On Mac/Windows:
 
 ```sh
 docker run -p 8888:8888 -t graph-notebook
@@ -43,7 +40,10 @@ docker run -p 8888:8888 \
  graph-notebook
 ```
 
-Example Notebooks are placed in the `Example Notebooks` sub-directory
+
+## Post-Launch Configuration
+
+Example Notebooks are placed in the `Example Notebooks` sub-directory.
 
 Within the Jupyter Notebook you must configure the Notebook settings to account for `localhost` or `remote` connections.
 


### PR DESCRIPTION
Issue #, if available: [#491](https://github.com/aws/graph-notebook/issues/491)
Description of changes:

Update README.md with information on Host Networking Mode

This PR updates the README.md file with information on Host Networking Mode in Docker. Host mode networking can be useful to optimize performance and handle a large range of ports, as it does not require network address translation (NAT), and no "userland-proxy" is created for each port. However, it is important to note that the host networking driver only works on Linux hosts and is not supported on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server.

This PR also includes examples of how to run a container in host networking mode on a local Mac or Windows machine.

This update provides valuable information to users who may be considering using host networking mode in their Docker containers and ensures that the README.md file is up-to-date and accurate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.