### PR TITLE
Replace static credentials with OIDC in docker publish workflow

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -19,18 +19,15 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
-      packages: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Get package version
-        uses: tyankatsu0105/read-package-version-actions@v1
-        with:
-          path: "./src/graph_notebook/widgets"
         id: package-version
+        run: echo "version=$(jq -r .version ./src/graph_notebook/widgets/package.json)" >> $GITHUB_OUTPUT
 
       - name: Get image tag
         id: get-image-tag
@@ -46,14 +43,10 @@ jobs:
           fi
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ECR }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ECR }}
+          role-to-assume: arn:aws:iam::967107632117:role/graph-notebook-ecr-publish
           aws-region: us-east-1
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_ECR }}
-          role-duration-seconds: 3600
-          role-session-name: NotebookImageUpdate
 
       - name: Login to Amazon ECR
         id: login-ecr-public


### PR DESCRIPTION
Issue #, if available:

Switch the `docker_publish` workflow to use GitHub OIDC for AWS authentication instead of long-lived access keys. Also replace the `third-party read-package-version-actions` with an inline script.

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.