### PR TITLE
Pin `@types/lodash` to 4.17.2

### DIFF
--- a/src/graph_notebook/widgets/package.json
+++ b/src/graph_notebook/widgets/package.json
@@ -21,6 +21,7 @@
     "@types/feather-icons": "4.7.0",
     "@types/jquery": "3.5.0",
     "@types/jqueryui": "1.12.13",
+    "@types/lodash": "4.17.2",
     "@types/mocha": "7.0.2",
     "@types/node": "13.13.5",
     "@types/webpack-env": "1.15.2",


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added a `"@types/lodash": "4.17.2"` pin to prevent TypeScript compilation errors when building the graph_notebook_widgets package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.