### PR TITLE
Mitigated visualization widget crash on newer `jupyterlab-widgets` versions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 ## Upcoming
 - Added Neptune `--use-port` option to `%%gremlin` and `%%oc` ([Link to PR](https://github.com/aws/graph-notebook/pull/712))
 - Fixed SPARQL path in example Fuseki configuration ([Link to PR](https://github.com/aws/graph-notebook/pull/713))
+- Mitigated visualizer crash on newer `jupyterlab-widgets` versions ([Link to PR](https://github.com/aws/graph-notebook/pull/716))
+- Fixed TS errors in visualizer widget build ([Link to PR](https://github.com/aws/graph-notebook/pull/716))
 
 ## Release 4.6.1 (October 1, 2024)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Jinja2>=3.0.3,<=3.1.4
 jupyter==1.0.0
 notebook>=6.1.5,<7.0.0
 ipywidgets==7.7.2
-jupyterlab_widgets>=1.0.0,<3.0.0
+jupyterlab_widgets>=1.0.0,<=1.1.10
 nbclient<=0.7.0
 jupyter-contrib-nbextensions<=0.7.0
 widgetsnbextension<=3.6.1

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         'SPARQLWrapper==2.0.0',
         'requests>=2.32.0,<=2.32.2',
         'ipywidgets==7.7.2',
-        'jupyterlab_widgets>=1.0.0,<3.0.0',
+        'jupyterlab_widgets>=1.0.0,<=1.1.10',
         'networkx==2.4',
         'Jinja2>=3.0.3,<=3.1.4',
         'notebook>=6.1.5,<7.0.0',


### PR DESCRIPTION
Issue #, if available: #714

Description of changes:
- Pinned `jupyterlab-widgets<=1.1.10` to mitigate visualization widget crashing on later versions due to JupyterLab 4 support requirement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.