### PR TITLE
Fix `@neptune_db_only` magics decorator

### DIFF
--- a/src/graph_notebook/decorators/decorators.py
+++ b/src/graph_notebook/decorators/decorators.py
@@ -136,7 +136,8 @@ def magic_variables(func):
 
 def neptune_db_only(func):
     @functools.wraps(func)
-    def check_neptune_db(self, *args, **kwargs):
+    def check_neptune_db(*args, **kwargs):
+        self = args[0]
         if not hasattr(self.graph_notebook_config, 'neptune_service'):
             return func(*args, **kwargs)
         else:


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed an issue where some notebook magics marked by the `@neptune_db_only` decorator would not function correctly when using `neptune-db` service.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.