### PR TITLE
Realign %seed widgets to fix truncated descriptions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed unit test workflows failing on type check assertion ([Link to PR](https://github.com/aws/graph-notebook/pull/514))
 - Fixed bad queries in openCypher Language Tutorial samples ([PR #1](https://github.com/aws/graph-notebook/pull/525)) ([PR #2](https://github.com/aws/graph-notebook/pull/526))
 - Fixed kernel crashing with ZMQ errors on magic execution ([Link to PR](https://github.com/aws/graph-notebook/pull/517))
+- Fixed truncated descriptions for some `%seed` fields ([Link to PR](https://github.com/aws/graph-notebook/pull/531))
 - Unpinned `boto3` and `botocore` to support NeptuneData SDK ([Link to PR](https://github.com/aws/graph-notebook/pull/528))
 
 ## Release 3.8.2 (June 5, 2023)

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -107,6 +107,7 @@ SEED_MODEL_OPTIONS = ['', 'propertygraph', 'rdf']
 SEED_LANGUAGE_OPTIONS = ['', 'gremlin', 'opencypher', 'sparql']
 SEED_SOURCE_OPTIONS = ['', 'samples', 'custom']
 SEED_NO_DATASETS_FOUND_MSG = "(No datasets available)"
+SEED_WIDGET_STYLE = {'description_width': '95px'}
 
 LOADER_FORMAT_CHOICES = ['']
 LOADER_FORMAT_CHOICES.extend(VALID_FORMATS)
@@ -2044,34 +2045,39 @@ class Graph(Magics):
         source_dropdown = widgets.Dropdown(
             options=SEED_SOURCE_OPTIONS,
             description='Source type:',
-            disabled=False
+            disabled=False,
+            style=SEED_WIDGET_STYLE
         )
 
         model_dropdown = widgets.Dropdown(
             options=SEED_MODEL_OPTIONS,
             description='Data model:',
             disabled=False,
-            layout=widgets.Layout(display='none')
+            layout=widgets.Layout(display='none'),
+            style=SEED_WIDGET_STYLE
         )
 
         custom_language_dropdown = widgets.Dropdown(
             options=SEED_LANGUAGE_OPTIONS,
             description='Language:',
             disabled=False,
-            layout=widgets.Layout(display='none')
+            layout=widgets.Layout(display='none'),
+            style=SEED_WIDGET_STYLE
         )
 
         samples_pg_language_dropdown = widgets.Dropdown(
             options=SEED_LANGUAGE_OPTIONS[:3],
             description='Language:',
             disabled=False,
-            layout=widgets.Layout(display='none')
+            layout=widgets.Layout(display='none'),
+            style=SEED_WIDGET_STYLE
         )
 
         data_set_drop_down = widgets.Dropdown(
             description='Data set:',
             disabled=False,
-            layout=widgets.Layout(display='none')
+            layout=widgets.Layout(display='none'),
+            style=SEED_WIDGET_STYLE
         )
 
         fullfile_option_dropdown = widgets.Dropdown(
@@ -2079,7 +2085,8 @@ class Graph(Magics):
             options=[True, False],
             value=args.full_file_query,
             disabled=False,
-            layout=widgets.Layout(display='none')
+            layout=widgets.Layout(display='none'),
+            style=SEED_WIDGET_STYLE
         )
 
         location_option_dropdown = widgets.Dropdown(
@@ -2087,13 +2094,15 @@ class Graph(Magics):
             options=['Local', 'S3'],
             value='Local',
             disabled=False,
-            layout=widgets.Layout(display='none')
+            layout=widgets.Layout(display='none'),
+            style=SEED_WIDGET_STYLE
         )
 
         seed_file_location_text = widgets.Text(
             description='Source:',
             placeholder='path/to/seedfiles/directory',
-            disabled=False
+            disabled=False,
+            style=SEED_WIDGET_STYLE
         )
 
         seed_file_location = FileChooser()


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed an issue with `%seed` where descriptions of some of the drop-down widgets were partially obscured.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.