### PR TITLE
Fix missing `%db_reset` output for token modes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Upgraded Neo4j Bolt driver to v5.x ([Link to PR](https://github.com/aws/graph-notebook/pull/682))
 - Added `%get_import_task` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/668))
 - Added `--export-to` JSON file option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/684))
-- Fix ipython config dir logic ([Link to PR](https://github.com/aws/graph-notebook/pull/687))
+- Improved iPython config directory retrieval logic ([Link to PR](https://github.com/aws/graph-notebook/pull/687))
+- Fixed `%db_reset` output for token modes ([Link to PR](https://github.com/aws/graph-notebook/pull/691))
 
 ## Release 4.5.2 (August 15, 2024)
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1967,7 +1967,7 @@ class Graph(Magics):
     @display_exceptions
     @neptune_db_only
     def db_reset(self, line, local_ns: dict = None):
-        self.reset(line, local_ns, service=NEPTUNE_DB_SERVICE_NAME)
+        return self.reset(line, local_ns, service=NEPTUNE_DB_SERVICE_NAME)
 
     @line_magic
     @needs_local_scope


### PR DESCRIPTION
Issue #, if available: #690

Description of changes:
- Fixed an `%db_reset` bug with the `--generate-token` and `--token` modes, where the output returned from the wrapped `%reset` magic would not be displayed to the user.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.