### PR TITLE
Generate Jinja2 templates in sandboxed environment

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))
 - Fixed `%%graph_notebook_config` error when excluding optional Gremlin section ([Link to PR](https://github.com/aws/graph-notebook/pull/633))
 - Fixed `--mode` argument for Neptune DB bulk loader requests via `%load` ([Link to PR](https://github.com/aws/graph-notebook/pull/637))
+- Switched to generating Jinja2 templates in sandboxed environment ([Link to PR](https://github.com/aws/graph-notebook/pull/639))
 
 ## Release 4.4.2 (June 18, 2024)
 - Set Gremlin `connection_protocol` defaults based on Neptune service when generating configuration via arguments ([Link to PR](https://github.com/aws/graph-notebook/pull/626))

--- a/src/graph_notebook/visualization/template_retriever.py
+++ b/src/graph_notebook/visualization/template_retriever.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import os
 
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -13,5 +13,8 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 def retrieve_template(template_name):
     with open('%s/templates/%s' % (dir_path, template_name), 'r') as tab_template_file:
         tab_template = tab_template_file.read().strip()
-    template = Template(tab_template)
+
+    env = SandboxedEnvironment()
+    template = env.from_string(tab_template)
+
     return template

--- a/src/graph_notebook/visualization/visualizer.py
+++ b/src/graph_notebook/visualization/visualizer.py
@@ -5,12 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 
 import os
 
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 with open('%s/templates/tabs.html' % dir_path, 'r') as tab_template_file:
     tab_template = tab_template_file.read().strip()
-template = Template(tab_template)
+
+env = SandboxedEnvironment()
+template = env.from_string(tab_template)
 
 
 class Visualizer(object):


### PR DESCRIPTION
Issue #, if available: CVE-2019-8341

Description of changes:
- Switching Jinja2 `Template()` usages to `SandboxedEnvironment.from_string()` to mitigate a vulnerability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.