### PR TITLE
Update magics for new Neptune Analytics API

### DIFF
--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -122,7 +122,9 @@ GRAPHBINARYV1_VARIANTS = ['graphbinaryv1', 'graphbinary', 'graphbinaryserializer
 
 STATISTICS_MODES = ["", "status", "disableAutoCompute", "enableAutoCompute", "refresh", "delete"]
 SUMMARY_MODES = ["", "basic", "detailed"]
-STATISTICS_LANGUAGE_INPUTS = ["propertygraph", "pg", "gremlin", "oc", "opencypher", "sparql", "rdf"]
+STATISTICS_LANGUAGE_INPUTS_PG = ["propertygraph", "pg", "gremlin", "oc", "opencypher"]
+STATISTICS_LANGUAGE_INPUTS_SPARQL = ["sparql", "rdf"]
+STATISTICS_LANGUAGE_INPUTS = STATISTICS_LANGUAGE_INPUTS_PG + STATISTICS_LANGUAGE_INPUTS_SPARQL
 
 SPARQL_EXPLAIN_MODES = ['dynamic', 'static', 'details']
 OPENCYPHER_EXPLAIN_MODES = ['dynamic', 'static', 'details']


### PR DESCRIPTION
Issue #, if available: #559

Description of changes:
- Switched to new Neptune Analytics API endpoints for `%oc_status`, `%oc_cancel`, and `%summary`.
- Disabled `%status` and `%statistics` for Neptune Analytics.
- Added new `%oc_status` parameters for Neptune Analytics:
    - `--state` - Specifies what subset of query states to retrieve the status of. Default is ALL.
    - `-m`/`--maxResults` - Sets an upper limit on the set of returned queries. Default is 200.
- Added new `%graph_notebook_service` magic.
- Added better messaging when using invalid `%summary` mode.
- Removed loader ARN requirement for `%load` when using Neptune Analytics.
- Removed ceiling restriction on `periodicCommit` and `concurrency` in the `%load` widget.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.