### PR TITLE
Add unified `%reset` magic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 - New Neptune Database notebook - Games Industry Graphs ([Link to PR](https://github.com/aws/graph-notebook/pull/566))
   - Path: 01-Neptune-Database > 03-Sample-Applications > 07-Games-Industry-Graphs
+- Added unified `%reset` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/644))
 - Added `--connected-table` option to magics with table widget output ([Link to PR](https://github.com/aws/graph-notebook/pull/634))
 - Added `--silent` option to the `%%graph_notebook_config` line and cell magics ([Link to PR](https://github.com/aws/graph-notebook/pull/641))
 - Changed `%%gremlin --store-to` to also store exceptions from non-Neptune queries ([Link to PR](https://github.com/aws/graph-notebook/pull/635))

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -633,11 +633,11 @@ class Client(object):
         res = self._http_session.send(req, verify=self.ssl_verify)
         return res
 
-    def reset_graph(self, graph_id: str = '', no_skip_snapshot: bool = False) -> dict:
+    def reset_graph(self, graph_id: str = '', snapshot: bool = False) -> dict:
         try:
             res = self.neptune_graph_client.reset_graph(
                 graphIdentifier=graph_id,
-                skipSnapshot=(not no_skip_snapshot)
+                skipSnapshot=(not snapshot)
             )
             return res
         except ClientError as e:


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added a new `%reset` magic compatible with both Neptune Database and Neptune Analytics. `%reset` inherits all of the original arguments of `%db_reset` and `%graph_reset`/`%reset_graph`, which now wrap the `%reset` and call it with the corresponding service.
- Renamed the `%graph_reset` `-ns`/`--no-skip-snapshot` argument to `-s`/`--snapshot`.

Example UI for Neptune Analytics:

<img width="641" alt="Screenshot 2024-07-10 at 9 35 58 PM" src="https://github.com/aws/graph-notebook/assets/10456376/40b4b939-59d5-4e53-9931-9047eb212360">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.