### PR TITLE
locked numba dependency to 0.60.0 to avoid numpy conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ dependencies = [
     'Jinja2>=3.0.3,<=3.1.4',
     'json-repair==0.29.2',
     'nest_asyncio>=1.5.5,<=1.6.0',
-    'requests>=2.32.0,<=2.32.2'
+    'requests>=2.32.0,<=2.32.2',
+    'numba==0.60.0'
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ Jinja2>=3.0.3,<=3.1.4
 json-repair==0.29.2
 nest_asyncio>=1.5.5,<=1.6.0
 requests>=2.32.0,<=2.32.2
+numba==0.60.0


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/graph-notebook/issues/734

Description of changes: locked numba dependency to 0.60.0 to avoid numpy conflict

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.