### PR TITLE
Add `--connected-table` option to query magics

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Added `--connected-table` option to magics with table widget output ([Link to PR](https://github.com/aws/graph-notebook/pull/634))
 - Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
 - Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))
 - Fixed `%%graph_notebook_config` error when excluding optional Gremlin section ([Link to PR](https://github.com/aws/graph-notebook/pull/633))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -27,7 +27,7 @@ from graph_notebook.network.opencypher.OCNetwork import OCNetwork
 import ipywidgets as widgets
 import pandas as pd
 import itables.options as opt
-from itables import show, JavascriptFunction
+from itables import show, JavascriptFunction, init_notebook_mode
 from SPARQLWrapper import SPARQLWrapper
 from botocore.session import get_session
 from gremlin_python.driver.protocol import GremlinServerError
@@ -725,6 +725,9 @@ class Graph(Magics):
         parser.add_argument('-sd', '--simulation-duration', type=int, default=1500,
                             help='Specifies maximum duration of visualization physics simulation. Default is 1500ms')
         parser.add_argument('--silent', action='store_true', default=False, help="Display no query output.")
+        parser.add_argument('-ct', '--connected-table', action='store_true', default=False,
+                            help=f'Dynamically load jQuery and DataTables resources for iTables. For more information, see: '
+                                 f'https://mwouts.github.io/itables/quick_start.html#offline-mode-versus-connected-mode')
         parser.add_argument('-r', '--results-per-page', type=int, default=10,
                             help='Specifies how many query results to display per page in the output. Default is 10')
         parser.add_argument('--no-scroll', action='store_true', default=False,
@@ -929,7 +932,9 @@ class Graph(Magics):
                     ]
                     if args.hide_index:
                         sparql_columndefs[1]["visible"] = False
+                    init_notebook_mode(connected=args.connected_table)
                     show(results_df,
+                         connected=args.connected_table,
                          scrollX=True,
                          scrollY=sparql_scrollY,
                          columnDefs=sparql_columndefs,
@@ -1085,6 +1090,9 @@ class Graph(Magics):
         parser.add_argument('-sd', '--simulation-duration', type=int, default=1500,
                             help='Specifies maximum duration of visualization physics simulation. Default is 1500ms')
         parser.add_argument('--silent', action='store_true', default=False, help="Display no query output.")
+        parser.add_argument('-ct', '--connected-table', action='store_true', default=False,
+                            help=f'Dynamically load jQuery and DataTables resources for iTables. For more information, see: '
+                                 f'https://mwouts.github.io/itables/quick_start.html#offline-mode-versus-connected-mode')
         parser.add_argument('-r', '--results-per-page', type=int, default=10,
                             help='Specifies how many query results to display per page in the output. Default is 10')
         parser.add_argument('--no-scroll', action='store_true', default=False,
@@ -1334,7 +1342,9 @@ class Graph(Magics):
                     ]
                     if args.hide_index:
                         gremlin_columndefs[1]["visible"] = False
+                    init_notebook_mode(connected=args.connected_table)
                     show(results_df,
+                         connected=args.connected_table,
                          scrollX=True,
                          scrollY=gremlin_scrollY,
                          columnDefs=gremlin_columndefs,
@@ -2341,6 +2351,9 @@ class Graph(Magics):
         parser.add_argument('--limit', type=int, default=maxsize,
                             help='If --details is True, only return the x most recent load job statuses. '
                                  'Defaults to sys.maxsize.')
+        parser.add_argument('-ct', '--connected-table', action='store_true', default=False,
+                            help=f'Dynamically load jQuery and DataTables resources for iTables. For more information, see: '
+                                 f'https://mwouts.github.io/itables/quick_start.html#offline-mode-versus-connected-mode')
         parser.add_argument('--silent', action='store_true', default=False, help="Display no output.")
         parser.add_argument('--store-to', type=str, default='')
         args = parser.parse_args(line.split())
@@ -2384,7 +2397,9 @@ class Graph(Magics):
                     results_df.insert(0, "#", range(1, len(results_df) + 1))
 
                     with table_output:
+                        init_notebook_mode(connected=args.connected_table)
                         show(results_df,
+                             connected=args.connected_table,
                              scrollX=True,
                              scrollY="475px",
                              columnDefs=[
@@ -3262,6 +3277,9 @@ class Graph(Magics):
         parser.add_argument('-sd', '--simulation-duration', type=int, default=1500,
                             help='Specifies maximum duration of visualization physics simulation. Default is 1500ms')
         parser.add_argument('--silent', action='store_true', default=False, help="Display no query output.")
+        parser.add_argument('-ct', '--connected-table', action='store_true', default=False,
+                            help=f'Dynamically load jQuery and DataTables resources for iTables. For more information, see: '
+                                 f'https://mwouts.github.io/itables/quick_start.html#offline-mode-versus-connected-mode')
         parser.add_argument('-r', '--results-per-page', type=int, default=10,
                             help='Specifies how many query results to display per page in the output. Default is 10')
         parser.add_argument('--no-scroll', action='store_true', default=False,
@@ -3445,7 +3463,9 @@ class Graph(Magics):
                     ]
                     if args.hide_index:
                         oc_columndefs[1]["visible"] = False
+                    init_notebook_mode(connected=args.connected_table)
                     show(results_df,
+                         connected=args.connected_table,
                          scrollX=True,
                          scrollY=oc_scrollY,
                          columnDefs=oc_columndefs,


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added a new `--connected-table` option to `%%gremlin`/`%%sparql`/`%%opencypher`/`%%load_ids`. When specified, this option will enable [iTables connected mode](https://mwouts.github.io/itables/quick_start.html#offline-mode-versus-connected-mode).
- Changed default behavior of results table widget to enforce offline mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.