### PR TITLE
Fix expected output in graph query tutorials

### DIFF
--- a/src/graph_notebook/notebooks/04-Language-Tutorials/01-Gremlin/01-Basic-Read-Queries.ipynb
+++ b/src/graph_notebook/notebooks/04-Language-Tutorials/01-Gremlin/01-Basic-Read-Queries.ipynb
@@ -1038,7 +1038,7 @@
     "\n",
     "* Find all the friends of friends that do not have a connection to Dave\n",
     "\n",
-    "The correct answer contains three results: \"Hank\", \"Denise\", \"Paras\""
+    "The correct answer contains two results: \"Denise\", \"Paras\""
    ]
   },
   {

--- a/src/graph_notebook/notebooks/04-Language-Tutorials/01-Gremlin/Gremlin-Exercises-Answer-Sheet.ipynb
+++ b/src/graph_notebook/notebooks/04-Language-Tutorials/01-Gremlin/Gremlin-Exercises-Answer-Sheet.ipynb
@@ -128,7 +128,7 @@
     "\n",
     "* Find all the friends of friends that do not have a connection to Dave\n",
     "\n",
-    "The correct answer contains three results: \"Hank\", \"Denise\", \"Paras\""
+    "The correct answer contains two results: \"Denise\", \"Paras\""
    ]
   },
   {

--- a/src/graph_notebook/notebooks/04-Language-Tutorials/02-openCypher/01-Basic-Read-Queries.ipynb
+++ b/src/graph_notebook/notebooks/04-Language-Tutorials/02-openCypher/01-Basic-Read-Queries.ipynb
@@ -839,7 +839,7 @@
     "\n",
     "* Find all the friends of friends that do not have a connection to Dave\n",
     "\n",
-    "The correct answer contains three results: \"Hank\", \"Denise\", \"Paras\""
+    "The correct answer contains two results: \"Denise\", \"Paras\""
    ]
   },
   {


### PR DESCRIPTION
Issue #724:

Description of changes:
This PR corrects the expected output in the "friends of friends not connected to Dave" exercise across both Gremlin and openCypher tutorial notebooks. The expected output has been updated to correctly state that there are two results (Denise, Paras) rather than three results (which incorrectly included Hank).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.