### PR TITLE
Add `%list_import_tasks` line magic

### DIFF
--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -687,7 +687,6 @@ class Client(object):
         if next_token != '':
             kwargs['nextToken'] = next_token
         try:
-            print(f"final kwargs: {kwargs}")
             res = self.neptune_graph_client.list_import_tasks(**kwargs)
             return res
         except ClientError as e:

--- a/src/graph_notebook/neptune/client.py
+++ b/src/graph_notebook/neptune/client.py
@@ -680,6 +680,20 @@ class Client(object):
             logger.debug(f"CreateGraphSnapshot call failed with service exception: {e}")
             raise e
 
+    def list_import_tasks(self, max_results: int = None, next_token: str = '') -> dict:
+        kwargs = {}
+        if max_results is not None:
+            kwargs['maxResults'] = max_results
+        if next_token != '':
+            kwargs['nextToken'] = next_token
+        try:
+            print(f"final kwargs: {kwargs}")
+            res = self.neptune_graph_client.list_import_tasks(**kwargs)
+            return res
+        except ClientError as e:
+            logger.debug(f"GetGraph call failed with service exception: {e}")
+            raise e
+
     def dataprocessing_start(self, s3_input_uri: str, s3_output_uri: str, **kwargs) -> requests.Response:
         data = {
             'inputDataS3Location': s3_input_uri,


### PR DESCRIPTION
Issue #, if available: #665, #667

Description of changes:
- Added new `%list_import_tasks` line magic for Neptune Analytics. This magic calls the [ListImportTasks](https://docs.aws.amazon.com/neptune-analytics/latest/apiref/API_ListImportTasks.html) API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.