### PR TITLE
Disable output from `get_config` function

### DIFF
--- a/src/graph_notebook/configuration/get_config.py
+++ b/src/graph_notebook/configuration/get_config.py
@@ -78,5 +78,4 @@ def get_config(path: str = DEFAULT_CONFIG_LOCATION,
                neptune_hosts: list = NEPTUNE_CONFIG_HOST_IDENTIFIERS) -> Configuration:
     with open(path) as config_file:
         data = json.load(config_file)
-        print(data)
         return get_config_from_dict(data=data, neptune_hosts=neptune_hosts)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Suppressed unnecessary output from `get_config`, added with the `%%gremlin --connection-protocol` feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.