### PR TITLE
Bump setuptools to 70.x

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Upgraded `setuptools` dependency to 70.x ([Link to PR](https://github.com/aws/graph-notebook/pull/649))
 
 ## Release 4.5.0 (July 15, 2024)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ipykernel==5.3.4
 ipyfilechooser==0.6.0
 neo4j>=4.4.9,<5.0.0
 rdflib==7.0.0
-setuptools>=65.5.1,<=66.0.0
+setuptools>=70.0.0,<=70.0.3
 nbconvert>=6.3.0,<=7.2.8
 jedi>=0.18.1,<=0.18.2
 markupsafe<2.1.0


### PR DESCRIPTION
Issue #, if available: CVE-2024-6345

Description of changes:
- Bumped `setuptools` requirement to >=70.0.0 to address a vulnerability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.