### PR TITLE
Support unit abbreviations for --max-content-length

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Deprecated Python 3.7 support ([Link to PR](https://github.com/aws/graph-notebook/pull/551))
+- Added unit abbreviation support tk `--max-content-length` ([Link to PR](https://github.com/aws/graph-notebook/pull/553))
 
 ## Release 4.0.2 (Dec 14, 2023)
 - Fixed `neptune_ml_utils` imports in `03-Neptune-ML` samples ([Link to PR](https://github.com/aws/graph-notebook/pull/546))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -883,7 +883,8 @@ class Graph(Magics):
                             help="Hide the index column numbers when displaying the results.")
         parser.add_argument('-mcl', '--max-content-length', type=str, default='',
                             help="Specifies maximum size (in bytes) of results that can be returned to the "
-                                 "GremlinPython client. Default is 10MB")
+                                 "GremlinPython client. Abbreviated memory units (ex.'50MB') are accepted. "
+                                 "Default is 10MB")
 
         args = parser.parse_args(line.split())
         mode = str_to_query_mode(args.query_mode)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added support for using abbreviated memory units with %%gremlin's `-mcl`/`--max-content-length` parameter. Provided short forms (ex. `50MB`) will be automatically converted for the final Gremlin request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.