### PR TITLE
Enable unit tests and fix widgets installation on Python 3.11

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,7 +7,7 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
     strategy:
       matrix:
-        python-version: ['3.8', '3.10']
+        python-version: ['3.8', '3.10', '3.11']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added better `%reset` user messaging on status check timeout ([Link to PR](https://github.com/aws/graph-notebook/pull/652))
 - Modified the `%reset --snapshot` option to use the CreateGraphSnapshot API ([Link to PR](https://github.com/aws/graph-notebook/pull/654))
 - Upgraded `setuptools` dependency to 70.x ([Link to PR](https://github.com/aws/graph-notebook/pull/649))
-- Experimental build support for Python 3.11 ([Link to PR](https://github.com/aws/graph-notebook/pull/645))
+- Experimental support for Python 3.11 ([PR #1](https://github.com/aws/graph-notebook/pull/645)) ([PR #2](https://github.com/aws/graph-notebook/pull/656))
 
 ## Release 4.5.0 (July 15, 2024)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ itables>=2.0.0,<=2.1.0
 pandas>=1.3.5,<=1.5.3
 numpy<1.24.0
 nest_asyncio>=1.5.5,<=1.5.6
+async-timeout>=4.0,<5.0
 
 # requirements for testing
 botocore~=1.34.74

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ setup(
         'itables>=2.0.0,<=2.1.0',
         'pandas>=1.3.5,<=1.5.3',
         'numpy<1.24.0',
-        'nest_asyncio>=1.5.5,<=1.5.6'
+        'nest_asyncio>=1.5.5,<=1.5.6',
+        'async-timeout>=4.0,<5.0'
     ],
     package_data={
         'graph_notebook': ['graph_notebook/widgets/nbextensions/**',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Added Python 3.11 to the GitHub unit tests workflow
- Fixed an issue where widgets installation would fail due on 3.11 due to a GremlinPython dependency error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.