### PR TITLE
Add support for Gremlin proxy host and Neptune HTTP query visualization

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 - Added `--explain-type` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/503))
 - Added general documentation for `%%graph_notebook_config` options ([Link to PR](https://github.com/aws/graph-notebook/pull/504))
+- Added support for Gremlin proxy hosts and visualization of Neptune HTTP results ([Link to PR](https://github.com/aws/graph-notebook/pull/530))
 - Modified Dockerfile to support Python 3.10 ([Link to PR](https://github.com/aws/graph-notebook/pull/519))
 - Updated Docker documentation with platform-specific run commands ([Link to PR](https://github.com/aws/graph-notebook/pull/502))
 - Fixed deprecation warnings in GitHub workflows ([Link to PR](https://github.com/aws/graph-notebook/pull/506))


### PR DESCRIPTION
Issue #, if available: #399

Description of changes:
- Fixed an issue with `%%gremlin` not utilizing the `proxy_host` and `proxy port` field values set in the notebook connection configuration. 
  - When a proxy is specified, Gremlin requests to Neptune will now be executed against the [HTTPS REST endpoint](https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-rest.html), and require engine version >=1.2.1.0.R5. 
  - Proxied Gremlin queries against all other databases will continue to use the gremlin-python client.
- Added support for visualizing Gremlin results returned in GraphSONv1 format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.