### PR TITLE
Change %load failOnError default behavior

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added `%graph_pg_info` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/570))
 - Added documentation for FontAwesome 5 settings ([Link to PR](https://github.com/aws/graph-notebook/pull/575))
 - Fixed unintended formatting in `%%oc explain` widget ([Link to PR](https://github.com/aws/graph-notebook/pull/576))
+- Changed `%load` parameter and default value for failOnError ([Link to PR](https://github.com/aws/graph-notebook/pull/577))
 
 ## Release 4.1.0 (February 1, 2024)
 - New Neptune Analytics notebook - Vector Similarity Algorithms ([Link to PR](https://github.com/aws/graph-notebook/pull/555))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1472,7 +1472,7 @@ class Graph(Magics):
             print("Missing required configuration option 'aws_region'. Please ensure that you have provided a "
                   "valid Neptune cluster endpoint URI in the 'host' field of %graph_notebook_config.")
             return
-        parser.add_argument('--fail-on-failure', action='store_true', default=False)
+        parser.add_argument('--no-fail-on-error', action='store_true', default=False)
         parser.add_argument('--update-single-cardinality', action='store_true', default=True)
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
         parser.add_argument('--run', action='store_true', default=False)
@@ -1548,7 +1548,7 @@ class Graph(Magics):
 
         fail_on_error = widgets.Dropdown(
             options=['TRUE', 'FALSE'],
-            value=str(args.fail_on_failure).upper(),
+            value=str(not args.no_fail_on_error).upper(),
             disabled=False,
             layout=widgets.Layout(width=widget_width)
         )


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Replaced `%load` `--fail-on-failure` with a new `--no-fail-on-error` parameter. This will also change the default passed value of `failOnError` to match the Neptune Bulk Loader [documentation](https://docs.aws.amazon.com/neptune/latest/userguide/load-api-reference-load.html#load-api-reference-load-parameters).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.