### PR TITLE
Include Neptune parameters in default %graph_notebook_config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
-- Updated default %graph_notebook_config to display Neptune-specific fields
+- Updated default %graph_notebook_config to display Neptune-specific fields ([Link to PR](https://github.com/aws/graph-notebook/pull/605))
 
 ## Release 4.3.0 (June 3, 2024)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Updated default %graph_notebook_config to display Neptune-specific fields
 
 ## Release 4.3.0 (June 3, 2024)
 

--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -216,7 +216,16 @@ def generate_config(host, port, auth_mode: AuthModeEnum = AuthModeEnum.DEFAULT, 
 
 
 def generate_default_config():
-    c = generate_config('change-me', 8182, AuthModeEnum.DEFAULT, True, True, NEPTUNE_DB_SERVICE_NAME, '', DEFAULT_REGION)
+    neptune_hosts_with_dummy = NEPTUNE_CONFIG_HOST_IDENTIFIERS + ['change-me']
+    c = generate_config(host='change-me',
+                        port=8182,
+                        auth_mode=AuthModeEnum.DEFAULT,
+                        ssl=True,
+                        ssl_verify=True,
+                        neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                        load_from_s3_arn='',
+                        aws_region=DEFAULT_REGION,
+                        neptune_hosts=neptune_hosts_with_dummy)
     return c
 
 

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -8,7 +8,7 @@ import unittest
 
 from graph_notebook.configuration.get_config import get_config
 from graph_notebook.configuration.generate_config import Configuration, DEFAULT_AUTH_MODE, AuthModeEnum, \
-    generate_config, GremlinSection
+    generate_config, generate_default_config, GremlinSection, SparqlSection, Neo4JSection
 from graph_notebook.neptune.client import NEPTUNE_DB_SERVICE_NAME, NEPTUNE_ANALYTICS_SERVICE_NAME
 
 
@@ -31,6 +31,29 @@ class TestGenerateConfiguration(unittest.TestCase):
     def tearDown(self) -> None:
         if os.path.exists(self.test_file_path):
             os.remove(self.test_file_path)
+
+    def test_generate_default_config(self):
+        config = generate_default_config()
+        self.assertEqual(True, config.is_neptune_config)
+        self.assertEqual('change-me', config.host)
+        self.assertEqual(8182, config.port)
+        self.assertEqual('', config._proxy_host)
+        self.assertEqual(8182, config.proxy_port)
+        self.assertEqual(DEFAULT_AUTH_MODE, config.auth_mode)
+        self.assertEqual(True, config.ssl)
+        self.assertEqual(True, config.ssl_verify)
+        self.assertEqual('neptune-db', config.neptune_service)
+        self.assertEqual('', config.load_from_s3_arn)
+        self.assertEqual('us-east-1', config.aws_region)
+        self.assertEqual('sparql', config.sparql.path)
+        self.assertEqual('g', config.gremlin.traversal_source)
+        self.assertEqual('', config.gremlin.username)
+        self.assertEqual('', config.gremlin.password)
+        self.assertEqual('graphsonv3', config.gremlin.message_serializer)
+        self.assertEqual('neo4j', config.neo4j.username)
+        self.assertEqual('password', config.neo4j.password)
+        self.assertEqual(True, config.neo4j.auth)
+        self.assertEqual(None, config.neo4j.database)
 
     def test_configuration_default_auth_defaults_neptune_reg(self):
         config = Configuration(self.neptune_host_reg, self.port)

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -8,7 +8,7 @@ import unittest
 
 from graph_notebook.configuration.get_config import get_config
 from graph_notebook.configuration.generate_config import Configuration, DEFAULT_AUTH_MODE, AuthModeEnum, \
-    generate_config, generate_default_config, GremlinSection, SparqlSection, Neo4JSection
+    generate_config, generate_default_config, GremlinSection
 from graph_notebook.neptune.client import NEPTUNE_DB_SERVICE_NAME, NEPTUNE_ANALYTICS_SERVICE_NAME
 
 


### PR DESCRIPTION
Issue #, if available: #604

Description of changes:
- Modified the dummy configuration generated for `%graph_notebook_config` to also display fields restricted to Neptune endpoints.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.