### PR TITLE
Bump Jinja2 to 3.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 SPARQLWrapper==1.8.4
 networkx==2.4
-Jinja2>=3.0.3,<=3.1.3
+Jinja2>=3.0.3,<=3.1.4
 jupyter==1.0.0
 notebook>=6.1.5,<7.0.0
 ipywidgets==7.7.2

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'ipywidgets==7.7.2',
         'jupyterlab_widgets>=1.0.0,<3.0.0',
         'networkx==2.4',
-        'Jinja2>=3.0.3,<=3.1.3',
+        'Jinja2>=3.0.3,<=3.1.4',
         'notebook>=6.1.5,<7.0.0',
         'nbclient<=0.7.3',
         'jupyter-contrib-nbextensions<=0.7.0',


### PR DESCRIPTION
Issue #, if available: CVE-2024-34064

Description of changes:
- Bump `Jinja2` ceiling to 3.1.4 for a security fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.