### PR TITLE
Fix `%%graph_notebook_config` error when excluding optional Gremlin section

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 - Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
 - Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))
+- Fixed `%%graph_notebook_config` error when excluding optional Gremlin section ([Link to PR](https://github.com/aws/graph-notebook/pull/633))
 
 ## Release 4.4.2 (June 18, 2024)
 - Set Gremlin `connection_protocol` defaults based on Neptune service when generating configuration via arguments ([Link to PR](https://github.com/aws/graph-notebook/pull/626))

--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -59,9 +59,10 @@ def get_config_from_dict(data: dict, neptune_hosts: list = NEPTUNE_CONFIG_HOST_I
         for p in neptune_params:
             if p in data:
                 excluded_params.append(p)
-        for gp in neptune_gremlin_params:
-            if gp in data['gremlin']:
-                excluded_params.append(gp)
+        if 'gremlin' in data:
+            for gp in neptune_gremlin_params:
+                if gp in data['gremlin']:
+                    excluded_params.append(gp)
         if excluded_params:
             print(f"The provided configuration contains the following parameters that are incompatible with the "
                   f"specified host: {str(excluded_params)}. These parameters have not been saved.\n")

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -342,7 +342,6 @@ class TestGenerateConfiguration(unittest.TestCase):
         config = get_config_from_dict(input_config, neptune_hosts=NEPTUNE_CONFIG_HOST_IDENTIFIERS)
         self.assertEqual(config.to_dict(), expected_config)
 
-
     def test_generate_configuration_with_defaults_neptune_reg(self):
         config = Configuration(self.neptune_host_reg, self.port)
         c = generate_config(config.host, config.port, auth_mode=config.auth_mode, ssl=config.ssl,


### PR DESCRIPTION
Issue #, if available: #632

Description of changes:
- Fixed an issue where setting `%%graph_notebook_config` for non-Neptune hosts would fail unless the optional `gremlin` sub-section was included in the JSON.
- Added unit tests to validate required/optional/allowed fields for `get_config`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.