### PR TITLE
Update ChangeLog.md

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,10 +3,10 @@
 Starting with v1.31.6, this file will contain a record of major features and updates made in each release of graph-notebook.
 
 ## Upcoming
-
+- Locked numba dependency to 0.60.0 to avoid numpy conflict ([Link to PR](https://github.com/aws/graph-notebook/pull/735))
+  
 ## Release 5.0.0 (April 8, 2025)
 - Upgrade project to Jupyterlab 4x ([Link to PR](https://github.com/aws/graph-notebook/pull/729))
-- Locked numba dependency to 0.60.0 to avoid numpy conflict ([Link to PR](https://github.com/aws/graph-notebook/pull/735))
   
 ## Release 4.6.2 (November 26, 2024)
 - Added Neptune `--use-port` option to `%%gremlin` and `%%oc` ([Link to PR](https://github.com/aws/graph-notebook/pull/712))


### PR DESCRIPTION
the change to lock numba to a specific version will be released in 5.0.1 and not 5.0.0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.