### PR TITLE
Add `%neptune_client_endpoint` line magic

### DIFF
--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -211,7 +211,7 @@ class Client(object):
                  neo4j_auth: bool = True, neo4j_database: str = DEFAULT_NEO4J_DATABASE,
                  auth=None, session: Session = None,
                  proxy_host: str = '', proxy_port: int = DEFAULT_PORT,
-                 neptune_hosts: list = None):
+                 neptune_hosts: list = None, neptune_client_endpoint: str = None):
         self.target_host = host
         self.target_port = port
         self.neptune_service = neptune_service
@@ -240,7 +240,11 @@ class Client(object):
 
         self._http_session = None
 
-        self.neptune_graph_client = boto3_client(service_name='neptune-graph', region_name=self.region)
+        if neptune_client_endpoint is not None:
+            self.neptune_graph_client = boto3_client(service_name='neptune-graph', region_name=self.region,
+                                                     endpoint_url=neptune_client_endpoint)
+        else:
+            self.neptune_graph_client = boto3_client(service_name='neptune-graph', region_name=self.region)
 
     @property
     def host(self):
@@ -1090,6 +1094,10 @@ class ClientBuilder(object):
 
     def with_custom_neptune_hosts(self, neptune_hosts: list):
         self.args['neptune_hosts'] = neptune_hosts
+        return ClientBuilder(self.args)
+
+    def with_custom_neptune_client_endpoint(self, endpoint_url: str):
+        self.args['neptune_client_endpoint'] = endpoint_url
         return ClientBuilder(self.args)
 
     def build(self) -> Client:


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added new `%neptune_client_endpoint` line magic. Allows users to set a custom [endpoint_url](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client) to use when initializing the `neptune-graph` SDK client.
- Modified `%%neptune_config_allowlist` to regenerate notebook client upon allowlist modification

**Example usage:**


To set the custom endpoint_url, run:

```
%neptune_client_endpoint https://your.endpoint.url.here
```

To reset the endpoint_url to the default constructed by Boto3, run:

<img width="517" alt="Screenshot 2024-07-18 at 9 30 04 PM" src="https://github.com/user-attachments/assets/5aa84b35-c4b3-450f-ae0b-2edef3206010">

To check the current endpoint_url state, specify no arguments:

<img width="517" alt="Screenshot 2024-07-18 at 9 27 36 PM" src="https://github.com/user-attachments/assets/86b8b48d-656b-425f-8f7b-ac0169f4bf85">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.