### PR TITLE
Fix endpoint creation in People-Analytics-using-Neptune-ML sample

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,8 +6,9 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 - New notebooks showing Telco examples leveraging GNN and LLM ([Link to PR](https://github.com/aws/graph-notebook/pull/587))
   - Path: 02-Neptune-ML > 03-Sample-Applications > 04-Telco-Networks
-- Added KMS encryption support to NeptuneDB Notebook CloudFormation template ([Link to PR]https://github.com/aws/graph-notebook/pull/590)
-- Improved handling of mixed type Gremlin results ([Link to PR]https://github.com/aws/graph-notebook/pull/592)
+- Added KMS encryption support to NeptuneDB Notebook CloudFormation template ([Link to PR](https://github.com/aws/graph-notebook/pull/590))
+- Improved handling of mixed type Gremlin results ([Link to PR](https://github.com/aws/graph-notebook/pull/592))
+- Fixed endpoint creation bug in People-Analytics-using-Neptune-ML sample ([Link to PR](https://github.com/aws/graph-notebook/pull/595))
 
 ## Release 4.2.0 (April 4, 2024)
 

--- a/src/graph_notebook/notebooks/03-Neptune-ML/03-Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb
+++ b/src/graph_notebook/notebooks/03-Neptune-ML/03-Sample-Applications/01-People-Analytics/People-Analytics-using-Neptune-ML.ipynb
@@ -1165,8 +1165,8 @@
    "outputs": [],
    "source": [
     "endpoint_params_link=f\"\"\"\n",
-    "--job-id {training_job_name_link} \n",
-    "--model-job-id {training_job_name_link}\"\"\""
+    "--id {training_job_name_link} \n",
+    "--model-training-job-id {training_job_name_link}\"\"\""
    ]
   },
   {


### PR DESCRIPTION
Issue #, if available: 594

Description of changes:
- Fixed the training job ID parameters being passed to the second `%neptune_ml endpoint create` command in the `People-Analytics-using-Neptune-ML` sample notebook.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.