### PR TITLE
Fix NoneType serialization for OC query params

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added `--store-format` option to query magics ([Link to PR](https://github.com/aws/graph-notebook/pull/580))
 - Added `--export-to` CSV file option to query magics ([Link to PR](https://github.com/aws/graph-notebook/pull/582))
 - Fixed unintended formatting in `%%oc explain` widget ([Link to PR](https://github.com/aws/graph-notebook/pull/576))
+- Fixed serialization of NoneType for `%%oc` query parameters ([Link to PR](https://github.com/aws/graph-notebook/pull/584))
 - Changed `%load` parameter and default value for failOnError ([Link to PR](https://github.com/aws/graph-notebook/pull/577))
 
 ## Release 4.1.0 (February 1, 2024)

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -3097,10 +3097,11 @@ class Graph(Magics):
             else:
                 query_params_input = args.query_parameters
             if isinstance(query_params_input, dict):
-                query_params = query_params_input
+                query_params = json.dumps(query_params_input)
             else:
                 try:
-                    query_params = json.loads(query_params_input.replace("'", '"'))
+                    query_params_dict = json.loads(query_params_input.replace("'", '"'))
+                    query_params = json.dumps(query_params_dict)
                 except Exception as e:
                     print(f"Invalid query parameter input, ignoring.")
 


### PR DESCRIPTION
Issue #, if available: #583

Description of changes:
- Fixed an bug where `%%oc --query-param` values of type `None` would cause Neptune queries to fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.