### PR TITLE
Improve Gremlin protocol auto-sets when generating config via arguments

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Set Gremlin `connection_protocol` defaults based on Neptune service when generating configuration via arguments ([Link to PR](https://github.com/aws/graph-notebook/pull/626))
 
 ## Release 4.4.1 (June 17, 2024)
 


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Improved arg-based calls directly to `generate_config` module by setting Gremlin `connection_protocol` defaults based on the service argument.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.