### PR TITLE
Use /queries endpoint for openCypher

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 
+- Updated `%%oc` to use the `/queries` endpoint for Neptune Analytics ([Link to PR](https://github.com/aws/graph-notebook/pull/705))
 - Added experimental TinkerPop 4.0 support ([Link to PR](https://github.com/aws/graph-notebook/pull/704))
 - Added documentation for group keys in `%%graph_notebook_vis_options` ([Link to PR](https://github.com/aws/graph-notebook/pull/703))
 - Enabled `--query-timeout` on `%%oc explain` for Neptune Analytics ([Link to PR](https://github.com/aws/graph-notebook/pull/701))


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Changed `%%oc` to use the port-less `/queries` endpoint for Neptune Analytics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.