### PR TITLE
Query fixes for Gremlin tutorial notebooks

### DIFF
--- a/src/graph_notebook/notebooks/06-Language-Tutorials/03-Gremlin/02-Loops-Repeats.ipynb
+++ b/src/graph_notebook/notebooks/06-Language-Tutorials/03-Gremlin/02-Loops-Repeats.ipynb
@@ -395,7 +395,8 @@
     "    .or(loops().is(2))\n",
     ")\n",
     ".path()\n",
-    ".by(elementMap())"
+    ".by(elementMap())\n",
+    ".limit(10)"
    ]
   },
   {
@@ -432,7 +433,8 @@
     ")\n",
     ".has(\"first_name\",\"Dave\")\n",
     ".path()\n",
-    ".by(elementMap())"
+    ".by(elementMap())\n",
+    ".limit(9)"
    ]
   },
   {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed an issue in the Gremlin `02-Loops-Repeats` tutorial notebook, where some variable hops queries could fail on Neptune with `MemoryLimitExceeded` exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.