### PR TITLE
Add silent option to `%%graph_notebook_config`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Added `--connected-table` option to magics with table widget output ([Link to PR](https://github.com/aws/graph-notebook/pull/634))
+- Added `--silent` option to the `%%graph_notebook_config` line and cell magics ([Link to PR](https://github.com/aws/graph-notebook/pull/641))
 - Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
 - Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))
 - Fixed `%%graph_notebook_config` error when excluding optional Gremlin section ([Link to PR](https://github.com/aws/graph-notebook/pull/633))

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -451,6 +451,7 @@ class Graph(Magics):
         parser.add_argument('mode', nargs='?', default='show',
                             help='mode (default=show) [show|reset|silent]')
         parser.add_argument('--store-to', type=str, default='', help='store query result to this variable')
+        parser.add_argument('--silent', action='store_true', default=False, help="Display no output.")
         args = parser.parse_args(line.split())
 
         if cell != '':
@@ -458,12 +459,14 @@ class Graph(Magics):
             config = get_config_from_dict(data, neptune_hosts=self.neptune_cfg_allowlist)
             self.graph_notebook_config = config
             self._generate_client_from_config(config)
-            print('set notebook config to:')
-            print(json.dumps(self.graph_notebook_config.to_dict(), indent=4))
+            if not args.silent:
+                print('set notebook config to:')
+                print(json.dumps(self.graph_notebook_config.to_dict(), indent=4))
         elif args.mode == 'reset':
             self.graph_notebook_config = get_config(self.config_location, neptune_hosts=self.neptune_cfg_allowlist)
-            print('reset notebook config to:')
-            print(json.dumps(self.graph_notebook_config.to_dict(), indent=4))
+            if not args.silent:
+                print('reset notebook config to:')
+                print(json.dumps(self.graph_notebook_config.to_dict(), indent=4))
         elif args.mode == 'silent':
             """
             silent option to that our neptune_menu extension can receive json instead
@@ -471,14 +474,14 @@ class Graph(Magics):
             """
             config_dict = self.graph_notebook_config.to_dict()
             store_to_ns(args.store_to, json.dumps(config_dict, indent=4), local_ns)
-            return print(json.dumps(config_dict, indent=4))
+            if not args.silent:
+                return print(json.dumps(config_dict, indent=4))
         else:
             config_dict = self.graph_notebook_config.to_dict()
-            print(json.dumps(config_dict, indent=4))
+            if not args.silent:
+                print(json.dumps(config_dict, indent=4))
 
         store_to_ns(args.store_to, json.dumps(self.graph_notebook_config.to_dict(), indent=4), local_ns)
-
-        return self.graph_notebook_config
 
     @line_cell_magic
     def neptune_config_allowlist(self, line='', cell=''):

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -483,6 +483,8 @@ class Graph(Magics):
 
         store_to_ns(args.store_to, json.dumps(self.graph_notebook_config.to_dict(), indent=4), local_ns)
 
+        return self.graph_notebook_config
+
     @line_cell_magic
     def neptune_config_allowlist(self, line='', cell=''):
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added the `--silent` option to the `%%graph_notebook_config` line and cell magics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.