### PR TITLE
fixed library target for nbclassic nbextension for graph_notebook_widget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     'nbclient>=0.7.3',
     'nbconvert>=6.3.0,<=7.2.8',
     'notebook>=7.0.0,<8.0.0',
-    'nbclassic>=1.0.0',
+    'nbclassic>=1.3.0',
 
     # Data processing and visualization
     'itables>=2.0.0,<=2.1.0',

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jupyterlab-widgets>=3.0.0,<4.0.0
 nbclient>=0.7.3
 nbconvert>=6.3.0,<=7.2.8
 notebook>=7.0.0,<8.0.0
-nbclassic>=1.0.0
+nbclassic>=1.3.0
 
 # Data processing and visualization
 itables>=2.0.0,<=2.1.0

--- a/src/graph_notebook/start_notebook.py
+++ b/src/graph_notebook/start_notebook.py
@@ -71,6 +71,7 @@ def main():
     # Starting with Notebook 7.0+, the classic notebook interface was rewritten to use JupyterLab's architecture.
     # This means traditional nbextensions (which rely on requirejs and jQuery) are not directly supported.
     # We use nbclassic package to maintain compatibility 
+    # Reference: https://jupyter-notebook.readthedocs.io/en/latest/migrating/multiple-interfaces.html#simultaneous-usage-of-different-versions-of-notebook-7-and-the-classic-notebook-ui
     kernel_manager_option = "--NotebookApp.kernel_manager_class=notebook.services.kernels.kernelmanager.AsyncMappingKernelManager"
     notebooks_dir = '~/notebook/destination/dir' if args.notebooks_dir == '' else args.notebooks_dir
     os.system(f'''jupyter nbclassic {kernel_manager_option} {notebooks_dir}''')


### PR DESCRIPTION
Issue #, if available: [Issue #738](https://github.com/aws/graph-notebook/issues/738)

Description of changes:
This PR addresses issues with extension loading in Jupyter Notebook Classic (NBClassic) environments. The changes modify the webpack configuration to ensure proper module definition and loading.

### Key Changes:

1. Modified the first nbextension output:
   - Changed `libraryTarget` from "amd" to "var"
   - This ensures the extension is properly exposed as a global variable, which is necessary for NBClassic's initial extension loading process

2. Adjusted the second nbextension output:
   - Removed the `library` name for the AMD module (set to `undefined`)
   - This allows for proper AMD module definition without potential namespace conflicts

These changes align our extension with the expected module loading patterns in Jupyter notebooks, addressing potential issues where the extension might fail to load or initialize properly in certain environments.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.