### PR TITLE
Add warnings for usage of `%%oc` with incompatible Neptune Analytics parameters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - New notebooks showing Telco examples leveraging GNN and LLM ([Link to PR](https://github.com/aws/graph-notebook/pull/587))
   - Path: 02-Neptune-ML > 03-Sample-Applications > 04-Telco-Networks
 - Added KMS encryption support to NeptuneDB Notebook CloudFormation template ([Link to PR](https://github.com/aws/graph-notebook/pull/590))
+- Added warnings for usage of `%%oc` with incompatible Neptune Analytics parameters ([Link to PR](https://github.com/aws/graph-notebook/pull/599))
 - Improved handling of mixed type Gremlin results ([Link to PR](https://github.com/aws/graph-notebook/pull/592))
 - Updated to `rdflib==7.0.0` and `SPARQLWrapper==2.0.0` ([Link to PR](https://github.com/aws/graph-notebook/pull/596))
 - Fixed formatting of query magic `--help` entries listing valid inputs ([Link to PR](https://github.com/aws/graph-notebook/pull/593))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -3036,9 +3036,10 @@ class Graph(Magics):
         """
         parser = argparse.ArgumentParser()
         parser.add_argument('-pc', '--plan-cache', type=str.lower, default='auto',
-                            help=f'Plan cache mode to use. Accepted values: {OPENCYPHER_PLAN_CACHE_MODES}')
+                            help=f'Neptune Analytics only. Specifies the plan cache mode to use. '
+                                 f'Accepted values: {OPENCYPHER_PLAN_CACHE_MODES}')
         parser.add_argument('-qt', '--query-timeout', type=int, default=None,
-                            help=f'Maximum query timeout in milliseconds.')
+                            help=f'Neptune Analytics only. Specifies the maximum query timeout in milliseconds.')
         parser.add_argument('--explain-type', type=str.lower, default='dynamic',
                             help=f'Explain mode to use when using the explain query mode. '
                                  f'Accepted values: {OPENCYPHER_EXPLAIN_MODES}')
@@ -3142,6 +3143,12 @@ class Graph(Magics):
                 first_tab_html = opencypher_explain_template.render(table=explain,
                                                                     link=f"data:text/html;base64,{base64_str}")
         elif args.mode == 'query':
+            if not self.client.is_analytics_domain():
+                if args.plan_cache != 'auto':
+                    print("planCache is not supported for Neptune DB, ignoring.")
+                if args.query_timeout is not None:
+                    print("queryTimeoutMilliseconds is not supported for Neptune DB, ignoring.")
+
             query_start = time.time() * 1000  # time.time() returns time in seconds w/high precision; x1000 to get in ms
             oc_http = self.client.opencypher_http(cell, query_params=query_params,
                                                   plan_cache=args.plan_cache,


### PR DESCRIPTION
Issue #, if available: #598

Description of changes:
- Display warnings when attempting to pass `--plan-cache` or `--query-timeout` parameters to `%%oc` while connected to a Neptune DB endpoint.
- Added better `--help` documentation for the `%%oc` Neptune Analytics parameters. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.