### PR TITLE
Add support for Memgraph and supply chain notebook

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 - Added `--explain-type` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/503))
 - Fixed kernel crashing with ZMQ errors on magic execution ([Link to PR](https://github.com/aws/graph-notebook/pull/517))
+- Added Memgraph as an additional graph database and the supply chain analysis notebook ([Link to PR]())
 
 ## Release 3.8.2 (June 5, 2023)
 - New Sample Applications - Healthcare and Life Sciences notebooks ([Link to PR](https://github.com/aws/graph-notebook/pull/484))

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Instructions for connecting to the following graph databases:
 |    [Blazegraph](#blazegraph)    |            RDF          |       SPARQL        |
 |[Amazon Neptune](#amazon-neptune)|  property graph or RDF  |  Gremlin or SPARQL  |
 |         [Neo4J](#neo4j)         |     property graph      |       Cypher        |
+|         [Memgraph](#memgraph)   |     property graph      |       Cypher        |
 
 We encourage others to contribute configurations they find useful. There is an [`additional-databases`](https://github.com/aws/graph-notebook/blob/main/additional-databases) folder where more information can be found.
 
@@ -192,6 +193,7 @@ Configuration options can be set using the `%graph_notebook_config` magic comman
 | sparql | SPARQL connection object | ``` { "path": "sparql" } ``` | string |
 | gremlin | Gremlin connection object | ``` { "username": "", "password": "", "traversal_source": "g",  "message_serializer": "graphsonv3" } ```| string |
 | neo4j | Neo4J connection object |``` { "username": "neo4j", "password": "password", "auth": true, "database": null } ``` | string |
+| memgraph | Memgraph connection object |``` { "username": "", "password": "", "auth": false, "database": "memgraph" } ``` | string |
 
 ### Gremlin Server
 
@@ -344,6 +346,31 @@ For a local Neo4j Desktop database, you can use the following command:
 Ensure that you also specify the `%%oc bolt` option when submitting queries to the Bolt endpoint.
 
 To setup a new local Neo4J Desktop database for use with the graph notebook, check out the [Neo4J Desktop User Interface Guide](https://neo4j.com/developer/neo4j-desktop/).
+
+### Memgraph
+
+Change the configuration using `%%graph_notebook_config` and modify the fields for `host` and `port`, `ssl`. 
+
+After local setup of Memgraph is complete, set the following configuration to connect from graph-notebook:
+
+```
+%%graph_notebook_config
+{
+  "host": "localhost",
+  "port": 7687,
+  "ssl": false
+}
+```
+
+Ensure that you specify the `%%oc bolt` option when submitting queries to the Bolt endpoint. For example, a correct way of running a Cypher query via Bolt protocol is:
+
+```
+%%oc bolt
+MATCH (n)
+RETURN count(n)
+```
+
+For more details on how to run Memgraph, refer to its [notebook guide](./additional-databases/memgraph/README.md).
 
 ## Building From Source
 

--- a/additional-databases/memgraph/README.md
+++ b/additional-databases/memgraph/README.md
@@ -1,0 +1,49 @@
+## Connecting graph notebook to Memgraph Bolt Endpoint
+
+[Memgraph](https://memgraph.com/) is an open-source in-memory graph database built for highly performant and advanced analytical insights. Memgraph is Neo4J Bolt protocol compatible and it uses the standardized Cypher query language. 
+
+For a quick start, run the following command in your terminal to start Memgraph Platform in a Docker container: 
+
+```
+docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-server-name-for-init=Neo4j/" memgraph/memgraph-platform
+```
+
+The above command started Memgraph database, MAGE (graph algorithms library) and Memgraph Lab (visual user interface). For additional instructions on setting up and running Memgraph locally, refer to the [Memgraph documentation](https://memgraph.com/docs/memgraph/installation). Connection to the graph notebook works if the `--bolt-server-name-for-init` setting is modified. For more information on changing configuration settings, refer to our [how-to guide](https://memgraph.com/docs/memgraph/how-to-guides/config-logs).
+
+
+After local setup of Memgraph is complete, set the following configuration to connect from graph-notebook:
+
+```
+%%graph_notebook_config
+{
+  "host": "localhost",
+  "port": 7687,
+  "ssl": false
+}
+```
+
+If you set up an authentication on your Memgraph instance, you can provide login details via configuration. For example, if you created user `username` identified by `password`, then the following configuration is the correct one:
+
+%%graph_notebook_config
+{
+  "host": "localhost",
+  "port": 7687,
+  "ssl": false,
+  "memgraph": {
+    "username": "username",
+    "password": "password",
+    "auth": true
+  }
+}
+
+To learn how to manage users in Memgraph, refer to [Memgraph documentation](https://memgraph.com/docs/memgraph/reference-guide/users).
+
+You can query Memgraph via Bolt protocol which was designed for efficient communication with graph databases. Memgraph supports versions 1 and 4 of the protocol. Ensure that you specify the `%%oc bolt` option when submitting queries to the Bolt endpoint. For example, a correct way of running a Cypher query via Bolt protocol is:
+
+```
+%%oc bolt
+MATCH (n)
+RETURN count(n)
+```
+
+Another way of ensuring that Memgraph is running, head to `localhost:3000` and check out Memgraph Lab, a visual user interface. You can see node and relationship count there, explore, query and visualize data. If you get stuck and have more questions, [let's talk at Memgraph Discord community](https://www.discord.gg/memgraph).

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -320,7 +320,9 @@ class Graph(Magics):
                 .with_gremlin_login(config.gremlin.username, config.gremlin.password) \
                 .with_gremlin_serializer(config.gremlin.message_serializer) \
                 .with_neo4j_login(config.neo4j.username, config.neo4j.password, config.neo4j.auth,
-                                  config.neo4j.database)
+                                  config.neo4j.database) \
+                .with_memgraph_login(config.memgraph.username, config.memgraph.password, config.memgraph.auth,
+                                  config.memgraph.database)
 
         self.client = builder.build()
 

--- a/src/graph_notebook/notebooks/01-Getting-Started/06-Supply-Chain-Analysis-with-Memgraph.ipynb
+++ b/src/graph_notebook/notebooks/01-Getting-Started/06-Supply-Chain-Analysis-with-Memgraph.ipynb
@@ -1,0 +1,457 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Supply Chain Analysis with Memgraph\n",
+    "\n",
+    "## Table of contents <a name=\"toc\"></a>\n",
+    "1. [Introduction](#introduction)\n",
+    "2. [Connect to Memgraph](#connect-to-memgraph)\n",
+    "3. [Create the dataset](#create-the-dataset)\n",
+    "4. [Supply Chain Analysis](#supply-chain-analysis)\n",
+    "    - [Acquiring critical hubs in the network with betweenness centrality](#critical-hubs)\n",
+    "    - [Get ingredients provided by the supplier](#get-ingredients)\n",
+    "    - [Pathfinding for necessary ingredients](#pathfinding)\n",
+    "    - [Checking dependencies of the product with ancestors](#ancestors)\n",
+    "    - [Ancestors graph](#ancestors-graph)\n",
+    "    - [Checking possible products for production with descendants](#descendants)\n",
+    "    - [Descendants graph](#descendants-graph)\n",
+    "    - [Getting the order of execution with topological sort](#topological-sort)\n",
+    "5. [Conclusion](#conclusion)\n",
+    "\n",
+    "## 1. Introduction<a name=\"introduction\"></a>\n",
+    "\n",
+    "In supply chain management, a network of process steps is drawn to minimize product delivery time from production to shipping. Up to this day, optimizations in process steps are mostly carried out by staff members, who can be prone to errors and under-optimized solutions. Moreover, it takes them a reasonable amount of time to design an optimal schedule when they could have been utilized for processes requiring more expertise and knowledge with an automated process scheduling the supply chain.\n",
+    "\n",
+    "In this notebook, you'll learn how to start Memgraph, connect to it and run Cypher queries to explore the supply chain and learn more about the power of graphs in that domain. \n",
+    "\n",
+    "## 2. Connect to Memgraph<a name=\"connect-to-memgraph\"></a>\n",
+    "\n",
+    "[Memgraph](https://memgraph.com/) is an open-source in-memory graph database built for highly performant and advanced analytical insights. Memgraph is Neo4j Bolt protocol compatible and uses the standardized Cypher query language. \n",
+    "\n",
+    "For a quick start, run the following command in your terminal to start the Memgraph Platform in a Docker container: \n",
+    "\n",
+    "```\n",
+    "docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH=\"--bolt-server-name-for-init=Neo4j/\" memgraph/memgraph-platform\n",
+    "```\n",
+    "\n",
+    "The above command starts the Memgraph database, MAGE (graph algorithms library) and Memgraph Lab (visual user interface). For additional instructions on setting up and running Memgraph locally, refer to the [Memgraph documentation](https://memgraph.com/docs/memgraph/installation). Connection to the Graph Notebook works if the `--bolt-server-name-for-init` setting is modified. For more information on changing configuration settings, refer to our [how-to guide](https://memgraph.com/docs/memgraph/how-to-guides/config-logs).\n",
+    "\n",
+    "\n",
+    "After the local setup of Memgraph is complete, set the following configuration to connect from the Graph Notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%graph_notebook_config\n",
+    "{\n",
+    "  \"host\": \"localhost\",\n",
+    "  \"port\": 7687,\n",
+    "  \"ssl\": false\n",
+    "}"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Create the dataset<a name=\"create-the-dataset\"></a>\n",
+    "\n",
+    "You can query Memgraph via Bolt protocol designed for efficient communication with graph databases. Memgraph supports versions 1, 4 and 5 of the protocol. Specify the `%%oc bolt` option when submitting queries to the Bolt endpoint.\n",
+    "\n",
+    "Before we analyze the dataset, we have to import it. The easiest way to do that with the `graph-notebook` is to run `CREATE` Cypher queries. Once you run the code cell below, the Memgraph database will be populated with a supply chain dataset. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "CREATE (sup1:Supplier {id: 1, name: \"Supplissimus\", centrality: 0.027920624240525559})\n",
+    "CREATE (sup2:Supplier {id: 2, name: \"Supplionis\", centrality: 0.002840909090909091})\n",
+    "CREATE (sup3:Supplier {id: 3, name: \"MegaSupplies\", centrality: 0.055822172619047615})\n",
+    "CREATE (sup4:Supplier {id: 4, name: \"Supplies4you\", centrality: 0})\n",
+    "CREATE (ing1:Ingredient {id: 1, name: \"Ingredient 1\", centrality: 0.0042365042365042358})\n",
+    "CREATE (ing2:Ingredient {id: 2, name: \"Ingredient 2\", centrality: 0.077438394705712787})\n",
+    "CREATE (ing3:Ingredient {id: 3, name: \"Ingredient 3\", centrality: 0.025363208468374868})\n",
+    "CREATE (ing4:Ingredient {id: 4, name: \"Ingredient 4\", centrality: 0.036831658149140731})\n",
+    "CREATE (ing5:Ingredient {id: 5, name: \"Ingredient 5\", centrality: 0.018939393939393933})\n",
+    "CREATE (ing6:Ingredient {id: 6, name: \"Ingredient 6\", centrality: 0.018939393939393933})\n",
+    "CREATE (ing7:Ingredient {id: 7, name: \"Ingredient 7\", centrality: 0.018939393939393933})\n",
+    "CREATE (ing8:Ingredient {id: 8, name: \"Ingredient 8\", centrality: 0.066602827149702143})\n",
+    "CREATE (ing9:Ingredient {id: 9, name: \"Ingredient 9\", centrality: 0.076719345469345446})\n",
+    "CREATE (ing10:Ingredient {id: 10, name: \"Ingredient 10\", centrality: 0.13523010455818119})\n",
+    "CREATE (pro1:Product {id: 1, name: \"Intermediate product 1\", centrality: 0.075849577597110474})\n",
+    "CREATE (pro2:Product {id: 2, name: \"Intermediate product 2\", centrality: 0.30307542895342809})\n",
+    "CREATE (pro3:Product {id: 3, name: \"Intermediate product 3\", centrality: 0.27450054057784318})\n",
+    "CREATE (pro4:Product {id: 4, name: \"Intermediate product 4\", centrality: 0.12564154013699291})\n",
+    "CREATE (pro5:Product {id: 5, name: \"Intermediate product 5\", centrality: 0.018604622671718259})\n",
+    "CREATE (pro6:FinalProduct:Product {id: 6, name: \"Final product 1\", centrality: 0.02814078282828282})\n",
+    "CREATE (pro7:FinalProduct:Product {id: 7, name: \"Final product 2\", centrality: 0.035353535353535366})\n",
+    "CREATE (pro8:FinalProduct:Product {id: 8, name: \"Final product 3\", centrality: 0.1539119291441273})\n",
+    "CREATE (shi1:Shipping {id: 1, name: \"Shipping point 1\", centrality: 0.0066761363636363633})\n",
+    "CREATE (shi2:Shipping {id: 2, name: \"Shipping point 2\", centrality: 0})\n",
+    "CREATE (rec1:Recipe {id: 1, name: \"Recipe for product 1\", centrality: 0.077470165525264201})\n",
+    "CREATE (rec2:Recipe {id: 2, name: \"Recipe for product 2\", centrality: 0.15612639008415902})\n",
+    "CREATE (rec3:Recipe {id: 3, name: \"Recipe for product 3\", centrality: 0.27750650680338179})\n",
+    "CREATE (rec4:Recipe {id: 4, name: \"Recipe for product 4\", centrality: 0.072996207394185345})\n",
+    "CREATE (rec5:Recipe {id: 5, name: \"Recipe for product 5\", centrality: 0.051091351458998513})\n",
+    "CREATE (rec6:Recipe {id: 6, name: \"Recipe for final product 1\", centrality: 0.23304036135039422})\n",
+    "CREATE (rec7:Recipe {id: 7, name: \"Recipe for final product 2\", centrality: 0.24386567715587651})\n",
+    "CREATE (rec8:Recipe {id: 8, name: \"Recipe for final product 3 - variant 1\", centrality: 0.088413170560519616})\n",
+    "CREATE (rec9:Recipe {id: 9, name: \"Recipe for final product 3 - variant 2\", centrality: 0.18098001437059097})\n",
+    "CREATE (rec10:Recipe {id: 10, name: \"Recipe for final product 3 - variant 3\", centrality: 0.082068494800692962})\n",
+    "CREATE (sup1)-[:SUPPLIES]->(ing1)\n",
+    "CREATE (sup1)-[:SUPPLIES]->(ing2)\n",
+    "CREATE (sup1)-[:SUPPLIES]->(ing3)\n",
+    "CREATE (sup1)-[:SUPPLIES]->(ing4)\n",
+    "CREATE (sup2)-[:SUPPLIES]->(ing5)\n",
+    "CREATE (sup2)-[:SUPPLIES]->(ing6)\n",
+    "CREATE (sup2)-[:SUPPLIES]->(ing7)\n",
+    "CREATE (sup3)-[:SUPPLIES]->(ing8)\n",
+    "CREATE (sup3)-[:SUPPLIES]->(ing9)\n",
+    "CREATE (sup4)-[:SUPPLIES]->(ing10)\n",
+    "CREATE (pro1)-[:FORMS {quantity: 30}]->(rec1)\n",
+    "CREATE (pro2)-[:FORMS {quantity: 50}]->(rec1)\n",
+    "CREATE (pro2)-[:FORMS {quantity: 100}]->(rec2)\n",
+    "CREATE (pro2)-[:FORMS {quantity: 50}]->(rec10)\n",
+    "CREATE (pro3)-[:FORMS {quantity: 80}]->(rec1)\n",
+    "CREATE (pro3)-[:FORMS {quantity: 200}]->(rec2)\n",
+    "CREATE (pro4)-[:FORMS {quantity: 150}]->(rec2)\n",
+    "CREATE (pro4)-[:FORMS {quantity: 70}]->(rec10)\n",
+    "CREATE (pro5)-[:FORMS {quantity: 10}]->(rec3)\n",
+    "CREATE (pro6)-[:FORMS {quantity: 90}]->(rec3)\n",
+    "CREATE (pro7)-[:FORMS {quantity: 100}]->(rec3)\n",
+    "CREATE (pro8)-[:FORMS {quantity: 200}]->(rec3)\n",
+    "CREATE (ing9)-[:FORMS {quantity: 300}]->(rec4)\n",
+    "CREATE (ing9)-[:FORMS {quantity: 80}]->(rec5)\n",
+    "CREATE (ing10)-[:FORMS {quantity: 120}]->(rec4)\n",
+    "CREATE (ing10)-[:FORMS {quantity: 5}]->(rec5)\n",
+    "CREATE (ing10)-[:FORMS {quantity: 100}]->(rec9)\n",
+    "CREATE (ing1)-[:FORMS {quantity: 15}]->(rec6)\n",
+    "CREATE (ing2)-[:FORMS {quantity: 25}]->(rec6)\n",
+    "CREATE (ing2)-[:FORMS {quantity: 65}]->(rec7)\n",
+    "CREATE (ing2)-[:FORMS {quantity: 100}]->(rec9)\n",
+    "CREATE (ing3)-[:FORMS {quantity: 35}]->(rec6)\n",
+    "CREATE (ing3)-[:FORMS {quantity: 120}]->(rec7)\n",
+    "CREATE (ing4)-[:FORMS {quantity: 130}]->(rec7)\n",
+    "CREATE (ing4)-[:FORMS {quantity: 140}]->(rec8)\n",
+    "CREATE (ing5)-[:FORMS {quantity: 85}]->(rec8)\n",
+    "CREATE (pro6)-[:SHIPS_WITH]->(shi1)\n",
+    "CREATE (pro7)-[:SHIPS_WITH]->(shi1)\n",
+    "CREATE (pro8)-[:SHIPS_WITH]->(shi2)\n",
+    "CREATE (rec1)-[:PRODUCES {quantity: 1}]->(pro1)\n",
+    "CREATE (rec2)-[:PRODUCES {quantity: 1}]->(pro2)\n",
+    "CREATE (rec3)-[:PRODUCES {quantity: 1}]->(pro3)\n",
+    "CREATE (rec4)-[:PRODUCES {quantity: 1}]->(pro4)\n",
+    "CREATE (rec5)-[:PRODUCES {quantity: 1}]->(pro5)\n",
+    "CREATE (rec6)-[:PRODUCES {quantity: 1}]->(pro6)\n",
+    "CREATE (rec7)-[:PRODUCES {quantity: 1}]->(pro7)\n",
+    "CREATE (rec8)-[:PRODUCES {quantity: 1}]->(pro8)\n",
+    "CREATE (rec9)-[:PRODUCES {quantity: 1}]->(pro8)\n",
+    "CREATE (rec10)-[:PRODUCES {quantity: 1}]->(pro8)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To ensure the data is stored in Memgraph, head to `localhost:3000` and check out Memgraph Lab, a visual user interface. You can see node and relationship count there, explore, query and visualize data. Besides that, you can head over to the Graph Schema tab to check if the imported data is appropriately modeled.\n",
+    "\n",
+    "<img src=\"https://public-assets.memgraph.com/graph-notebook/graph-schema-supply-chain.png\" alt=\"drawing\" style=\"width:500px;\"/>\n",
+    "\n",
+    "Another way of verifying that the database is not empty is by running the following query:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH (n)\n",
+    "RETURN count(n)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! The data is imported into Memgraph, and we can start analyzing it!\n",
+    "\n",
+    "## 4. Supply Chain Analysis<a name=\"supply-chain-analysis\"></a>\n",
+    "\n",
+    "### Acquiring critical hubs in the network with betweenness centrality<a name=\"critical-hubs\"></a>\n",
+    "\n",
+    "If, at some point, a critical path of the pipeline fails, it could mean that some products won't get constructed. Some pipeline failures don't affect as many products and don't need much attention fixing (if the priority isn't high). Some, on the other hand, need immediate attention. \n",
+    "\n",
+    "An algorithm like *betweenness centrality* does just that. It detects hubs on the network based on the number of paths that cross a node from all the pairs of nodes in the graph. \n",
+    "\n",
+    "By running the query below, we can see that some Intermediate products, if missing, could result in having all of the final products not produced, which is a massive error in the pipeline, and needs extra care to prevent that from happening (by having some alternative measures, additional monitoring of intermediate product production, etc.).\n",
+    "\n",
+    "Memgraph's support of betweenness centrality is done through the **betweenness_centrality_online.set()** method, which also works in streaming examples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "CALL betweenness_centrality_online.set() YIELD betweenness_centrality, node\n",
+    "SET node.centrality = betweenness_centrality;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH (n)-[r]->(m) RETURN n, r, m;"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get ingredients provided by the supplier<a name=\"get-ingredients\"></a>\n",
+    "\n",
+    "Since a graph database can be the ultimate source of truth between different data sources, it makes sense if all the information about our suppliers is stored in Memgraph.\n",
+    "\n",
+    "From there, we can query, for example, which ingredients are supplied by the supplier *Supplissimus*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH (s:Supplier {name:\"Supplissimus\"})-[r:SUPPLIES]->(i:Ingredient)\n",
+    "RETURN i;\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pathfinding for necessary ingredients<a name=\"pathfinding\"></a>\n",
+    "\n",
+    "We have seen a 1-hop query, which is essentially looking for the nearest neighbors in the network.\n",
+    "\n",
+    "Memgraph supports graph traversals, e.g., **Breadth-first search (BFS)**. With it, we can see which ingredients are used to form the product with the ID of 6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH p=(i:Ingredient)-[*BFS]->(f:FinalProduct {id:6})\n",
+    "RETURN p"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Checking dependencies of the product with ancestors<a name=\"ancestors\"></a>\n",
+    "\n",
+    "But traversals are not only a part of graph databases, as whole graph algorithms can be exploited on graph storage like Memgraph. \n",
+    "\n",
+    "This query determines what happens before the **:FinalProduct** with the ID 6 gets produced. It is done using the **graph_util.ancestors** procedure captures all the nodes from which a path to the destination node (FinalProduct) exists. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH (f:FinalProduct {id:6})\n",
+    "CALL graph_util.ancestors(f) YIELD ancestors\n",
+    "UNWIND ancestors AS ancestor\n",
+    "RETURN ancestor;\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ancestors graph<a name=\"ancestors-graph\"></a>\n",
+    "\n",
+    "The previous procedure has yielded us all the precedent nodes, but it only means a little since we don't know how they are connected. \n",
+    "\n",
+    "To connect the nodes, we can use another MAGE extension procedure called **graph_util.connect_nodes**, which will connect the nodes with corresponding relationships between them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH (f:FinalProduct {id:6})\n",
+    "CALL graph_util.ancestors(f) YIELD ancestors\n",
+    "WITH ancestors + [f] AS nodes\n",
+    "CALL graph_util.connect_nodes(nodes) YIELD connections\n",
+    "UNWIND nodes + connections AS graph\n",
+    "RETURN graph;"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Checking possible products for production with descendants<a name=\"descendants\"></a>\n",
+    "\n",
+    "We might look at the pipeline from the other direction. From the supplier's view, we can see how many products or operations in the pipeline are affected by him. In case he is unavailable, this information could be helpful to minimize the risk.\n",
+    "\n",
+    "Just as with ancestors, we use the procedure **graph_util.descendants**, which yields all the nodes to which a path exists from the source node (supplier *Supplissimus* in this case)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH (s:Supplier {name: \"Supplissimus\"})\n",
+    "CALL graph_util.descendants(s) YIELD descendants\n",
+    "UNWIND descendants AS descendant\n",
+    "RETURN descendant;\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Descendants graph<a name=\"descendants-graph\"></a>\n",
+    "\n",
+    "We do the same as before and connect the nodes with the **graph_util.connect_nodes** procedure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH (s:Supplier {name: \"Supplissimus\"})\n",
+    "CALL nxalg.descendants(s) YIELD descendants\n",
+    "WITH descendants + [s] AS nodes\n",
+    "CALL graph_util.connect_nodes(nodes) YIELD connections\n",
+    "UNWIND nodes + connections AS graph\n",
+    "RETURN graph;\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting the order of execution with topological sort<a name=\"topological-sort\"></a>\n",
+    "\n",
+    "There are cases when some operations can't start before others finish, which causes problems because it blocks the pipeline until the process or a job with no dependencies or bottlenecks finishes. Then, some jobs are released and resolved of their dependencies, and they can start executing again. \n",
+    "\n",
+    "In graph theory, that's precisely what topological sort does. It sorts the nodes to yield the ones (jobs, operations, or products) that get executed or produced first, followed by those that can start after the previous ones have started.\n",
+    "\n",
+    "For sorting the nodes topologically, we will use **graph_util.topological_sort** procedure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%oc bolt\n",
+    "MATCH p=(r:Recipe)-[*bfs]->(f:FinalProduct)\n",
+    "WITH project(p) AS graph\n",
+    "CALL graph_util.topological_sort(graph) YIELD sorted_nodes\n",
+    "UNWIND sorted_nodes AS nodes\n",
+    "RETURN nodes.name;"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Conclusion<a name=\"conclusion\"></a>\n",
+    "\n",
+    "Hopefully, you learned about Memgraph, supply chains and how it's intuitive to analyze them with Cypher queries. If you want to understand why graph databases are the future of network resource optimization, head over to [Memgraph's blog post](https://memgraph.com/blog/graphs-databases-are-the-future-for-network-resource-optimization). For any questions regarding this notebook, Cypher, Memgraph or graphs in general, [join our Discord community](https://www.discord.gg/memgraph). \n",
+    "\n",
+    "<h4 align=\"center\"><a href=#toc>⬆️ GO TO TOP ⬆️</a></h3>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/test/integration/IntegrationTest.py
+++ b/test/integration/IntegrationTest.py
@@ -26,7 +26,8 @@ def setup_client_builder(config: Configuration) -> ClientBuilder:
             .with_sparql_path(config.sparql.path) \
             .with_gremlin_traversal_source(config.gremlin.traversal_source) \
             .with_gremlin_serializer(config.gremlin.message_serializer) \
-            .with_neo4j_login(config.neo4j.username, config.neo4j.password, config.neo4j.auth, config.neo4j.database)
+            .with_neo4j_login(config.neo4j.username, config.neo4j.password, config.neo4j.auth, config.neo4j.database) \
+            .with_memgraph_login(config.memgraph.username, config.memgraph.password, config.memgraph.auth, config.memgraph.database)
         if config.auth_mode == AuthModeEnum.IAM:
             builder = builder.with_iam(get_session())
     else:
@@ -41,7 +42,8 @@ def setup_client_builder(config: Configuration) -> ClientBuilder:
             .with_gremlin_traversal_source(config.gremlin.traversal_source) \
             .with_gremlin_login(config.gremlin.username, config.gremlin.password) \
             .with_gremlin_serializer(config.gremlin.message_serializer) \
-            .with_neo4j_login(config.neo4j.username, config.neo4j.password, config.neo4j.auth, config.neo4j.database)
+            .with_neo4j_login(config.neo4j.username, config.neo4j.password, config.neo4j.auth, config.neo4j.database) \
+            .with_memgraph_login(config.memgraph.username, config.memgraph.password, config.memgraph.auth, config.memgraph.database)
 
     return builder
 

--- a/test/integration/iam/ml/__init__.py
+++ b/test/integration/iam/ml/__init__.py
@@ -23,6 +23,7 @@ def setup_iam_client(config: Configuration) -> Client:
         .with_gremlin_login(config.gremlin.username, config.gremlin.password) \
         .with_gremlin_serializer(config.gremlin.message_serializer) \
         .with_neo4j_login(config.neo4j.username, config.neo4j.password, config.neo4j.auth, config.neo4j.database) \
+        .with_memgraph_login(config.memgraph.username, config.memgraph.password, config.memgraph.auth, config.memgraph.database) \
         .with_iam(get_session()) \
         .build()
 
@@ -40,6 +41,10 @@ def setup_iam_client(config: Configuration) -> Client:
     assert client.neo4j_password == config.neo4j.password
     assert client.neo4j_auth == config.neo4j.auth
     assert client.neo4j_database == config.neo4j.database
+    assert client.memgraph_username == config.memgraph.username
+    assert client.memgraph_password == config.memgraph.password
+    assert client.memgraph_auth == config.memgraph.auth
+    assert client.memgraph_database == config.memgraph.database
     assert client.ssl is config.ssl
     assert client.ssl_verify is config.ssl_verify
     return client

--- a/test/integration/iam/notebook/test_open_cypher_graph_notebook.py
+++ b/test/integration/iam/notebook/test_open_cypher_graph_notebook.py
@@ -123,6 +123,12 @@ class TestGraphMagicOpenCypher(GraphNotebookIntegrationTest):
                     "auth": true,
                     "database": ""
                   }
+                  "memgraph": {
+                    "username": "",
+                    "password": "",
+                    "auth": false,
+                    "database": "memgraph"
+                  }
                 }'''
 
         self.ip.run_cell_magic('graph_notebook_config', '', config)


### PR DESCRIPTION
I created a new PR to add support for the Memgraph database without formatting changes. While fixing this, I fixed a couple of other things I noticed, so it turned out to be a good thing to check it. 

I added `README` to the additional databases folder to show that connecting to Memgraph is achievable via the existing Neo4j setup. But, since it's not intuitive for the users to set a username and password for the neo4j configuration setting, I created `MemgraphSection` in the configuration and exposed `username`, `password`, `auth` and `database` configuration flags. I added `database` section too, because Memgraph released a multitenancy feature in v2.10.

I also updated the `README` in the root folder accordingly.

Since I added Memgraph as an additional database, I also decided to contribute with a notebook.

I would like to add that I missed local testing instructions to be sure all is alright, but I did test the connection to Memgraph and run queries from the Supply Chain Analysis notebook. 

Let me know what I need to do else in order to get this PR merged and I will be more than happy to contribute more.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.