### PR TITLE
Fix IPython config dir retrieval logic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Upgraded Neo4j Bolt driver to v5.x ([Link to PR](https://github.com/aws/graph-notebook/pull/682))
 - Added `%get_import_task` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/668))
 - Added `--export-to` JSON file option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/684))
+- Fix ipython config dir logic ([Link to PR](https://github.com/aws/graph-notebook/pull/687))
 
 ## Release 4.5.2 (August 15, 2024)
 

--- a/src/graph_notebook/ipython_profile/configure_ipython_profile.py
+++ b/src/graph_notebook/ipython_profile/configure_ipython_profile.py
@@ -6,8 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 import os
 import json
 
-HOME_PATH = os.path.expanduser("~")
-IPYTHON_DIR_TREE = HOME_PATH + '/.ipython/profile_default'
+from IPython import paths as ipython_paths
+
+IPYTHON_DIR_TREE = ipython_paths.get_ipython_dir() + "/profile_default"
 IPYTHON_CFG_FILE_NAME = 'ipython_config.json'
 IPYTHON_CFG_PATH = IPYTHON_DIR_TREE + '/' + IPYTHON_CFG_FILE_NAME
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Apply IPython's own logic to retrieve the location of the IPython configuration directory as detailed in the [docs](https://ipython.readthedocs.io/en/stable/development/config.html#configuration-file-location). This allows reuse of custom config dirs like ~/.config/ipython or any path specified via IPYTHONDIR environment variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.