### PR TITLE
fix: update ITables to 2.4+

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ Starting with v1.31.6, this file will contain a record of major features and upd
 
 ## Upcoming
 - Autoformatter for gremlin queries
+- Updated ITables to 2.4+ with safe query-table HTML rendering ([Link to PR](https://github.com/aws/graph-notebook/pull/785))
 
 ## Release 5.2.0 (Mar 11, 2026)
 - Added %degreeDistribution magic command ([PR](https://github.com/aws/graph-notebook/pull/749)) 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     'nbclassic>=1.3.0',
 
     # Data processing and visualization
-    'itables>=2.0.0,<=2.1.0',
+    'itables>=2.4.0,<3.0.0',
     'networkx>=3.0,<4.0',
     'numpy>=1.24.0',
     'pandas>=2.2.2',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ notebook>=7.0.0,<8.0.0
 nbclassic>=1.3.0
 
 # Data processing and visualization
-itables>=2.0.0,<=2.1.0
+itables>=2.4.0,<3.0.0
 networkx>3.0,<4.0
 numpy>1.24.0
 pandas>2.2.2

--- a/src/graph_notebook/magics/graph_magic.py
+++ b/src/graph_notebook/magics/graph_magic.py
@@ -342,6 +342,21 @@ def encode_html_chars(result):
     return fixed_result
 
 
+def encode_html_axis_label(label):
+    if isinstance(label, tuple):
+        return tuple(encode_html_axis_label(item) for item in label)
+    if isinstance(label, str):
+        return encode_html_chars(label)
+    return label
+
+
+def show_pre_encoded_results(results_df, **kwargs):
+    """Display query results whose HTML-sensitive characters are already encoded."""
+    display_df = results_df.rename(columns=encode_html_axis_label)
+    display_df.columns.names = [encode_html_axis_label(name) for name in display_df.columns.names]
+    return show(display_df, allow_html=True, **kwargs)
+
+
 def decode_html_chars(results_df: pd.DataFrame = None) -> pd.DataFrame:
     for k, v in iter(DT_HTML_CHAR_MAP.items()):
         results_df = results_df.map(lambda x: x.replace(v, k))
@@ -1019,7 +1034,7 @@ class Graph(Magics):
                     if args.hide_index:
                         sparql_columndefs[1]["visible"] = False
                     init_notebook_mode(connected=args.connected_table)
-                    show(results_df,
+                    show_pre_encoded_results(results_df,
                          connected=args.connected_table,
                          scrollX=True,
                          scrollY=sparql_scrollY,
@@ -1499,7 +1514,7 @@ class Graph(Magics):
                     if args.hide_index:
                         gremlin_columndefs[1]["visible"] = False
                     init_notebook_mode(connected=args.connected_table)
-                    show(results_df,
+                    show_pre_encoded_results(results_df,
                          connected=args.connected_table,
                          scrollX=True,
                          scrollY=gremlin_scrollY,
@@ -3880,7 +3895,7 @@ class Graph(Magics):
                     if args.hide_index:
                         oc_columndefs[1]["visible"] = False
                     init_notebook_mode(connected=args.connected_table)
-                    show(results_df,
+                    show_pre_encoded_results(results_df,
                          connected=args.connected_table,
                          scrollX=True,
                          scrollY=oc_scrollY,

--- a/test/unit/graph_magic/test_itables_html_safety.py
+++ b/test/unit/graph_magic/test_itables_html_safety.py
@@ -1,0 +1,66 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import pandas as pd
+from itables import to_html_datatable
+
+from graph_notebook.magics import graph_magic
+
+
+SCRIPT_PAYLOAD = "</script><script>alert('graph-notebook')</script>"
+
+
+def test_itables_default_escapes_raw_html():
+    html = to_html_datatable(
+        pd.DataFrame({"value": [SCRIPT_PAYLOAD]}),
+        connected=False,
+    )
+
+    assert SCRIPT_PAYLOAD not in html
+    assert "&lt;/script&gt;" in html
+
+
+def test_pre_encoded_query_results_are_not_escaped_twice(monkeypatch):
+    monkeypatch.setattr(graph_magic, "show", to_html_datatable)
+    encoded_payload = graph_magic.encode_html_chars(SCRIPT_PAYLOAD)
+    html = graph_magic.show_pre_encoded_results(
+        pd.DataFrame({"value": [encoded_payload]}),
+        connected=False,
+    )
+
+    assert "&amp;lt;/script&amp;gt;" not in html
+    assert "&lt;/script&gt;" in html
+
+
+def test_pre_encoded_query_results_escape_column_labels(monkeypatch):
+    monkeypatch.setattr(graph_magic, "show", to_html_datatable)
+    results_df = pd.DataFrame(
+        [["safe"]],
+        columns=pd.Index([SCRIPT_PAYLOAD], name=SCRIPT_PAYLOAD),
+    )
+
+    html = graph_magic.show_pre_encoded_results(results_df, connected=False)
+
+    assert SCRIPT_PAYLOAD not in html
+    assert "&lt;/script&gt;" in html
+
+
+def test_pre_encoded_query_results_preserve_source_and_range_index(monkeypatch):
+    captured = {}
+
+    def capture_show(results_df, **kwargs):
+        captured["results_df"] = results_df
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(graph_magic, "show", capture_show)
+    results_df = pd.DataFrame([["safe"]], columns=[0])
+
+    graph_magic.show_pre_encoded_results(results_df, connected=False)
+
+    assert captured["results_df"] is not results_df
+    assert isinstance(results_df.index, pd.RangeIndex)
+    assert isinstance(captured["results_df"].index, pd.RangeIndex)
+    assert captured["results_df"].columns[0] == 0
+    assert captured["kwargs"]["allow_html"] is True


### PR DESCRIPTION
Issue #, if available:

Fixes #780

Description of changes:

- update the ITables dependency range to `>=2.4.0,<3.0.0` in both dependency declarations so raw table content uses the newer default HTML escaping
- preserve the existing single-encoded display for SPARQL, Gremlin, and openCypher query results without enabling HTML globally
- encode untrusted query-result column labels on a display-only copy before opting those pre-encoded cells into `allow_html=True`
- add regression coverage for raw HTML escaping, double escaping, unsafe headers, source-frame immutability, and RangeIndex preservation

Local validation:

- 582 unit tests with ITables 2.4.0
- 582 unit tests with ITables 2.9.1
- repository CI-equivalent Flake8 checks
- sdist and wheel build, isolated wheel installation, and `pip check`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.