### PR TITLE
Pass `blankNodeHandling` option to batch `%load`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - New Neptune Analytics notebooks - openCypher over RDF ([Link to PR](https://github.com/aws/graph-notebook/pull/672))
   - Path: 02-Neptune-Analytics > 04-OpenCypher-Over-RDF
 - Added regional S3 bucket mappings to Neptune CloudFormation template ([Link to PR](https://github.com/aws/graph-notebook/pull/664))
-- Enabled n-triples data for `%load` with Neptune Analytics ([Link to PR](https://github.com/aws/graph-notebook/pull/671))
+- Enabled n-triples data for `%load` with Neptune Analytics ([PR #1](https://github.com/aws/graph-notebook/pull/671)) ( ([PR #2](https://github.com/aws/graph-notebook/pull/675)))
 - Removed unused options from `%load`([Link to PR](https://github.com/aws/graph-notebook/pull/662))
 - Made EncryptionKey optional in Neptune CloudFormation template ([Link to PR](https://github.com/aws/graph-notebook/pull/663))
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -2339,7 +2339,8 @@ class Graph(Magics):
                     incremental_load_kwargs = {
                         'source': source.value,
                         'format': source_format.value,
-                        'concurrency': concurrency.value
+                        'concurrency': concurrency.value,
+                        'blankNodeHandling': 'convertToIri'
                     }
                     kwargs.update(incremental_load_kwargs)
                 else:

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -47,7 +47,7 @@ from graph_notebook.magics.streams import StreamViewer
 from graph_notebook.neptune.client import (ClientBuilder, Client, PARALLELISM_OPTIONS, PARALLELISM_HIGH, \
     LOAD_JOB_MODES, MODE_AUTO, FINAL_LOAD_STATUSES, SPARQL_ACTION, FORMAT_CSV, FORMAT_OPENCYPHER, FORMAT_NTRIPLE, \
     DB_LOAD_TYPES, ANALYTICS_LOAD_TYPES, VALID_BULK_FORMATS, VALID_INCREMENTAL_FORMATS, \
-    FORMAT_NQUADS, FORMAT_RDFXML, FORMAT_TURTLE, STREAM_RDF, STREAM_PG, STREAM_ENDPOINTS, \
+    FORMAT_NQUADS, FORMAT_RDFXML, FORMAT_TURTLE, FORMAT_NTRIPLE, STREAM_RDF, STREAM_PG, STREAM_ENDPOINTS, \
     NEPTUNE_CONFIG_HOST_IDENTIFIERS, is_allowed_neptune_host, \
     STATISTICS_LANGUAGE_INPUTS, STATISTICS_LANGUAGE_INPUTS_SPARQL, STATISTICS_MODES, SUMMARY_MODES, \
     SPARQL_EXPLAIN_MODES, OPENCYPHER_EXPLAIN_MODES, GREMLIN_EXPLAIN_MODES, \
@@ -2340,8 +2340,9 @@ class Graph(Magics):
                         'source': source.value,
                         'format': source_format.value,
                         'concurrency': concurrency.value,
-                        'blankNodeHandling': 'convertToIri'
                     }
+                    if source.value == FORMAT_NTRIPLE:
+                        incremental_load_kwargs['blankNodeHandling'] = 'convertToIri'
                     kwargs.update(incremental_load_kwargs)
                 else:
                     bulk_load_kwargs = {


### PR DESCRIPTION
Issue #, if available: #673

Description of changes:
- Hardcode required `'blankNodeHandling': 'convertToIri'` parameter when executing `%load --format ntriples` against Neptune Analytics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.