### PR TITLE
Fix datatables export options for %%sparql

### DIFF
--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -100,7 +100,7 @@ GREMLIN_RESULTS_FILENAME = "gremlin_results"
 OC_RESULTS_FILENAME = "oc_results"
 LOAD_IDS_FILENAME = "load_ids"
 RESULTS_EXPORT_OPTIONS = {
-    "columns": 1,
+    "columns": ":gt(0)",
     "modifier": {
         "header": False,
         "page": "all",


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed a issue with some `%%sparql` queries where the results table copy/download buttons would only export the first column of selected results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.