### PR TITLE
Fix notebook kernel crashing with ZMQ errors on magic execution

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Added `--explain-type` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/503))
+- Fixed kernel crashing with ZMQ errors on magic execution ([Link to PR](https://github.com/aws/graph-notebook/pull/517))
 
 ## Release 3.8.2 (June 5, 2023)
 - New Sample Applications - Healthcare and Life Sciences notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/484))

--- a/additional-databases/sagemaker/sagemaker-notebook-lifecycle/install-graph-notebook-lc-cn.sh
+++ b/additional-databases/sagemaker/sagemaker-notebook-lifecycle/install-graph-notebook-lc-cn.sh
@@ -28,12 +28,8 @@ python3 -m ipykernel install --sys-prefix --name python3 --display-name "Python 
 echo "installing python dependencies..."
 pip uninstall NeptuneGraphNotebook -y # legacy uninstall when we used to install from source in s3
 
-pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "ipython==7.16.1"
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "jupyter-console<=6.4.0"
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "jupyter-client<=6.1.12"
-pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "ipywidgets<=7.7.1"
-pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "notebook==6.4.12"
-pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "nbclient<=0.7.0"
 pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn "awswrangler"
 
 if [[ ${VERSION} == "" ]]; then

--- a/additional-databases/sagemaker/sagemaker-notebook-lifecycle/install-graph-notebook-lc.sh
+++ b/additional-databases/sagemaker/sagemaker-notebook-lifecycle/install-graph-notebook-lc.sh
@@ -28,12 +28,8 @@ python3 -m ipykernel install --sys-prefix --name python3 --display-name "Python 
 echo "installing python dependencies..."
 pip uninstall NeptuneGraphNotebook -y # legacy uninstall when we used to install from source in s3
 
-pip install "ipython==7.16.1"
 pip install "jupyter-console<=6.4.0"
 pip install "jupyter-client<=6.1.12"
-pip install "ipywidgets<=7.7.1"
-pip install "notebook==6.4.12"
-pip install "nbclient<=0.7.0"
 pip install awswrangler
 
 if [[ ${VERSION} == "" ]]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ SPARQLWrapper==1.8.4
 networkx==2.4
 Jinja2>=3.0.3,<=3.1.2
 jupyter==1.0.0
-notebook>=6.1.5,<6.5.0
+notebook>=6.1.5,<7.0.0
 ipywidgets==7.7.2
 jupyterlab_widgets>=1.0.0,<3.0.0
 nbclient<=0.7.0

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'jupyterlab_widgets>=1.0.0,<3.0.0',
         'networkx==2.4',
         'Jinja2>=3.0.3,<=3.1.2',
-        'notebook>=6.1.5,<6.5.0',
+        'notebook>=6.1.5,<7.0.0',
         'nbclient<=0.7.3',
         'jupyter-contrib-nbextensions<=0.7.0',
         'widgetsnbextension<=3.6.1',


### PR DESCRIPTION
Issue #, if available: #516

Description of changes:
- Upgrade to `notebook` pin ceiling to `<7.0.0` to mitigate: https://github.com/jupyter/notebook/issues/6721.
- Cleaned up legacy version pins in SageMaker Lifecycle scripts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.