### PR TITLE
Improve handling of mixed type Gremlin results

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 - New notebooks showing Telco examples leveraging GNN and LLM ([Link to PR](https://github.com/aws/graph-notebook/pull/587))
   - Path: 02-Neptune-ML > 03-Sample-Applications > 04-Telco-Networks
-- Added KMS encryption support to NeptuneDB Notebook CloudFormation template (https://github.com/aws/graph-notebook/pull/590)
+- Added KMS encryption support to NeptuneDB Notebook CloudFormation template ([Link to PR]https://github.com/aws/graph-notebook/pull/590)
+- Improved handling of mixed type Gremlin results ([Link to PR]https://github.com/aws/graph-notebook/pull/592)
 
 ## Release 4.2.0 (April 4, 2024)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1202,8 +1202,9 @@ class Graph(Magics):
                 if query_res:
                     # If the results set contains multiple datatypes, and the first result is a map, we need to insert a
                     # temp non-map first element, or we will get an error when creating the Dataframe.
-                    if isinstance(query_res[0], dict) and len(query_res) > 1:
-                        if not all(isinstance(x, dict) for x in query_res[1:]):
+                    first_res_type = type(query_res[0])
+                    if first_res_type in [dict, list, set] and len(query_res) > 1:
+                        if not all(isinstance(x, first_res_type) for x in query_res[1:]):
                             mixed_results = True
                             query_res_deque = deque(query_res)
                             query_res_deque.appendleft('x')

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1200,8 +1200,8 @@ class Graph(Magics):
 
                 mixed_results = False
                 if query_res:
-                    # If the results set contains multiple datatypes, and the first result is a map, we need to insert a
-                    # temp non-map first element, or we will get an error when creating the Dataframe.
+                    # If the results set contains multiple datatypes, and the first result is a map or list, we need to
+                    # insert a temp string first element, or we will get an error when creating the Dataframe.
                     first_res_type = type(query_res[0])
                     if first_res_type in [dict, list, set] and len(query_res) > 1:
                         if not all(isinstance(x, first_res_type) for x in query_res[1:]):


### PR DESCRIPTION
Issue #, if available: #591

Description of changes:
- Fixed a `%%gremlin` bug where the results DataFrame would fail to create when processing both list and vertex/string type elements.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.