### PR TITLE
Fix alignment of numeric values in results table

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 
 - Added `--connection-protocol` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/617))
+- Restored left alignment of numeric value columns in results table widget ([Link to PR](https://github.com/aws/graph-notebook/pull/620))
 
 ## Release 4.4.0 (June 10, 2024)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -918,6 +918,7 @@ class Graph(Magics):
                     visible_results, final_pagination_options, final_pagination_menu = generate_pagination_vars(
                         args.results_per_page)
                     sparql_columndefs = [
+                        {"type": "string", "targets": "_all"},
                         {"width": "5%", "targets": 0},
                         {"visible": True, "targets": 0},
                         {"searchable": False, "targets": 0},
@@ -1300,6 +1301,7 @@ class Graph(Magics):
                     visible_results, final_pagination_options, final_pagination_menu = generate_pagination_vars(
                         args.results_per_page)
                     gremlin_columndefs = [
+                        {"type": "string", "targets": "_all"},
                         {"width": "5%", "targets": 0},
                         {"visible": True, "targets": 0},
                         {"searchable": False, "targets": 0},
@@ -3411,6 +3413,7 @@ class Graph(Magics):
                     visible_results, final_pagination_options, final_pagination_menu = generate_pagination_vars(
                         args.results_per_page)
                     oc_columndefs = [
+                        {"type": "string", "targets": "_all"},
                         {"width": "5%", "targets": 0},
                         {"visible": True, "targets": 0},
                         {"searchable": False, "targets": 0},


### PR DESCRIPTION
Issue #, if available: #619

Description of changes:
- Restored left alignment of numeric value columns in results table, which was lost in v4.3.1 due to breaking changes introduced with DataTables 2.x. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.