### PR TITLE
Deprecate Python 3.7 support

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.10']
+        python-version: ['3.8', '3.10']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Deprecated Python 3.7 support ([Link to PR](https://github.com/aws/graph-notebook/pull/551))
 
 ## Release 4.0.2 (Dec 14, 2023)
 - Fixed `neptune_ml_utils` imports in `03-Neptune-ML` samples ([Link to PR](https://github.com/aws/graph-notebook/pull/546))

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ It is recommended to check the [ChangeLog.md](ChangeLog.md) file periodically to
 
 You will need:
 
-* [Python](https://www.python.org/downloads/) 3.7.x-3.10.13
+* [Python](https://www.python.org/downloads/) 3.8.x-3.10.13
 * A graph database that provides one or more of:
   * A SPARQL 1.1 endpoint
   * An Apache TinkerPop Gremlin Server compatible endpoint

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     cmdclass=cmd_class,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.8',
         'License :: OSI Approved :: Apache Software License'
     ],
     keywords='jupyter neptune gremlin sparql',

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     cmdclass=cmd_class,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: Apache Software License'
     ],
     keywords='jupyter neptune gremlin sparql',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Deprecating support for Python 3.7 due to discontinuation of security support. Additionally, this change ensures compatibility with the latest versions of Boto library, which have also [removed 3.7 support](https://github.com/boto/boto3/blob/59b53f94d5992a1d252b2ba15d3c8283f94f047c/.changes/1.34.0.json#L4) and [added the `neptune-graph` SDK](https://github.com/boto/boto3/blob/59b53f94d5992a1d252b2ba15d3c8283f94f047c/.changes/1.34.1.json#L43). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.