### PR TITLE
Store exception messages when using `%%gremlin --store-to`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,6 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
 - Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))
 - Fixed `%%graph_notebook_config` error when excluding optional Gremlin section ([Link to PR](https://github.com/aws/graph-notebook/pull/633))
-
 - Fixed `--mode` argument for Neptune DB bulk loader requests via `%load` ([Link to PR](https://github.com/aws/graph-notebook/pull/637))
 - Switched to generating Jinja2 templates in sandboxed environment ([Link to PR](https://github.com/aws/graph-notebook/pull/639))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,10 +4,11 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Added `--connected-table` option to magics with table widget output ([Link to PR](https://github.com/aws/graph-notebook/pull/634))
+- Changed `%%gremlin --store-to` to also store exceptions from non-Neptune queries ([Link to PR](https://github.com/aws/graph-notebook/pull/635))
 - Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
 - Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))
 - Fixed `%%graph_notebook_config` error when excluding optional Gremlin section ([Link to PR](https://github.com/aws/graph-notebook/pull/633))
-- Fixed `%%gremlin` magic command to return error messages along with query results when using `--store-to` ([Link to PR](https://github.com/aws/graph-notebook/pull/635))
+
 - Fixed `--mode` argument for Neptune DB bulk loader requests via `%load` ([Link to PR](https://github.com/aws/graph-notebook/pull/637))
 - Switched to generating Jinja2 templates in sandboxed environment ([Link to PR](https://github.com/aws/graph-notebook/pull/639))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
 - Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))
 - Fixed `%%graph_notebook_config` error when excluding optional Gremlin section ([Link to PR](https://github.com/aws/graph-notebook/pull/633))
+- Fixed `%%gremlin` magic command to return error messages along with query results when using `--store-to` ([Link to PR](https://github.com/aws/graph-notebook/pull/635))
 
 ## Release 4.4.2 (June 18, 2024)
 - Set Gremlin `connection_protocol` defaults based on Neptune service when generating configuration via arguments ([Link to PR](https://github.com/aws/graph-notebook/pull/626))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1216,7 +1216,11 @@ class Graph(Magics):
                         print("%%gremlin is incompatible with Neptune Analytics.")
                     raise e
             else:
-                query_res = self.client.gremlin_query(cell, transport_args=transport_args)
+                try:
+                    query_res = self.client.gremlin_query(cell, transport_args=transport_args)
+                except Exception as e:
+                    store_to_ns(args.store_to, {'error': str(e)[5:]}, local_ns)  # remove the leading error code.
+                    raise e
             query_time = time.time() * 1000 - query_start
             if not args.silent:
                 gremlin_metadata = build_gremlin_metadata_from_query(query_type='query', results=query_res,


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

- Fixed `%%gremlin` magic command to return error messages along with query results when using `--store-to`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.