### PR TITLE
Make EncryptionKey optional in Neptune CloudFormation template

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 
 - Removed unused options from `%load`([Link to PR](https://github.com/aws/graph-notebook/pull/662))
+- Made EncryptionKey optional in Neptune CloudFormation template ([Link to PR](https://github.com/aws/graph-notebook/pull/663))
 
 ## Release 4.5.1 (July 31, 2024)
 

--- a/additional-databases/sagemaker/neptune-notebook-cloudformation/neptune-workbench-stack.yaml
+++ b/additional-databases/sagemaker/neptune-notebook-cloudformation/neptune-workbench-stack.yaml
@@ -101,6 +101,11 @@ Conditions:
     Fn::Equals:
       - !Ref SageMakerNotebookRoleArn
       - ""
+  UseEncryptionKey:
+    Fn::Not:
+      - Fn::Equals:
+        - Ref: EncryptionKey
+        - ""
 
 Resources:
   NeptuneNotebookInstance:
@@ -133,7 +138,10 @@ Resources:
         - Key: aws-neptune-resource-id
           Value: !Ref NeptuneClusterResourceId
       KmsKeyId:
-        Ref: EncryptionKey
+        Fn::If:
+          - UseEncryptionKey
+          - Ref: EncryptionKey
+          - Ref: AWS::NoValue
 
   NeptuneNotebookInstanceLifecycleConfig:
     Type: AWS::SageMaker::NotebookInstanceLifecycleConfig


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Removed EncryptionKey parameter requirement in the Neptune SageMaker noteobook CloudFormation template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.