### PR TITLE
Add `%get_graph` line magic, enable `%status` for Neptune Analytics

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Added `%reset_graph` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/610))
+- Added `%get_graph` line magic and enabled `%status` for Neptune Analytics ([Link to PR](https://github.com/aws/graph-notebook/pull/611))
 
 ## Release 4.3.1 (June 3, 2024)
 

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -589,6 +589,16 @@ class Client(object):
             logger.debug(f"Reset Graph call failed with service exception: {e}")
             raise e
 
+    def get_graph(self, graph_id: str = '') -> dict:
+        try:
+            res = self.neptune_graph_client.get_graph(
+                graphIdentifier=graph_id
+            )
+            return res
+        except ClientError as e:
+            logger.debug(f"GetGraph call failed with service exception: {e}")
+            raise e
+
     def dataprocessing_start(self, s3_input_uri: str, s3_output_uri: str, **kwargs) -> requests.Response:
         data = {
             'inputDataS3Location': s3_input_uri,


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added a new `%get_graph` line magic for Neptune Analytics. This magic calls the [GetGraph](https://docs.aws.amazon.com/neptune-analytics/latest/apiref/API_GetGraph.html) API to retrieve information about the graph host specified in `%graph_notebook_config`.
- Enabled `%status` for Neptune Analytics as a redirect for `%get_graph`.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.