### PR TITLE
Bump Jinja2 to 3.1.3

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Deprecated Python 3.7 support ([Link to PR](https://github.com/aws/graph-notebook/pull/551))
-- Added unit abbreviation support tk `--max-content-length` ([Link to PR](https://github.com/aws/graph-notebook/pull/553))
+- Added unit abbreviation support to `--max-content-length` ([Link to PR](https://github.com/aws/graph-notebook/pull/553))
 
 ## Release 4.0.2 (Dec 14, 2023)
 - Fixed `neptune_ml_utils` imports in `03-Neptune-ML` samples ([Link to PR](https://github.com/aws/graph-notebook/pull/546))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 SPARQLWrapper==1.8.4
 networkx==2.4
-Jinja2>=3.0.3,<=3.1.2
+Jinja2>=3.0.3,<=3.1.3
 jupyter==1.0.0
 notebook>=6.1.5,<7.0.0
 ipywidgets==7.7.2

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'ipywidgets==7.7.2',
         'jupyterlab_widgets>=1.0.0,<3.0.0',
         'networkx==2.4',
-        'Jinja2>=3.0.3,<=3.1.2',
+        'Jinja2>=3.0.3,<=3.1.3',
         'notebook>=6.1.5,<7.0.0',
         'nbclient<=0.7.3',
         'jupyter-contrib-nbextensions<=0.7.0',


### PR DESCRIPTION
Issue #, if available: CVE-2024-22195

Description of changes:
- Bump `Jinja2` dependency ceiling for a security fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.