### PR TITLE
Update to RDFLib 7.0.0 and SPARQLWrapper 2.0.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,9 +8,10 @@ Starting with v1.31.6, this file will contain a record of major features and upd
   - Path: 02-Neptune-ML > 03-Sample-Applications > 04-Telco-Networks
 - Added KMS encryption support to NeptuneDB Notebook CloudFormation template ([Link to PR](https://github.com/aws/graph-notebook/pull/590))
 - Improved handling of mixed type Gremlin results ([Link to PR](https://github.com/aws/graph-notebook/pull/592))
+- Updated to `rdflib==7.0.0` and `SPARQLWrapper==2.0.0` ([Link to PR](https://github.com/aws/graph-notebook/pull/596))
 - Fixed formatting of query magic `--help` entries listing valid inputs ([Link to PR](https://github.com/aws/graph-notebook/pull/593))
 - Fixed endpoint creation bug in People-Analytics-using-Neptune-ML sample ([Link to PR](https://github.com/aws/graph-notebook/pull/595))
-- Updated SPARQL dependencies to `rdflib==7.0.0` and `SPARQLWrapper==2.0.0` ([Link to PR](https://github.com/aws/graph-notebook/pull/596))
+- Fixed deprecated usage of Pandas `DataFrameGroupBy.mean` in NeptuneML SPARQL utils ([Link to PR](https://github.com/aws/graph-notebook/pull/596))
 
 ## Release 4.2.0 (April 4, 2024)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,9 +6,9 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 - New notebooks showing Telco examples leveraging GNN and LLM ([Link to PR](https://github.com/aws/graph-notebook/pull/587))
   - Path: 02-Neptune-ML > 03-Sample-Applications > 04-Telco-Networks
-- Added KMS encryption support to NeptuneDB Notebook CloudFormation template ([Link to PR]https://github.com/aws/graph-notebook/pull/590)
-- Improved handling of mixed type Gremlin results ([Link to PR]https://github.com/aws/graph-notebook/pull/592)
-- Fixed formatting of query magic `--help` entries listing valid inputs ([Link to PR]https://github.com/aws/graph-notebook/pull/593)
+- Added KMS encryption support to NeptuneDB Notebook CloudFormation template ([Link to PR](https://github.com/aws/graph-notebook/pull/590))
+- Improved handling of mixed type Gremlin results ([Link to PR](https://github.com/aws/graph-notebook/pull/592))
+- Fixed formatting of query magic `--help` entries listing valid inputs ([Link to PR](https://github.com/aws/graph-notebook/pull/593))
 - Fixed endpoint creation bug in People-Analytics-using-Neptune-ML sample ([Link to PR](https://github.com/aws/graph-notebook/pull/595))
 
 ## Release 4.2.0 (April 4, 2024)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Improved handling of mixed type Gremlin results ([Link to PR](https://github.com/aws/graph-notebook/pull/592))
 - Fixed formatting of query magic `--help` entries listing valid inputs ([Link to PR](https://github.com/aws/graph-notebook/pull/593))
 - Fixed endpoint creation bug in People-Analytics-using-Neptune-ML sample ([Link to PR](https://github.com/aws/graph-notebook/pull/595))
+- Updated SPARQL dependencies to `rdflib==7.0.0` and `SPARQLWrapper==2.0.0` ([Link to PR](https://github.com/aws/graph-notebook/pull/596))
 
 ## Release 4.2.0 (April 4, 2024)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-SPARQLWrapper==1.8.4
+SPARQLWrapper==2.0.0
 networkx==2.4
 Jinja2>=3.0.3,<=3.1.4
 jupyter==1.0.0
@@ -14,7 +14,7 @@ ipython>=7.16.1,<=8.10.0
 ipykernel==5.3.4
 ipyfilechooser==0.6.0
 neo4j>=4.4.9,<5.0.0
-rdflib==5.0.0
+rdflib==7.0.0
 setuptools>=65.5.1,<=66.0.0
 nbconvert>=6.3.0,<=7.2.8
 jedi>=0.18.1,<=0.18.2

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'gremlinpython>=3.5.1,<=3.6.2',
-        'SPARQLWrapper==1.8.4',
+        'SPARQLWrapper==2.0.0',
         'requests>=2.27.0,<=2.31.0',
         'ipywidgets==7.7.2',
         'jupyterlab_widgets>=1.0.0,<3.0.0',
@@ -82,7 +82,7 @@ setup(
         'boto3>=1.18.49',
         'ipython>=7.16.1,<=8.10.0',
         'neo4j>=4.4.9,<5.0.0',
-        'rdflib==5.0.0',
+        'rdflib==7.0.0',
         'ipykernel==5.3.4',
         'ipyfilechooser==0.6.0',
         'nbconvert>=6.3.0,<=7.2.8',

--- a/src/graph_notebook/network/sparql/SPARQLNetwork.py
+++ b/src/graph_notebook/network/sparql/SPARQLNetwork.py
@@ -9,8 +9,8 @@ from rdflib.namespace import RDF, RDFS, OWL, XSD, SKOS, DOAP, FOAF, DC, DCTERMS,
 
 from graph_notebook.network.EventfulNetwork import EventfulNetwork, DEFAULT_GRP, DEFAULT_RAW_GRP_KEY
 
-NAMESPACE_RDFS = str(RDFS.uri)
-NAMESPACE_RDF = str(RDF.uri)
+NAMESPACE_RDFS = str(RDFS)
+NAMESPACE_RDF = str(RDF)
 NAMESPACE_OWL = str(OWL)
 NAMESPACE_XSD = str(XSD)
 NAMESPACE_SKOS = str(SKOS)

--- a/src/graph_notebook/notebooks/03-Neptune-ML/02-SPARQL/neptune_ml_sparql_utils.py
+++ b/src/graph_notebook/notebooks/03-Neptune-ML/02-SPARQL/neptune_ml_sparql_utils.py
@@ -455,7 +455,7 @@ class MovieLensProcessor:
 
         averages_graph = ConjunctiveGraph()
 
-        for index, row in ratings_vertices.groupby('~to').mean().iterrows():
+        for index, row in ratings_vertices.groupby('~to').mean(numeric_only=True).iterrows():
             score = int(round(row['score:Int']))
             averages_graph.add((
                 self.ns_resource[index], self.ns_ontology.criticScore, Literal(score, datatype=XSD.integer),


### PR DESCRIPTION
Issue #, if available: #439

Description of changes:
- Updating the `rdflib` and `SPARQLWrapper` dependencies to the latest versions supported by Python 3.8.
- Fixed deprecated usage of Pandas `DataFrameGroupBy.mean` in NeptuneML SPARQL utils

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.