### PR TITLE
Fix selected node highlights in force widget

### DIFF
--- a/src/graph_notebook/options/options.py
+++ b/src/graph_notebook/options/options.py
@@ -6,8 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 # Documentation for these options: https://visjs.github.io/vis-network/docs/network
 OPTIONS_DEFAULT_DIRECTED = {
     "nodes": {
-        "borderWidthSelected": 0,
+        "borderWidthSelected": 3,
         "borderWidth": 0,
+        "chosen": True,
         "color": {
             "background": "rgba(210, 229, 255, 1)",
             "border": "transparent",

--- a/src/graph_notebook/widgets/src/force_widget.ts
+++ b/src/graph_notebook/widgets/src/force_widget.ts
@@ -493,7 +493,7 @@ export class ForceView extends DOMWidgetView {
     this.vis?.on("deselectNode", (params) => {
       console.log("deselect");
       params.previousSelection.nodes.forEach((value) => {
-        this.handleDeselectNode(value);
+        this.handleDeselectNode(value.id);
       });
     });
 

--- a/test/unit/options/test_options.py
+++ b/test/unit/options/test_options.py
@@ -127,8 +127,9 @@ class TestOptions(unittest.TestCase):
                 },
                 'expected': {
                     "nodes": {
-                        "borderWidthSelected": 0,
+                        "borderWidthSelected": 3,
                         "borderWidth": 0,
+                        "chosen": True,
                         "color": {
                             "background": "rgba(210, 229, 255, 1)",
                             "border": "transparent",
@@ -222,8 +223,9 @@ class TestOptions(unittest.TestCase):
                 },
                 'expected': {
                     "nodes": {
-                        "borderWidthSelected": 0,
+                        "borderWidthSelected": 3,
                         "borderWidth": 0,
+                        "chosen": True,
                         "color": {
                             "background": "rgba(210, 229, 255, 1)",
                             "border": "transparent",


### PR DESCRIPTION
**Issue**
Node selection highlighting was not working in the force-widget graph visualization component.
The issue was caused by incompatible changes in the vis-network package dependency versions, which affected the graph-notebook selection functionality.

**Changes Made**
- Updated the node selection implementation to align with the new vis-network package requirements
- Fixed the highlighting behavior for selected nodes in the graph visualization


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.