### PR TITLE
Add global Gremlin `connection_protocol` field to notebook configuration

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 
 - Added `--connection-protocol` option to `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/617))
+- Added global Gremlin `connection_protocol` setting to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/621))
 - Restored left alignment of numeric value columns in results table widget ([Link to PR](https://github.com/aws/graph-notebook/pull/620))
 
 ## Release 4.4.0 (June 10, 2024)

--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -8,11 +8,14 @@ import json
 import os
 from enum import Enum
 
-from graph_notebook.neptune.client import SPARQL_ACTION, DEFAULT_PORT, DEFAULT_REGION, DEFAULT_GREMLIN_SERIALIZER, \
-    DEFAULT_GREMLIN_TRAVERSAL_SOURCE, DEFAULT_NEO4J_USERNAME, DEFAULT_NEO4J_PASSWORD, DEFAULT_NEO4J_DATABASE, \
-    NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_allowed_neptune_host, false_str_variants, \
-    GRAPHSONV3_VARIANTS, GRAPHSONV2_VARIANTS, GRAPHBINARYV1_VARIANTS, \
-    NEPTUNE_DB_SERVICE_NAME, normalize_service_name
+from graph_notebook.neptune.client import (SPARQL_ACTION, DEFAULT_PORT, DEFAULT_REGION,
+                                           DEFAULT_GREMLIN_SERIALIZER, DEFAULT_GREMLIN_TRAVERSAL_SOURCE,
+                                           DEFAULT_GREMLIN_PROTOCOL, DEFAULT_HTTP_PROTOCOL, DEFAULT_WS_PROTOCOL,
+                                           HTTP_PROTOCOL_FORMATS, WS_PROTOCOL_FORMATS,
+                                           DEFAULT_NEO4J_USERNAME, DEFAULT_NEO4J_PASSWORD, DEFAULT_NEO4J_DATABASE,
+                                           NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_allowed_neptune_host, false_str_variants,
+                                           GRAPHSONV3_VARIANTS, GRAPHSONV2_VARIANTS, GRAPHBINARYV1_VARIANTS,
+                                           NEPTUNE_DB_SERVICE_NAME, normalize_service_name)
 
 DEFAULT_CONFIG_LOCATION = os.path.expanduser('~/graph_notebook_config.json')
 
@@ -53,13 +56,15 @@ class GremlinSection(object):
     """
 
     def __init__(self, traversal_source: str = '', username: str = '', password: str = '',
-                 message_serializer: str = ''):
+                 message_serializer: str = '', connection_protocol: str = '', include_protocol: bool = False):
         """
         :param traversal_source: used to specify the traversal source for a Gremlin traversal, in the case that we are
         connected to an endpoint that can access multiple graphs.
         :param username: used to specify a username for authenticating to Gremlin Server, if the endpoint supports it.
         :param password: used to specify a password for authenticating to Gremlin Server, if the endpoint supports it.
         :param message_serializer: used to specify a serializer for encoding the data to and from Gremlin Server.
+        :param connection_protocol: used to specify a protocol for the Gremlin connection.
+        :param include_protocol: used to specify whether to include connection_protocol in the Gremlin config.
         """
 
         if traversal_source == '':
@@ -80,11 +85,24 @@ class GremlinSection(object):
                   f'Valid serializers: [graphsonv3, graphsonv2, graphbinaryv1].')
             message_serializer = DEFAULT_GREMLIN_SERIALIZER
 
-
         self.traversal_source = traversal_source
         self.username = username
         self.password = password
         self.message_serializer = message_serializer
+
+        if include_protocol:
+            protocol_lower = connection_protocol.lower()
+            if protocol_lower == '':
+                connection_protocol = DEFAULT_GREMLIN_PROTOCOL
+            elif protocol_lower in HTTP_PROTOCOL_FORMATS:
+                connection_protocol = DEFAULT_HTTP_PROTOCOL
+            elif protocol_lower in WS_PROTOCOL_FORMATS:
+                connection_protocol = DEFAULT_WS_PROTOCOL
+            else:
+                print(f"Invalid connection protocol specified, defaulting to {DEFAULT_GREMLIN_PROTOCOL}. "
+                      f"Valid protocols: [websockets, http].")
+                connection_protocol = DEFAULT_GREMLIN_PROTOCOL
+            self.connection_protocol = connection_protocol
 
     def to_dict(self):
         return self.__dict__
@@ -142,8 +160,20 @@ class Configuration(object):
             self.auth_mode = auth_mode
             self.load_from_s3_arn = load_from_s3_arn
             self.aws_region = aws_region
-            self.gremlin = GremlinSection(message_serializer=gremlin_section.message_serializer) \
-                if gremlin_section is not None else GremlinSection()
+            default_protocol = DEFAULT_HTTP_PROTOCOL if self._proxy_host != '' else DEFAULT_GREMLIN_PROTOCOL
+            if gremlin_section is not None:
+                if hasattr(gremlin_section, "connection_protocol"):
+                    if self._proxy_host != '' and gremlin_section.connection_protocol != DEFAULT_HTTP_PROTOCOL:
+                        print("Enforcing HTTP connection protocol for proxy connections.")
+                        final_protocol = DEFAULT_HTTP_PROTOCOL
+                    else:
+                        final_protocol = gremlin_section.connection_protocol
+                else:
+                    final_protocol = default_protocol
+                self.gremlin = GremlinSection(message_serializer=gremlin_section.message_serializer,
+                                              connection_protocol=final_protocol, include_protocol=True)
+            else:
+                self.gremlin = GremlinSection(connection_protocol=default_protocol, include_protocol=True)
             self.neo4j = Neo4JSection()
         else:
             self.is_neptune_config = False
@@ -267,6 +297,9 @@ if __name__ == "__main__":
     parser.add_argument("--gremlin_serializer",
                         help="the serializer to use as the encoding format when creating Gremlin connections",
                         default=DEFAULT_GREMLIN_SERIALIZER)
+    parser.add_argument("--gremlin_connection_protocol",
+                        help="the connection protocol to use for Gremlin connections",
+                        default=DEFAULT_GREMLIN_PROTOCOL)
     parser.add_argument("--neo4j_username", help="the username to use for Neo4J connections",
                         default=DEFAULT_NEO4J_USERNAME)
     parser.add_argument("--neo4j_password", help="the password to use for Neo4J connections",
@@ -285,7 +318,8 @@ if __name__ == "__main__":
                              args.load_from_s3_arn, args.aws_region, args.proxy_host, int(args.proxy_port),
                              SparqlSection(args.sparql_path, ''),
                              GremlinSection(args.gremlin_traversal_source, args.gremlin_username,
-                                            args.gremlin_password, args.gremlin_serializer),
+                                            args.gremlin_password, args.gremlin_serializer,
+                                            args.gremlin_connection_protocol),
                              Neo4JSection(args.neo4j_username, args.neo4j_password,
                                           args.neo4j_auth, args.neo4j_database),
                              args.neptune_hosts)

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -12,6 +12,7 @@ from graph_notebook.neptune.client import NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_al
     NEPTUNE_DB_SERVICE_NAME, NEPTUNE_ANALYTICS_SERVICE_NAME, NEPTUNE_DB_CONFIG_NAMES, NEPTUNE_ANALYTICS_CONFIG_NAMES
 
 neptune_params = ['neptune_service', 'auth_mode', 'load_from_s3_arn', 'aws_region']
+neptune_gremlin_params = ['connection_protocol']
 
 
 def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_IDENTIFIERS) -> Configuration:
@@ -21,8 +22,8 @@ def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_I
     else:
         ssl_verify = True
     sparql_section = SparqlSection(**data['sparql']) if 'sparql' in data else SparqlSection('')
-    gremlin_section = GremlinSection(**data['gremlin']) if 'gremlin' in data else GremlinSection()
-    neo4j_section = Neo4JSection(**data['neo4j']) if 'neo4j' in data else Neo4JSection('', '', True, '')
+    neo4j_section = Neo4JSection(**data['neo4j']) \
+        if 'neo4j' in data else Neo4JSection('', '', True, '')
     proxy_host = str(data['proxy_host']) if 'proxy_host' in data else ''
     proxy_port = int(data['proxy_port']) if 'proxy_port' in data else 8182
 
@@ -30,8 +31,13 @@ def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_I
 
     if is_neptune_host:
         neptune_service = data['neptune_service'] if 'neptune_service' in data else NEPTUNE_DB_SERVICE_NAME
-        if gremlin_section.to_dict()['traversal_source'] != 'g':
-            print('Ignoring custom traversal source, Amazon Neptune does not support this functionality.\n')
+        if 'gremlin' in data:
+            data['gremlin']['include_protocol'] = True
+            gremlin_section = GremlinSection(**data['gremlin'])
+            if gremlin_section.to_dict()['traversal_source'] != 'g':
+                print('Ignoring custom traversal source, Amazon Neptune does not support this functionality.\n')
+        else:
+            gremlin_section = GremlinSection(include_protocol=True)
         if neo4j_section.to_dict()['username'] != DEFAULT_NEO4J_USERNAME \
                 or neo4j_section.to_dict()['password'] != DEFAULT_NEO4J_PASSWORD:
             print('Ignoring Neo4J custom authentication, Amazon Neptune does not support this functionality.\n')
@@ -49,9 +55,13 @@ def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_I
         for p in neptune_params:
             if p in data:
                 excluded_params.append(p)
+        for gp in neptune_gremlin_params:
+            if gp in data['gremlin']:
+                excluded_params.append(gp)
         if excluded_params:
             print(f"The provided configuration contains the following parameters that are incompatible with the "
                   f"specified host: {str(excluded_params)}. These parameters have not been saved.\n")
+        gremlin_section = GremlinSection(**data['gremlin']) if 'gremlin' in data else GremlinSection()
 
         config = Configuration(host=data['host'], port=data['port'], ssl=data['ssl'], ssl_verify=ssl_verify,
                                sparql_section=sparql_section, gremlin_section=gremlin_section, neo4j_section=neo4j_section,
@@ -63,4 +73,5 @@ def get_config(path: str = DEFAULT_CONFIG_LOCATION,
                neptune_hosts: list = NEPTUNE_CONFIG_HOST_IDENTIFIERS) -> Configuration:
     with open(path) as config_file:
         data = json.load(config_file)
+        print(data)
         return get_config_from_dict(data=data, neptune_hosts=neptune_hosts)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added a new `connection_protocol` field to the Gremlin section of `%%graph_notebook_config`, to support switching between WebSockets and HTTP connections. This setting will apply globally to all `%%gremlin` queries to Neptune endpoints, although it can still be overridden by the `%%gremlin --connection-protocol` argument.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.