### PR TITLE
Update OC-RDF samples to load from regional S3 buckets

### DIFF
--- a/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/01-Air-Routes.ipynb
+++ b/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/01-Air-Routes.ipynb
@@ -51,11 +51,52 @@
    "source": [
     "## Creating the Graph\n",
     "\n",
-    "This notebook assumes that you already have a Neptune Analytics graph with the Air Routes RDF data loaded.\n",
+    "Run the following two cells to load the Air Routes RDF graph, using [Neptune batch load](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/batch-load.html).  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9b16519669e1e39",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import graph_notebook as gn\n",
     "\n",
-    "To create the graph, you must have the Air Routes NTRIPLES file loaded into your Neptune Analytics graph.\n",
+    "config = gn.configuration.get_config.get_config()\n",
+    "region = config.aws_region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "115b0bc4a8524820",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%oc\n",
     "\n",
-    "If you do not already have the data loaded, refer to the Neptune Analytics documentation for creating a graph from existing sources using the Air Routes ontology and NTRIPLES files available in S3: `s3://aws-neptune-customer-samples-[AWS_REGION_HERE]/airroutes-rdf/airroutes.nt`. Ensure that you substitute the AWS Region identifier corresponding to that of your graph."
+    "CALL neptune.load(\n",
+    "  {\n",
+    "    source: \"s3://aws-neptune-customer-samples-${region}/airroutes-rdf/airroutes.nt\",\n",
+    "    region: \"${region}\",\n",
+    "    format: \"ntriples\",\n",
+    "    failOnError: true,\n",
+    "    blankNodeHandling: \"convertToIri\"\n",
+    "  }\n",
+    ")"
    ]
   },
   {
@@ -82,7 +123,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5a8776f5",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%oc\n",
@@ -319,11 +362,9 @@
   },
   {
    "cell_type": "markdown",
-   "source": [],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "2fae2627ca1adc97"
+   "id": "2fae2627ca1adc97",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "code",
@@ -544,7 +585,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/01-Air-Routes.ipynb
+++ b/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/01-Air-Routes.ipynb
@@ -26,8 +26,7 @@
     "\n",
     "### The Air Routes Ontology (Schema)\n",
     "\n",
-    "The Air Routes ontology and data used in this notebook are available in a single NTRIPLES file on S3:\n",
-    "[s3://aws-neptune-customer-samples/airroutes-rdf/airroutes.nt](s3://aws-neptune-customer-samples/airroutes-rdf/airroutes.nt)\n",
+    "The Air Routes ontology and data used in this notebook are available in a single NTRIPLES file on S3: `s3://aws-neptune-customer-samples-[AWS_REGION_HERE]/airroutes-rdf/airroutes.nt`\n",
     "\n",
     "In this notebook, we work with a subset of the ontology, shown here:"
    ]
@@ -56,8 +55,7 @@
     "\n",
     "To create the graph, you must have the Air Routes NTRIPLES file loaded into your Neptune Analytics graph.\n",
     "\n",
-    "If you do not already have the data loaded, refer to the Neptune Analytics documentation for creating a graph from existing sources using the Air Routes ontology and NTRIPLES file available in S3:\n",
-    "[s3://aws-neptune-customer-samples/airroutes-rdf/airroutes.nt](s3://aws-neptune-customer-samples/airroutes-rdf/airroutes.nt)"
+    "If you do not already have the data loaded, refer to the Neptune Analytics documentation for creating a graph from existing sources using the Air Routes ontology and NTRIPLES files available in S3: `s3://aws-neptune-customer-samples-[AWS_REGION_HERE]/airroutes-rdf/airroutes.nt`. Ensure that you substitute the AWS Region identifier corresponding to that of your graph."
    ]
   },
   {

--- a/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/02-Air-Routes-GeoNames.ipynb
+++ b/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/02-Air-Routes-GeoNames.ipynb
@@ -50,6 +50,32 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "### Presets for data loading\n",
+    "\n",
+    "Before executing the GeoNames and Air Routes data loads that follow, run the following cell. This will set the load commands to use an S3 bucket in the same region as the graph - this is a requirement for batch load."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "8111ccacffd41586"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "import graph_notebook as gn\n",
+    "\n",
+    "config = gn.configuration.get_config.get_config()\n",
+    "region = config.aws_region"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "98bf6d5e82a415f6"
+  },
+  {
+   "cell_type": "markdown",
    "id": "c0950c69",
    "metadata": {},
    "source": [
@@ -69,8 +95,8 @@
     "\n",
     "CALL neptune.load(\n",
     "  {\n",
-    "    source: \"s3://aws-neptune-customer-samples/geonames-rdf/geonames-cities-countries.nt\",\n",
-    "    region: \"us-east-1\",\n",
+    "    source: \"s3://aws-neptune-customer-samples-${region}/geonames-rdf/geonames-cities-countries.nt\",\n",
+    "    region: \"${region}\",\n",
     "    format: \"ntriples\",\n",
     "    failOnError: true,\n",
     "    blankNodeHandling: \"convertToIri\"\n",
@@ -99,8 +125,8 @@
     "\n",
     "CALL neptune.load(\n",
     "  {\n",
-    "    source: \"s3://aws-neptune-customer-samples/airroutes-rdf/airroutes.nt\",\n",
-    "    region: \"us-east-1\",\n",
+    "    source: \"s3://aws-neptune-customer-samples-${region}/airroutes-rdf/airroutes.nt\",\n",
+    "    region: \"${region}\",\n",
     "    format: \"ntriples\",\n",
     "    failOnError: true,\n",
     "    blankNodeHandling: \"convertToIri\"\n",

--- a/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/02-Air-Routes-GeoNames.ipynb
+++ b/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/02-Air-Routes-GeoNames.ipynb
@@ -50,29 +50,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8111ccacffd41586",
+   "metadata": {},
    "source": [
     "### Presets for data loading\n",
     "\n",
     "Before executing the GeoNames and Air Routes data loads that follow, run the following cell. This will set the load commands to use an S3 bucket in the same region as the graph - this is a requirement for batch load."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "8111ccacffd41586"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "98bf6d5e82a415f6",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import graph_notebook as gn\n",
     "\n",
     "config = gn.configuration.get_config.get_config()\n",
     "region = config.aws_region"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "98bf6d5e82a415f6"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -88,7 +91,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "11f981cb",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%oc\n",
@@ -118,7 +123,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ea98a771",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%oc\n",
@@ -340,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Issue #, if available: #674

Description of changes:
- Updated the [04-OpenCypher-Over-RDF](https://github.com/aws/graph-notebook/tree/main/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF) sample notebooks to load data from regional S3 buckets.
- Added batch load commands to replace bulk import instructions in the [01-Air-Routes](https://github.com/aws/graph-notebook/blob/main/src/graph_notebook/notebooks/02-Neptune-Analytics/04-OpenCypher-Over-RDF/01-Air-Routes.ipynb) sample.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.