### PR TITLE
fix: updates to allow building the library Python 3.11

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added better `%reset` user messaging on status check timeout ([Link to PR](https://github.com/aws/graph-notebook/pull/652))
 - Modified the `%reset --snapshot` option to use the CreateGraphSnapshot API ([Link to PR](https://github.com/aws/graph-notebook/pull/654))
 - Upgraded `setuptools` dependency to 70.x ([Link to PR](https://github.com/aws/graph-notebook/pull/649))
+- Experimental build support for Python 3.11 ([Link to PR](https://github.com/aws/graph-notebook/pull/645))
 
 ## Release 4.5.0 (July 15, 2024)
 

--- a/setupbase.py
+++ b/setupbase.py
@@ -671,7 +671,7 @@ def _translate_glob(pat):
         translated_parts.append(_translate_glob_part(part))
     os_sep_class = '[%s]' % re.escape(SEPARATORS)
     res = _join_translated(translated_parts, os_sep_class)
-    return '{res}\\Z(?ms)'.format(res=res)
+    return '(?ms){res}\\Z'.format(res=res)
 
 
 def _join_translated(translated_parts, os_sep_class):

--- a/setupbase.py
+++ b/setupbase.py
@@ -644,7 +644,7 @@ def _compile_pattern(pat, ignore_case=True):
     else:
         res = _translate_glob(pat)
     flags = re.IGNORECASE if ignore_case else 0
-    return re.compile(res, flags=flags).match
+    return re.compile(res, flags=flags | re.DOTALL | re.MULTILINE).match
 
 
 def _iexplode_path(path):
@@ -671,7 +671,7 @@ def _translate_glob(pat):
         translated_parts.append(_translate_glob_part(part))
     os_sep_class = '[%s]' % re.escape(SEPARATORS)
     res = _join_translated(translated_parts, os_sep_class)
-    return '(?ms){res}\\Z'.format(res=res)
+    return '{res}\\Z'.format(res=res)
 
 
 def _join_translated(translated_parts, os_sep_class):


### PR DESCRIPTION
### Description of changes:

This PR addresses a bug that occurs when building the **graph-notebook** with Python3.11. The [Porting to Python 3.11 summary](https://docs.python.org/3/whatsnew/3.11.html#porting-to-python-3-11) calls out a change to global inline flags so that they can **only** be used at the start of a regular expression.

The existing code for converting globs -> regexes  appends the `(?ms)` modifier at the end of the pattern. This PR removes the [multiline](https://docs.python.org/3/library/re.html#re.MULTILINE) and [dotall](https://docs.python.org/3/library/re.html#re.DOTALL) modifiers from the regex string template. Instead, it uses the **multiline** and **dotall** flags in the compile statement.

This allows the `graph-notebook` library to, at a minimum, build with Python3.11

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.