### PR TITLE
Add redirect messaging for service-restricted Neptune magics

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
   - Path: 01-Neptune-Database > 03-Sample-Applications > 07-Games-Industry-Graphs
 - Added `--connected-table` option to magics with table widget output ([Link to PR](https://github.com/aws/graph-notebook/pull/634))
 - Added `--silent` option to the `%%graph_notebook_config` line and cell magics ([Link to PR](https://github.com/aws/graph-notebook/pull/641))
+- Added helpful redirect messaging for service-specific Neptune magics ([Link to PR](https://github.com/aws/graph-notebook/pull/643))
 - Changed `%%gremlin --store-to` to also store exceptions from non-Neptune queries ([Link to PR](https://github.com/aws/graph-notebook/pull/635))
 - Fixed broken `--help` option for `%%gremlin` ([Link to PR](https://github.com/aws/graph-notebook/pull/630))
 - Fixed openCypher query bug regression in the [`01-About-the-Neptune-Notebook`](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/01-Getting-Started/01-About-the-Neptune-Notebook.ipynb) sample ([Link to PR](https://github.com/aws/graph-notebook/pull/631))


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added more helpful user guidance for select magics restricted by the `%neptune_db_only` or `%neptune_graph_only` decorators. Users will be directed to use an alternative magic specific to the configured `neptune_service`, where available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.