### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate Stack Name
         id: generate-stack-name
-        run: echo "::set-output name=stack-name::$(echo graph-notebook-$RANDOM)"
+        run: echo "stack-name=$(echo graph-notebook-$RANDOM)" >> $GITHUB_OUTPUT
         shell: bash
   create-stack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Issue #, if available:

Resolve #505 

Description of changes:

Update `.github/workflows/integration.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "::set-output name=stack-name::$(echo graph-notebook-$RANDOM)"
```

**TO-BE**

```yaml
run: echo "stack-name=$(echo graph-notebook-$RANDOM)" >> $GITHUB_OUTPUT
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.