### PR TITLE
Add @neptune_graph_only decorator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Updated `create-graph` CLI commands in Neptune Analytics samples ([Link to PR](https://github.com/aws/graph-notebook/pull/565))
+- Added `@neptune_graph_only` magics decorator ([Link to PR](https://github.com/aws/graph-notebook/pull/569))
 
 ## Release 4.1.0 (February 1, 2024)
 - New Neptune Analytics notebook - Vector Similarity Algorithms ([Link to PR](https://github.com/aws/graph-notebook/pull/555))

--- a/src/graph_notebook/decorators/decorators.py
+++ b/src/graph_notebook/decorators/decorators.py
@@ -12,7 +12,7 @@ from IPython.core.display import HTML, display, clear_output
 
 import ipywidgets as widgets
 from graph_notebook.visualization.template_retriever import retrieve_template
-from graph_notebook.neptune.client import NEPTUNE_ANALYTICS_SERVICE_NAME
+from graph_notebook.neptune.client import NEPTUNE_ANALYTICS_SERVICE_NAME, NEPTUNE_DB_SERVICE_NAME
 from gremlin_python.driver.protocol import GremlinServerError
 from requests import HTTPError
 
@@ -149,6 +149,23 @@ def neptune_db_only(func):
                 return func(*args, **kwargs)
 
     return check_neptune_db
+
+
+def neptune_graph_only(func):
+    @functools.wraps(func)
+    def check_neptune_graph(*args, **kwargs):
+        self = args[0]
+        if not hasattr(self.graph_notebook_config, 'neptune_service'):
+            return func(*args, **kwargs)
+        else:
+            service_type = self.graph_notebook_config.neptune_service
+            if service_type == NEPTUNE_DB_SERVICE_NAME:
+                print(f'This magic is unavailable for Neptune DB.')
+                return
+            else:
+                return func(*args, **kwargs)
+
+    return check_neptune_graph
 
 
 def http_ex_to_html(http_ex: HTTPError):


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added a new decorator function for restricting usage of magics only supported for Neptune Analytics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.