### PR TITLE
Use CreateGraphSnapshot API for `%reset --snapshot` 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 - Added `%create_graph_snapshot` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/653))
 - Added better `%reset` user messaging on status check timeout ([Link to PR](https://github.com/aws/graph-notebook/pull/652))
+- Modified the `%reset --snapshot` option to use the CreateGraphSnapshot API ([Link to PR](https://github.com/aws/graph-notebook/pull/654))
 - Upgraded `setuptools` dependency to 70.x ([Link to PR](https://github.com/aws/graph-notebook/pull/649))
 
 ## Release 4.5.0 (July 15, 2024)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Added `%create_graph_snapshot` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/653))
 - Upgraded `setuptools` dependency to 70.x ([Link to PR](https://github.com/aws/graph-notebook/pull/649))
 
 ## Release 4.5.0 (July 15, 2024)

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -654,6 +654,20 @@ class Client(object):
             logger.debug(f"GetGraph call failed with service exception: {e}")
             raise e
 
+    def create_graph_snapshot(self, graph_id: str = '', snapshot_name: str = '', tags: dict = None) -> dict:
+        if not tags:
+            tags = {}
+        try:
+            res = self.neptune_graph_client.create_graph_snapshot(
+                graphIdentifier=graph_id,
+                snapshotName=snapshot_name,
+                tags=tags
+            )
+            return res
+        except ClientError as e:
+            logger.debug(f"CreateGraphSnapshot call failed with service exception: {e}")
+            raise e
+
     def dataprocessing_start(self, s3_input_uri: str, s3_output_uri: str, **kwargs) -> requests.Response:
         data = {
             'inputDataS3Location': s3_input_uri,

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 import json
 import logging
 import re
+import datetime
 
 import requests
 import urllib3
@@ -189,6 +190,13 @@ def set_plan_cache_hint(query: str, plan_cache_value: str):
     plan_cache_hint = f'USING QUERY: PLANCACHE "{plan_cache_value}"\n'
     query_with_hint = plan_cache_hint + query
     return query_with_hint
+
+
+def generate_snapshot_name(graph_id: str):
+    datetime_iso = datetime.datetime.utcnow().isoformat()
+    timestamp = re.sub(r'\D', '', datetime_iso)
+    snapshot_name = f"snapshot-{graph_id}-{timestamp}"
+    return snapshot_name
 
 
 class Client(object):


### PR DESCRIPTION
Issue #, if available: #651

Description of changes:
- Changed the Neptune Analytics `--snapshot` option for `%reset` to call and poll the CreateGraphSnapshot API, instead of  passing `skipSnapshot=False` with the GraphReset API call. This ensures that `--snapshot` will work even on graphs where `skipSnapshot` is unsupported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.