### PR TITLE
Fix broken `%%gremlin --help` command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
 
 ## Release 4.4.2 (June 18, 2024)
 - Set Gremlin `connection_protocol` defaults based on Neptune service when generating configuration via arguments ([Link to PR](https://github.com/aws/graph-notebook/pull/626))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1033,7 +1033,7 @@ class Graph(Magics):
                             help=f'Neptune endpoints only. Connection protocol to use for connecting to the Gremlin '
                                  f'database - either Websockets or HTTP. Valid inputs: {GREMLIN_PROTOCOL_FORMATS}. '
                                  f'If not specified, defaults to the value of the gremlin.connection_protocol field '
-                                 f'in %graph_notebook_config. Please note that this option has no effect on the '
+                                 f'in %%graph_notebook_config. Please note that this option has no effect on the '
                                  f'Profile and Explain modes, which must use HTTP.')
         parser.add_argument('--explain-type', type=str.lower, default='dynamic',
                             help=f'Explain mode to use when using the explain query mode. '


### PR DESCRIPTION
Issue #, if available: #629

Description of changes:
- Fixed an issue where `%%gremlin --help` would fail due to an unescaped special character in the `--connection-protocol` docstring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.