### PR TITLE
Improve `%reset` status user messaging on retry timeout

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Added better `%reset` user messaging on status check timeout ([Link to PR](https://github.com/aws/graph-notebook/pull/652))
 - Upgraded `setuptools` dependency to 70.x ([Link to PR](https://github.com/aws/graph-notebook/pull/649))
 
 ## Release 4.5.0 (July 15, 2024)

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1724,15 +1724,29 @@ class Graph(Magics):
                         with interval_output:
                             print(f'checking status in {time_remaining} seconds')
                     time.sleep(1)
-                with output:
+                with (output):
                     job_status_output.clear_output()
                     interval_output.close()
                     total_status_wait = max_status_retries * poll_interval
-                    print(result)
-                    if interval_check_response.get("status") != 'healthy':
-                        print(f"Could not retrieve the status of the reset operation within the allotted time of "
-                              f"{total_status_wait} seconds. If the database is not in healthy status after at least 1 "
-                              f"minute, please try the operation again or reboot the {message_instance}.")
+                    final_status = interval_check_response.get("status")
+                    if using_db:
+                        if final_status != 'healthy':
+                            print(f"Could not retrieve the status of the reset operation within the allotted time of "
+                                  f"{total_status_wait} seconds. If the database is not in healthy status after at "
+                                  f"least 1 minute, please try the operation again or reboot the cluster.")
+                            print(result)
+                    else:
+                        if final_status == 'RESETTING':
+                            print(f"Reset is still in progress after the allotted wait time of {total_status_wait} "
+                                  f"seconds, halting status checks. Please use %status to verify when your graph is "
+                                  f"available again.")
+                            print(f"\nTIP: For future resets, you can use the --max-status-retries option to extend "
+                                  f"the total wait duration.")
+                        elif final_status != 'AVAILABLE':
+                            print(f"Graph is not in AVAILABLE or RESETTING status after the allotted time of "
+                                  f"{total_status_wait} seconds, something went wrong. "
+                                  f"Current status is {final_status}, see below for details.")
+                            print(result)
 
             def on_button_cancel_clicked(b):
                 confirm_text_hbox.close()


### PR DESCRIPTION
Issue #, if available: #651

Description of changes:
- Diverging `%reset` outputs on retry timeout to be relevant/helpful for the current Neptune service.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.