### PR TITLE
Fixed formatting in openCypher explain widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Updated NeptuneDB Notebook CloudFormation template ([Link to PR](https://github.com/aws/graph-notebook/pull/571))
 - Added `@neptune_graph_only` magics decorator ([Link to PR](https://github.com/aws/graph-notebook/pull/569))
 - Added `%graph_pg_info` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/570))
+- Fixed unintended formatting in `%%oc explain` widget ([Link to PR](https://github.com/aws/graph-notebook/pull/576))
 
 ## Release 4.1.0 (February 1, 2024)
 - New Neptune Analytics notebook - Vector Similarity Algorithms ([Link to PR](https://github.com/aws/graph-notebook/pull/555))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -3020,9 +3020,10 @@ class Graph(Magics):
             res = self.client.opencypher_http(cell, explain=args.explain_type, query_params=query_params,
                                               plan_cache=args.plan_cache)
             query_time = time.time() * 1000 - query_start
-            explain = res.content.decode("utf-8")
+            res_replace_chars = res.content.replace(b'$', b'\&#36;')
+            explain = res_replace_chars.decode("utf-8")
             res.raise_for_status()
-            ##store_to_ns(args.store_to, explain, local_ns)
+            store_to_ns(args.store_to, explain, local_ns)
             if not args.silent:
                 oc_metadata = build_opencypher_metadata_from_query(query_type='explain', results=None,
                                                                    results_type='explain', res=res,
@@ -3153,7 +3154,8 @@ class Graph(Magics):
                 with first_tab_output:
                     display(HTML(first_tab_html))
 
-        store_to_ns(args.store_to, res, local_ns)
+        if args.mode != 'explain':
+            store_to_ns(args.store_to, res, local_ns)
 
     def handle_opencypher_status(self, line, local_ns):
         """


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Escaped parameterized query symbols in certain `%%oc explain` results to prevent unintended formatting.
- Fixed content of store-to for `%%oc explain`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.