### PR TITLE
Enforce Gremlin protocol and serializer based on database type

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 
 - Updated Gremlin config `message_serializer` to accept all TinkerPop serializers ([Link to PR](https://github.com/aws/graph-notebook/pull/685))
+- Implemented service-based dynamic allowlists and defaults for Gremlin serializer and protocol combinations ([Link to PR](https://github.com/aws/graph-notebook/pull/697))
 - Added `%get_import_task` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/668))
 - Added `--export-to` JSON file option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/684))
 - Deprecated Python 3.8 support ([Link to PR](https://github.com/aws/graph-notebook/pull/683))

--- a/src/graph_notebook/configuration/generate_config.py
+++ b/src/graph_notebook/configuration/generate_config.py
@@ -359,11 +359,14 @@ if __name__ == "__main__":
     auth_mode_arg = args.auth_mode if args.auth_mode != '' else AuthModeEnum.DEFAULT.value
     protocol_arg = args.gremlin_connection_protocol
     include_protocol = False
+    gremlin_service = ''
     if is_allowed_neptune_host(args.host, args.neptune_hosts):
         include_protocol = True
+        gremlin_service = args.neptune_service
         if not protocol_arg:
             protocol_arg = DEFAULT_HTTP_PROTOCOL \
                 if args.neptune_service == NEPTUNE_ANALYTICS_SERVICE_NAME else DEFAULT_WS_PROTOCOL
+
     config = generate_config(args.host, int(args.port),
                              AuthModeEnum(auth_mode_arg),
                              args.ssl, args.ssl_verify,
@@ -372,7 +375,7 @@ if __name__ == "__main__":
                              SparqlSection(args.sparql_path, ''),
                              GremlinSection(args.gremlin_traversal_source, args.gremlin_username,
                                             args.gremlin_password, args.gremlin_serializer,
-                                            protocol_arg, include_protocol),
+                                            protocol_arg, include_protocol, gremlin_service),
                              Neo4JSection(args.neo4j_username, args.neo4j_password,
                                           args.neo4j_auth, args.neo4j_database),
                              args.neptune_hosts)

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -10,7 +10,7 @@ from graph_notebook.configuration.get_config import get_config, get_config_from_
 from graph_notebook.configuration.generate_config import Configuration, DEFAULT_AUTH_MODE, AuthModeEnum, \
     generate_config, generate_default_config, GremlinSection
 from graph_notebook.neptune.client import NEPTUNE_DB_SERVICE_NAME, NEPTUNE_ANALYTICS_SERVICE_NAME, \
-    DEFAULT_GREMLIN_PROTOCOL, DEFAULT_HTTP_PROTOCOL, NEPTUNE_CONFIG_HOST_IDENTIFIERS
+    DEFAULT_WS_PROTOCOL, DEFAULT_HTTP_PROTOCOL, NEPTUNE_CONFIG_HOST_IDENTIFIERS
 
 
 class TestGenerateConfiguration(unittest.TestCase):
@@ -50,8 +50,8 @@ class TestGenerateConfiguration(unittest.TestCase):
         self.assertEqual('g', config.gremlin.traversal_source)
         self.assertEqual('', config.gremlin.username)
         self.assertEqual('', config.gremlin.password)
-        self.assertEqual(DEFAULT_GREMLIN_PROTOCOL, config.gremlin.connection_protocol)
-        self.assertEqual('GraphSONUntypedMessageSerializerV1', config.gremlin.message_serializer)
+        self.assertEqual(DEFAULT_WS_PROTOCOL, config.gremlin.connection_protocol)
+        self.assertEqual('GraphSONMessageSerializerV3', config.gremlin.message_serializer)
         self.assertEqual('neo4j', config.neo4j.username)
         self.assertEqual('password', config.neo4j.password)
         self.assertEqual(True, config.neo4j.auth)
@@ -170,7 +170,7 @@ class TestGenerateConfiguration(unittest.TestCase):
                 'traversal_source': 'g',
                 'username': '',
                 'password': '',
-                'message_serializer': 'GraphSONUntypedMessageSerializerV1'
+                'message_serializer': 'GraphSONMessageSerializerV3'
             },
             'neo4j': {
                 'username': 'neo4j',
@@ -267,8 +267,8 @@ class TestGenerateConfiguration(unittest.TestCase):
                 'traversal_source': 'g',
                 'username': '',
                 'password': '',
-                'message_serializer': 'GraphSONUntypedMessageSerializerV1',
-                'connection_protocol': 'http'
+                'message_serializer': 'GraphSONMessageSerializerV3',
+                'connection_protocol': 'websockets'
             },
             'neo4j': {
                 'username': 'neo4j',
@@ -472,7 +472,7 @@ class TestGenerateConfiguration(unittest.TestCase):
         self.assertEqual(config.gremlin.traversal_source, 'g')
         self.assertEqual(config.gremlin.username, '')
         self.assertEqual(config.gremlin.password, '')
-        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV1')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
         self.assertFalse(hasattr(config.gremlin, "connection_protocol"))
 
     def test_configuration_gremlinsection_generic_override(self):
@@ -494,8 +494,8 @@ class TestGenerateConfiguration(unittest.TestCase):
         self.assertEqual(config.gremlin.traversal_source, 'g')
         self.assertEqual(config.gremlin.username, '')
         self.assertEqual(config.gremlin.password, '')
-        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV1')
-        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_GREMLIN_PROTOCOL)
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
 
     def test_configuration_gremlinsection_neptune_override(self):
         config = Configuration(self.neptune_host_reg,
@@ -510,14 +510,14 @@ class TestGenerateConfiguration(unittest.TestCase):
         self.assertEqual(config.gremlin.traversal_source, 'g')
         self.assertEqual(config.gremlin.username, '')
         self.assertEqual(config.gremlin.password, '')
-        self.assertEqual(config.gremlin.message_serializer, 'GraphBinaryMessageSerializerV1')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
         self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
 
     def test_configuration_gremlinsection_protocol_neptune_default_with_proxy(self):
         config = Configuration(self.neptune_host_reg,
                                self.port,
                                proxy_host='test_proxy')
-        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
 
     def test_configuration_gremlinsection_protocol_neptune_override_with_proxy(self):
         config = Configuration(self.neptune_host_reg,

--- a/test/unit/configuration/test_configuration.py
+++ b/test/unit/configuration/test_configuration.py
@@ -475,18 +475,40 @@ class TestGenerateConfiguration(unittest.TestCase):
         self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
         self.assertFalse(hasattr(config.gremlin, "connection_protocol"))
 
-    def test_configuration_gremlinsection_generic_override(self):
+    def test_configuration_gremlinsection_generic_override_protocol(self):
+        config = Configuration('localhost',
+                               self.port,
+                               gremlin_section=GremlinSection(connection_protocol='http'),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
+        self.assertFalse(hasattr(config.gremlin, "connection_protocol"))
+
+    def test_configuration_gremlinsection_generic_override_serializer_invalid(self):
+        config = Configuration('localhost',
+                               self.port,
+                               gremlin_section=GremlinSection(message_serializer='not_a_serializer'),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
+        self.assertFalse(hasattr(config.gremlin, "connection_protocol"))
+
+    def test_configuration_gremlinsection_generic_override_serializer_http_only(self):
         config = Configuration('localhost',
                                self.port,
                                gremlin_section=GremlinSection(traversal_source='t',
                                                               username='foo',
                                                               password='bar',
-                                                              message_serializer='graphbinary'),
+                                                              message_serializer='GraphSONUntypedMessageSerializerV1'),
                                )
         self.assertEqual(config.gremlin.traversal_source, 't')
         self.assertEqual(config.gremlin.username, 'foo')
         self.assertEqual(config.gremlin.password, 'bar')
-        self.assertEqual(config.gremlin.message_serializer, 'GraphBinaryMessageSerializerV1')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
         self.assertFalse(hasattr(config.gremlin, "connection_protocol"))
 
     def test_configuration_gremlinsection_neptune_default(self):
@@ -497,7 +519,7 @@ class TestGenerateConfiguration(unittest.TestCase):
         self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
         self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
 
-    def test_configuration_gremlinsection_neptune_override(self):
+    def test_configuration_gremlinsection_neptune_override_all(self):
         config = Configuration(self.neptune_host_reg,
                                self.port,
                                gremlin_section=GremlinSection(traversal_source='t',
@@ -506,6 +528,240 @@ class TestGenerateConfiguration(unittest.TestCase):
                                                               message_serializer='graphbinary',
                                                               connection_protocol='http',
                                                               include_protocol=True),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_default_db(self):
+        config = Configuration(self.neptune_host_reg, self.port, neptune_service=NEPTUNE_DB_SERVICE_NAME)
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_protocol(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='http',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_protocol_invalid(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='not_a_protocol',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_serializer(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(message_serializer='graphbinary',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphBinaryMessageSerializerV1')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_serializer_invalid(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(message_serializer='not_a_serializer',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_http_protocol_and_serializer(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='http',
+                                                              message_serializer='graphsonv1untyped',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV1')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_http_protocol_and_serializer_invalid(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='http',
+                                                              message_serializer='not_a_serializer',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_http_protocol_and_serializer_not_graphson_untyped(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='http',
+                                                              message_serializer='graphbinaryv1',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_ws_protocol_and_serializer(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='ws',
+                                                              message_serializer='graphbinaryv1',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphBinaryMessageSerializerV1')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_ws_protocol_and_serializer_invalid(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='ws',
+                                                              message_serializer='graphbinaryv1',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphBinaryMessageSerializerV1')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_db_override_ws_protocol_and_serializer_http_only(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_DB_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='ws',
+                                                              message_serializer='graphsonv3untyped',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_DB_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_WS_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_default_analytics(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME)
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_analytics_override_ws_protocol(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='ws',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_analytics_override_serializer(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME,
+                               gremlin_section=GremlinSection(message_serializer='graphsonv1untyped',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV1')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_analytics_override_serializer_invalid(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME,
+                               gremlin_section=GremlinSection(message_serializer='not_a_serializer',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_analytics_override_serializer_not_graphson_untyped(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME,
+                               gremlin_section=GremlinSection(message_serializer='graphbinaryv1',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME),
+                               )
+        self.assertEqual(config.gremlin.traversal_source, 'g')
+        self.assertEqual(config.gremlin.username, '')
+        self.assertEqual(config.gremlin.password, '')
+        self.assertEqual(config.gremlin.message_serializer, 'GraphSONUntypedMessageSerializerV3')
+        self.assertEqual(config.gremlin.connection_protocol, DEFAULT_HTTP_PROTOCOL)
+
+    def test_configuration_gremlinsection_neptune_analytics_override_http_protocol(self):
+        config = Configuration(self.neptune_host_reg,
+                               self.port,
+                               neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME,
+                               gremlin_section=GremlinSection(connection_protocol='http',
+                                                              include_protocol=True,
+                                                              neptune_service=NEPTUNE_ANALYTICS_SERVICE_NAME),
                                )
         self.assertEqual(config.gremlin.traversal_source, 'g')
         self.assertEqual(config.gremlin.username, '')

--- a/test/unit/configuration/test_configuration_from_main.py
+++ b/test/unit/configuration/test_configuration_from_main.py
@@ -165,6 +165,48 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         config_dict = config.to_dict()
         self.assertEqual(DEFAULT_HTTP_PROTOCOL, config_dict['gremlin']['connection_protocol'])
 
+    def test_generate_configuration_main_gremlin_serializer_no_service(self):
+        result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '
+                           f'--host "{self.neptune_host_reg}" '
+                           f'--port "{self.port}" '
+                           f'--neptune_service "" '
+                           f'--auth_mode "" '
+                           f'--ssl "" '
+                           f'--load_from_s3_arn "" '
+                           f'--config_destination="{self.test_file_path}" ')
+        self.assertEqual(0, result)
+        config = get_config(self.test_file_path)
+        config_dict = config.to_dict()
+        self.assertEqual('GraphSONMessageSerializerV3', config_dict['gremlin']['message_serializer'])
+
+    def test_generate_configuration_main_gremlin_serializer_db(self):
+        result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '
+                           f'--host "{self.neptune_host_reg}" '
+                           f'--port "{self.port}" '
+                           f'--neptune_service "{NEPTUNE_DB_SERVICE_NAME}" '
+                           f'--auth_mode "" '
+                           f'--ssl "" '
+                           f'--load_from_s3_arn "" '
+                           f'--config_destination="{self.test_file_path}" ')
+        self.assertEqual(0, result)
+        config = get_config(self.test_file_path)
+        config_dict = config.to_dict()
+        self.assertEqual('GraphSONMessageSerializerV3', config_dict['gremlin']['message_serializer'])
+
+    def test_generate_configuration_main_gremlin_serializer_analytics(self):
+        result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '
+                           f'--host "{self.neptune_host_reg}" '
+                           f'--port "{self.port}" '
+                           f'--neptune_service "{NEPTUNE_ANALYTICS_SERVICE_NAME}" '
+                           f'--auth_mode "" '
+                           f'--ssl "" '
+                           f'--load_from_s3_arn "" '
+                           f'--config_destination="{self.test_file_path}" ')
+        self.assertEqual(0, result)
+        config = get_config(self.test_file_path)
+        config_dict = config.to_dict()
+        self.assertEqual('GraphSONUntypedMessageSerializerV3', config_dict['gremlin']['message_serializer'])
+
     def test_generate_configuration_main_empty_args_custom(self):
         expected_config = Configuration(self.neptune_host_custom, self.port, neptune_hosts=self.custom_hosts_list)
         result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '

--- a/test/unit/configuration/test_configuration_from_main.py
+++ b/test/unit/configuration/test_configuration_from_main.py
@@ -9,7 +9,7 @@ import unittest
 from graph_notebook.configuration.generate_config import AuthModeEnum, Configuration, GremlinSection
 from graph_notebook.configuration.get_config import get_config
 from graph_notebook.neptune.client import (NEPTUNE_DB_SERVICE_NAME, NEPTUNE_ANALYTICS_SERVICE_NAME,
-                                           DEFAULT_HTTP_PROTOCOL)
+                                           DEFAULT_HTTP_PROTOCOL, DEFAULT_WS_PROTOCOL)
 
 
 class TestGenerateConfigurationMain(unittest.TestCase):
@@ -135,7 +135,7 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         self.assertEqual(0, result)
         config = get_config(self.test_file_path)
         config_dict = config.to_dict()
-        self.assertEqual(DEFAULT_HTTP_PROTOCOL, config_dict['gremlin']['connection_protocol'])
+        self.assertEqual(DEFAULT_WS_PROTOCOL, config_dict['gremlin']['connection_protocol'])
 
     def test_generate_configuration_main_gremlin_protocol_db(self):
         result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '
@@ -149,7 +149,7 @@ class TestGenerateConfigurationMain(unittest.TestCase):
         self.assertEqual(0, result)
         config = get_config(self.test_file_path)
         config_dict = config.to_dict()
-        self.assertEqual(DEFAULT_HTTP_PROTOCOL, config_dict['gremlin']['connection_protocol'])
+        self.assertEqual(DEFAULT_WS_PROTOCOL, config_dict['gremlin']['connection_protocol'])
 
     def test_generate_configuration_main_gremlin_protocol_analytics(self):
         result = os.system(f'{self.python_cmd} -m graph_notebook.configuration.generate_config '


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Reworked Gremlin config generation to set allowed inputs and defaults for `connection_protocol` and `message_serializer` based on service type
- Fixed `message_serializer` not enforcing serializer input compatible with the GremlinPython driver when connecting to non-Neptune endpoints
- Temporarily restricted `message_serializer` to GraphSON-untyped serializers on HTTP connections

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.