### PR TITLE
Fix openCypher query regression in `01-About-the-Neptune-Notebook` sample 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
+- Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))
 
 ## Release 4.4.2 (June 18, 2024)
 - Set Gremlin `connection_protocol` defaults based on Neptune service when generating configuration via arguments ([Link to PR](https://github.com/aws/graph-notebook/pull/626))

--- a/src/graph_notebook/notebooks/01-Neptune-Database/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb
+++ b/src/graph_notebook/notebooks/01-Neptune-Database/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb
@@ -279,9 +279,9 @@
    "source": [
     "%%oc\n",
     "\n",
-    "CREATE (n:Language {name:\"Gremlin\"})\n",
-    "CREATE (n:Language {name:\"Cypher\"})\n",
-    "CREATE (n:Language {name:\"SPARQL\"})"
+    "CREATE (a:Language {name:\"Gremlin\"})\n",
+    "CREATE (b:Language {name:\"Cypher\"})\n",
+    "CREATE (c:Language {name:\"SPARQL\"})"
    ]
   },
   {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed an openCypher query execution bug in [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) caused by an accidental reversion of https://github.com/aws/graph-notebook/pull/501 in the changes introduced with https://github.com/aws/graph-notebook/pull/541.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.