### PR TITLE
Add `%create_graph_snapshot` line magic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Added `%create_graph_snapshot` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/653))
 - Upgraded `setuptools` dependency to 70.x ([Link to PR](https://github.com/aws/graph-notebook/pull/649))
 
 ## Release 4.5.0 (July 15, 2024)

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -654,6 +654,20 @@ class Client(object):
             logger.debug(f"GetGraph call failed with service exception: {e}")
             raise e
 
+    def create_graph_snapshot(self, graph_id: str = '', snapshot_name: str = '', tags: dict = None) -> dict:
+        if not tags:
+            tags = {}
+        try:
+            res = self.neptune_graph_client.create_graph_snapshot(
+                graphIdentifier=graph_id,
+                snapshotName=snapshot_name,
+                tags=tags
+            )
+            return res
+        except ClientError as e:
+            logger.debug(f"CreateGraphSnapshot call failed with service exception: {e}")
+            raise e
+
     def dataprocessing_start(self, s3_input_uri: str, s3_output_uri: str, **kwargs) -> requests.Response:
         data = {
             'inputDataS3Location': s3_input_uri,


### PR DESCRIPTION
Issue #, if available: #651

Description of changes:
- Added a new `%create_graph_snapshot` for Neptune Analytics. This magic interfaces with the [CreateGraphSnapshot API](https://docs.aws.amazon.com/neptune-analytics/latest/apiref/API_CreateGraphSnapshot.html), the supported parameters of which can be passed via optional line arguments:
  - `-s`/`--snapshot-name`: Sets the `snapShot` string parameter. If not supplied, the notebook will automatically create and use a name in the format `snapshot-[graph_id]-[timestamp]`.
  - `-t`/`--tags`: Sets the `tags` parameter. Accepts a map in string format, ex. `{"tag1":"foo","tag2":"bar"}`.
  
Example usage:
<img width="830" alt="Screenshot 2024-07-17 at 5 25 21 PM" src="https://github.com/user-attachments/assets/e25f4a3f-6d86-4ae9-b5a0-c56422b01c56">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.