### PR TITLE
Bump nest_asyncio to 1.6.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 - Deprecated Python 3.8 support ([Link to PR](https://github.com/aws/graph-notebook/pull/683))
 - Upgraded Neo4j Bolt driver to v5.x ([Link to PR](https://github.com/aws/graph-notebook/pull/682))
+- Upgraded nest_asyncio to 1.6.0 ([Link to PR](https://github.com/aws/graph-notebook/pull/698))
 - Added `%get_import_task` line magic ([Link to PR](https://github.com/aws/graph-notebook/pull/668))
 - Added `--export-to` JSON file option to `%%graph_notebook_config` ([Link to PR](https://github.com/aws/graph-notebook/pull/684))
 - Improved iPython config directory retrieval logic ([Link to PR](https://github.com/aws/graph-notebook/pull/687))

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ markupsafe<2.1.0
 itables>=2.0.0,<=2.1.0
 pandas>=2.1.0,<=2.2.2
 numpy<1.24.0
-nest_asyncio>=1.5.5,<=1.5.6
+nest_asyncio>=1.5.5,<=1.6.0
 async-timeout>=4.0,<5.0
 json-repair==0.29.2
 

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         'itables>=2.0.0,<=2.1.0',
         'pandas>=2.1.0,<=2.2.2',
         'numpy<1.24.0',
-        'nest_asyncio>=1.5.5,<=1.5.6',
+        'nest_asyncio>=1.5.5,<=1.6.0',
         'async-timeout>=4.0,<5.0',
         'json-repair==0.29.2'
     ],


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Moved `nest_asyncio` to 1.6.0 for improved compatibility with third party libraries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.