### PR TITLE
Fix `%%gremlin profile` serializer issue on Neptune DB <=1.2.x

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 - Added `--export-to` JSON file option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/684))
 - Improved iPython config directory retrieval logic ([Link to PR](https://github.com/aws/graph-notebook/pull/687))
 - Fixed `%db_reset` output for token modes ([Link to PR](https://github.com/aws/graph-notebook/pull/691))
+- Fixed `%%gremlin profile` serialization issue on Neptune DB v1.2 and older ([Link to PR](https://github.com/aws/graph-notebook/pull/694))
 - Use `extras_require` to specify tests ([Link to PR](https://github.com/aws/graph-notebook/pull/688))
 - Updated Gremlin HTTP requests, fixed handling of internal error responses ([Link to PR](https://github.com/aws/graph-notebook/pull/692))
 

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -1127,9 +1127,9 @@ class Graph(Magics):
                                  'the profile report by default.')
         parser.add_argument('--profile-chop', type=int, default=250,
                             help='Property to specify max length of profile results string. Default is 250')
-        parser.add_argument('--profile-serializer', type=str, default='GRAPHSON_V3_UNTYPED',
+        parser.add_argument('--profile-serializer', type=str, default='GRAPHSON_V3',
                             help='Specify how to serialize results. Allowed values are any of the valid MIME type or '
-                                 'TinkerPop driver "Serializers" enum values. Default is GRAPHSON_V3_UNTYPED')
+                                 'TinkerPop driver "Serializers" enum values. Default is GRAPHSON_V3')
         parser.add_argument('--profile-indexOps', action='store_true', default=False,
                             help='Show a detailed report of all index operations.')
         parser.add_argument('--profile-debug', action='store_true', default=False,


### PR DESCRIPTION
Issue #, if available: #693

Description of changes:
- Switched the default value of the `%%gremlin profile --profile-serializer` option from `GRAPHSON_V3_UNTYPED` to `GRAPHSON_V3` (typed). This fixed a backwards compatibility issue with Neptune Database instances on major engine version 1.2 or older.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.