### PR TITLE
Add --explain-type option to %%gremlin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Added `--explain-type` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/503))
 
 ## Release 3.8.2 (June 5, 2023)
 - New Sample Applications - Healthcare and Life Sciences notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/484))

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -114,6 +114,9 @@ STATISTICS_MODES = ["", "status", "disableAutoCompute", "enableAutoCompute", "re
 SUMMARY_MODES = ["", "basic", "detailed"]
 STATISTICS_LANGUAGE_INPUTS = ["propertygraph", "pg", "gremlin", "oc", "opencypher", "sparql", "rdf"]
 
+SPARQL_EXPLAIN_MODES = ['dynamic', 'static', 'details']
+OPENCYPHER_EXPLAIN_MODES = ['dynamic', 'static', 'details']
+
 
 def is_allowed_neptune_host(hostname: str, host_allowlist: list):
     for host_snippet in host_allowlist:
@@ -211,12 +214,8 @@ class Client(object):
         if 'content-type' not in headers:
             headers['content-type'] = DEFAULT_SPARQL_CONTENT_TYPE
 
-        explain = explain.lower()
         if explain != '':
-            if explain not in ['static', 'dynamic', 'details']:
-                raise ValueError('explain mode not valid, must be one of "static", "dynamic", or "details"')
-            else:
-                data['explain'] = explain
+            data['explain'] = explain
 
         if path != '':
             sparql_path = f'/{path}'


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added the `--explain-type` option to `%%gremlin`
- Changed `--explain-type` option in `%%sparql` and `%%oc` to accept arbitrary string input.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.