### PR TITLE
Fix SPARQL path in Fuseki docs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Added Neptune `--use-port` option to `%%gremlin` and `%%oc` ([Link to PR](https://github.com/aws/graph-notebook/pull/712))
+- Fixed SPARQL path in example Fuseki configuration ([Link to PR](https://github.com/aws/graph-notebook/pull/713))
 
 ## Release 4.6.1 (October 1, 2024)
 

--- a/additional-databases/fuseki/README.md
+++ b/additional-databases/fuseki/README.md
@@ -14,7 +14,7 @@ like in the following example that connects to `http://localhost:3030/ds/sparql`
   "port": 3030,
   "ssl": false,
   "sparql": {
-    "path": "ds/sparql"
+    "path": "ds"
   }
 }
 ```


### PR DESCRIPTION
Issue #, if available: #702

Description of changes:
- Fixed an issue in the Fuseki documentation where the example configuration contained a read-only path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.