### PR TITLE
Add --store-format option to query magics

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added `@neptune_graph_only` magics decorator ([Link to PR](https://github.com/aws/graph-notebook/pull/569))
 - Added `%graph_pg_info` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/570))
 - Added documentation for FontAwesome 5 settings ([Link to PR](https://github.com/aws/graph-notebook/pull/575))
+- Added `--store-format` option to query magics ([Link to PR](https://github.com/aws/graph-notebook/pull/580))
 - Fixed unintended formatting in `%%oc explain` widget ([Link to PR](https://github.com/aws/graph-notebook/pull/576))
 - Changed `%load` parameter and default value for failOnError ([Link to PR](https://github.com/aws/graph-notebook/pull/577))
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1231,7 +1231,6 @@ class Graph(Magics):
         else:
             stored_results = query_res
         store_to_ns(args.store_to, stored_results, local_ns)
-        # store_to_ns(args.store_to, query_res, local_ns)
 
     @line_magic
     @needs_local_scope

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -16,7 +16,6 @@ import uuid
 import ast
 import re
 
-import pandas
 from ipyfilechooser import FileChooser
 from enum import Enum
 from copy import copy
@@ -271,7 +270,7 @@ def encode_html_chars(result):
     return fixed_result
 
 
-def decode_html_chars(results_df: pandas.DataFrame = None):
+def decode_html_chars(results_df: pd.DataFrame = None):
     for k, v in iter(DT_HTML_CHAR_MAP.items()):
         results_df = results_df.applymap(lambda x: x.replace(v, k))
 


### PR DESCRIPTION
Issue #, if available: #579

Description of changes:
- Added a new `--store-format` option to the `%%gremlin`/`%%oc`/`%%sparql` magic commands. This option allows users to choose between JSON dictionary (default) or Pandas DataFrame format when saving query mode results with `--store-to`.
- Restored DataTables formatting to the `%%sparql` results widget.

Example usage:
```
%%oc --store-to a_variable --store-format pandas
...
```

![Screenshot 2024-04-01 at 11 14 18 PM](https://github.com/aws/graph-notebook/assets/10456376/8f829b9f-2c12-411f-b503-18335dc50104)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.