### PR TITLE
use extras_require to specify tests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added `%get_import_task` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/668))
 - Added `--export-to` JSON file option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/684))
 - Fix ipython config dir logic ([Link to PR](https://github.com/aws/graph-notebook/pull/687))
+- Use extras\_require to specify tests ([Link to PR](https://github.com/aws/graph-notebook/pull/688))
 
 ## Release 4.5.2 (August 15, 2024)
 

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,9 @@ setup(
         'License :: OSI Approved :: Apache Software License'
     ],
     keywords='jupyter neptune gremlin sparql',
-    tests_require=[
-        'pytest==6.2.5'
-    ]
+    extras_require={
+        'test': [
+            'pytest==6.2.5'
+            ],
+    }
 )


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Specify test dependency in `extras_require` instead of `tests_require`.  
Reason: The latter is deprecated. See https://github.com/pypa/setuptools/blob/bb0506352435a13f6fd70fa3b9eae6fd0f6e1ea8/docs/references/keywords.rst?plain=1#L452-L467

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

P.S.: This change (together with setting environment variable `NODE_OPTIONS="--openssl-legacy-provider"` for a totally different reason), allows to specify graph-notebook as a git-based dependency in a pyproject.toml and to install it using `poetry`:  
```
[tool.poetry.group.dev.dependencies]
graph-notebook = { git = "https://github.com/bauer-at-work/graph-notebook", branch = "main" }
```