### PR TITLE
Upgrade Neo4j Python Driver to 5.x

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
+- Upgraded Neo4j Bolt driver to v5.x ([Link to PR](https://github.com/aws/graph-notebook/pull/682))
 
 ## Release 4.5.2 (August 15, 2024)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ requests>=2.32.0,<=2.32.2
 ipython>=7.16.1,<=8.10.0
 ipykernel==5.3.4
 ipyfilechooser==0.6.0
-neo4j>=4.4.9,<5.0.0
+neo4j>=4.4.9,<=5.23.1
 rdflib==7.0.0
 setuptools>=70.0.0,<=70.0.3
 nbconvert>=6.3.0,<=7.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ requests>=2.32.0,<=2.32.2
 ipython>=7.16.1,<=8.10.0
 ipykernel==5.3.4
 ipyfilechooser==0.6.0
-neo4j>=4.4.9,<=5.23.1
+neo4j>=5.0.0,<=5.23.1
 rdflib==7.0.0
 setuptools>=70.0.0,<=70.0.3
 nbconvert>=6.3.0,<=7.2.8

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'botocore>=1.34.74',
         'boto3>=1.34.74',
         'ipython>=7.16.1,<=8.10.0',
-        'neo4j>=4.4.9,<=5.23.1',
+        'neo4j>=5.0.0,<=5.23.1',
         'rdflib==7.0.0',
         'ipykernel==5.3.4',
         'ipyfilechooser==0.6.0',

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'botocore>=1.34.74',
         'boto3>=1.34.74',
         'ipython>=7.16.1,<=8.10.0',
-        'neo4j>=4.4.9,<5.0.0',
+        'neo4j>=4.4.9,<=5.23.1',
         'rdflib==7.0.0',
         'ipykernel==5.3.4',
         'ipyfilechooser==0.6.0',


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Bumped `neo4j` dependency floor from 4.4.x to 5.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.